### PR TITLE
use JDK_8 for travis compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+jdk: oraclejdk8
 language: android
 android:
   components:


### PR DESCRIPTION
use JDK_8 for travis compilation
resolve the travis error (master branch).
