### PR TITLE
fix #249 display no photo when no nutrition data

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/NutrientLevelListAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/NutrientLevelListAdapter.java
@@ -51,7 +51,12 @@ public class NutrientLevelListAdapter extends BaseAdapter {
         ImageView imgIcon = (ImageView) convertView.findViewById(R.id.imgLevel);
         TextView txtTitle = (TextView) convertView.findViewById(R.id.descriptionLevel);
 
-        imgIcon.setImageResource(nutrientLevelItems.get(position).getIcon());
+        if (nutrientLevelItems.get(position).getIcon() == R.drawable.error_image) {
+            imgIcon.setVisibility(View.GONE);
+        } else {
+            imgIcon.setImageResource(nutrientLevelItems.get(position).getIcon());
+            imgIcon.setVisibility(View.VISIBLE);
+        }
         txtTitle.setText(nutrientLevelItems.get(position).getTitle());
 
         return convertView;


### PR DESCRIPTION
When simply setting the image size to 1 pixel, image was not displaied but indents the message.
