### PR TITLE
Resolves #566 Removes deprecated methods

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoginActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoginActivity.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.customtabs.CustomTabsIntent;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.util.Log;
@@ -106,8 +107,8 @@ public class LoginActivity extends BaseActivity implements CustomTabActivityHelp
         final LoadToast lt = new LoadToast(this);
         save.setClickable(false);
         lt.setText(getString(R.string.toast_retrieving));
-        lt.setBackgroundColor(getResources().getColor(R.color.blue));
-        lt.setTextColor(getResources().getColor(R.color.white));
+        lt.setBackgroundColor(ContextCompat.getColor(this,R.color.blue));
+        lt.setTextColor(ContextCompat.getColor(this,R.color.white));
         lt.show();
 
         final Activity context = this;

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/SplashActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/SplashActivity.java
@@ -8,6 +8,7 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -89,8 +90,8 @@ public class SplashActivity extends BaseActivity {
         protected void onPreExecute() {
             super.onPreExecute();
             lt.setText(activity.getString(R.string.toast_retrieving));
-            lt.setBackgroundColor(activity.getResources().getColor(R.color.blue));
-            lt.setTextColor(activity.getResources().getColor(R.color.white));
+            lt.setBackgroundColor(ContextCompat.getColor(SplashActivity.this,R.color.blue));
+            lt.setTextColor(ContextCompat.getColor(SplashActivity.this,R.color.white));
             lt.show();
         }
 


### PR DESCRIPTION
This pull request removes deprecated getColor() methods and replaces them with accepted ContextCompat.getColor() methods.Minor fix. Resolves #566 

##### Tested on Android 8.0.0 (Mi A1) device.