### PR TITLE
Nutritional info #97

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/NutritionProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/NutritionProductFragment.java
@@ -53,10 +53,10 @@ public class NutritionProductFragment extends BaseFragment {
             String sugarsTxt = Html.fromHtml("<b>" + getString(R.string.txtSugars) + "</b>" + ' ' + nt.getSugars() + " (" + product.getNutriments().getSugars100g() + product.getNutriments().getSugarsUnit() + ")").toString();
             String saturatedFatTxt = Html.fromHtml("<b>" + getString(R.string.txtSaturatedFat) + "</b>" + ' ' + nt.getSaturatedFat() + " (" + product.getNutriments().getSaturatedFat100g() + product.getNutriments().getSaturatedFatUnit() + ")").toString();
 
-            levelItem.add(new NutrientLevelItem(saltTxt, getImageLevel(nt.getSalt())));
             levelItem.add(new NutrientLevelItem(fatTxt, getImageLevel(nt.getFat())));
-            levelItem.add(new NutrientLevelItem(sugarsTxt, getImageLevel(nt.getSugars())));
             levelItem.add(new NutrientLevelItem(saturatedFatTxt, getImageLevel(nt.getSaturatedFat())));
+            levelItem.add(new NutrientLevelItem(sugarsTxt, getImageLevel(nt.getSugars())));
+            levelItem.add(new NutrientLevelItem(saltTxt, getImageLevel(nt.getSalt())));
 
             img.setImageResource(getImageGrade(product.getNutritionGradeFr()));
         }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/NutritionProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/NutritionProductFragment.java
@@ -49,10 +49,10 @@ public class NutritionProductFragment extends BaseFragment {
             levelItem.add(new NutrientLevelItem(getString(R.string.txtNoData), R.drawable.error_image));
         } else {
 
-            String fatTxt = Html.fromHtml("<b>" + getString(R.string.txtFat) + "</b>" + ' ' + nt.getFat() + " (" + product.getNutriments().getFat100g() + product.getNutriments().getFatUnit() + ")").toString();
-            String saturatedFatTxt = Html.fromHtml("<b>" + getString(R.string.txtSaturatedFat) + "</b>" + ' ' + nt.getSaturatedFat() + " (" + product.getNutriments().getSaturatedFat100g() + product.getNutriments().getSaturatedFatUnit() + ")").toString();
-            String sugarsTxt = Html.fromHtml("<b>" + getString(R.string.txtSugars) + "</b>" + ' ' + nt.getSugars() + " (" + product.getNutriments().getSugars100g() + product.getNutriments().getSugarsUnit() + ")").toString();
-            String saltTxt = Html.fromHtml("<b>" + getString(R.string.txtSalt) + "</b>" + ' ' + nt.getSalt() + " (" + product.getNutriments().getSalt100g() + product.getNutriments().getSaltUnit() + ")").toString();
+            String fatTxt = Html.fromHtml("<b>" + getString(R.string.txtFat) + "</b>" + ' ' + localiseNutritionLevel(nt.getFat()) + " (" + product.getNutriments().getFat100g() + product.getNutriments().getFatUnit() + ")").toString();
+            String saturatedFatTxt = Html.fromHtml("<b>" + getString(R.string.txtSaturatedFat) + "</b>" + ' ' + localiseNutritionLevel(nt.getSaturatedFat()) + " (" + product.getNutriments().getSaturatedFat100g() + product.getNutriments().getSaturatedFatUnit() + ")").toString();
+            String sugarsTxt = Html.fromHtml("<b>" + getString(R.string.txtSugars) + "</b>" + ' ' + localiseNutritionLevel(nt.getSugars()) + " (" + product.getNutriments().getSugars100g() + product.getNutriments().getSugarsUnit() + ")").toString();
+            String saltTxt = Html.fromHtml("<b>" + getString(R.string.txtSalt) + "</b>" + ' ' + localiseNutritionLevel(nt.getSalt()) + " (" + product.getNutriments().getSalt100g() + product.getNutriments().getSaltUnit() + ")").toString();
 
             levelItem.add(new NutrientLevelItem(fatTxt, getImageLevel(nt.getFat())));
             levelItem.add(new NutrientLevelItem(saturatedFatTxt, getImageLevel(nt.getSaturatedFat())));
@@ -125,5 +125,24 @@ public class NutritionProductFragment extends BaseFragment {
         }
 
         return drawable;
+    }
+
+    /**
+     *
+     * @param nutritionAmount Either "low", "moderate" or "high"
+     * @return The localised word for the nutrition amount. If nutritionAmount is neither low,
+     * moderate nor high, return nutritionAmount
+     */
+    private String localiseNutritionLevel(String nutritionAmount){
+        switch (nutritionAmount){
+            case "low":
+                return getString(R.string.txtNutritionLevelLow);
+            case "moderate":
+                return getString(R.string.txtNutritionLevelModerate);
+            case "high":
+                return getString(R.string.txtNutritionLevelHigh);
+            default:
+                return nutritionAmount;
+        }
     }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/NutritionProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/NutritionProductFragment.java
@@ -48,10 +48,11 @@ public class NutritionProductFragment extends BaseFragment {
                 && nt.getSaturatedFat() == null && nt.getSugars() == null)) {
             levelItem.add(new NutrientLevelItem(getString(R.string.txtNoData), R.drawable.error_image));
         } else {
-            String saltTxt = Html.fromHtml("<b>" + getString(R.string.txtSalt) + "</b>" + ' ' + nt.getSalt() + " (" + product.getNutriments().getSalt100g() + product.getNutriments().getSaltUnit() + ")").toString();
+
             String fatTxt = Html.fromHtml("<b>" + getString(R.string.txtFat) + "</b>" + ' ' + nt.getFat() + " (" + product.getNutriments().getFat100g() + product.getNutriments().getFatUnit() + ")").toString();
-            String sugarsTxt = Html.fromHtml("<b>" + getString(R.string.txtSugars) + "</b>" + ' ' + nt.getSugars() + " (" + product.getNutriments().getSugars100g() + product.getNutriments().getSugarsUnit() + ")").toString();
             String saturatedFatTxt = Html.fromHtml("<b>" + getString(R.string.txtSaturatedFat) + "</b>" + ' ' + nt.getSaturatedFat() + " (" + product.getNutriments().getSaturatedFat100g() + product.getNutriments().getSaturatedFatUnit() + ")").toString();
+            String sugarsTxt = Html.fromHtml("<b>" + getString(R.string.txtSugars) + "</b>" + ' ' + nt.getSugars() + " (" + product.getNutriments().getSugars100g() + product.getNutriments().getSugarsUnit() + ")").toString();
+            String saltTxt = Html.fromHtml("<b>" + getString(R.string.txtSalt) + "</b>" + ' ' + nt.getSalt() + " (" + product.getNutriments().getSalt100g() + product.getNutriments().getSaltUnit() + ")").toString();
 
             levelItem.add(new NutrientLevelItem(fatTxt, getImageLevel(nt.getFat())));
             levelItem.add(new NutrientLevelItem(saturatedFatTxt, getImageLevel(nt.getSaturatedFat())));

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -49,6 +49,9 @@
   <string name="txtPalmOilProduct">Zutaten aus Palmöl:</string>
   <string name="txtServingSize">Portiongröße:</string>
   <string name="txtNutrientLevel100g">Nahrungsbedarf pro 100 g:</string>
+  <string name="txtNutritionLevelLow">wenig</string>
+  <string name="txtNutritionLevelModerate">moderat</string>
+  <string name="txtNutritionLevelHigh">hoch</string>
   <string name="txtLogin">Login :</string>
   <string name="txtPass">Passwort :</string>
   <string name="txtTitleHome">Open your food und lerne kennen, was du isst</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -49,6 +49,9 @@
   <string name="txtPalmOilProduct">Ingrédients issus de l\'huile de palme :</string>
   <string name="txtServingSize">Taille d\'une portion :</string>
   <string name="txtNutrientLevel100g">Repères nutritionnels pour 100g :</string>
+  <string name="txtNutritionLevelLow">faible</string>
+  <string name="txtNutritionLevelModerate">modérée</string>
+  <string name="txtNutritionLevelHigh">élevée</string>
   <string name="txtLogin">Identifiant :</string>
   <string name="txtPass">Mot de passe :</string>
   <string name="txtTitleHome">Ouvrez votre nourriture pour savoir ce que vous mangez</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,9 @@
     <string name="txtPalmOilProduct">Ingredients from palm oil :</string>
     <string name="txtServingSize">Serving size :</string>
     <string name="txtNutrientLevel100g">Nutrient levels for 100g :</string>
+    <string name="txtNutritionLevelLow">low</string>
+    <string name="txtNutritionLevelModerate">moderate</string>
+    <string name="txtNutritionLevelHigh">high</string>
     <string name="txtLogin">Login :</string>
     <string name="txtPass">Password :</string>
     <string name="txtTitleHome">Open your food and know what you eat</string>


### PR DESCRIPTION
Fixed https://github.com/openfoodfacts/OpenFoodFacts-androidApp/issues/97.
Changed the order of nutritions in the products nutrition information screen.
Created a method which replaces the nutrition level string from the api with the corresponding localized value.
Added a localisation in German (my native language) and French (copied from the website, so might be not correct in this context).