### PR TITLE
Add SerialVersionUID to Nutriments.java

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/Nutriments.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/Nutriments.java
@@ -20,6 +20,7 @@ import static android.text.TextUtils.isEmpty;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Nutriments implements Serializable {
 
+    private static final long serialVersionUID = 1L;
     private static final String DEFAULT_UNIT = "g";
 
     public final static String ENERGY ="energy";


### PR DESCRIPTION
fix https://github.com/openfoodfacts/openfoodfacts-androidapp/issues/569


Helpful articles  at :- https://dzone.com/articles/what-is-serialversionuid?fromrel=true 
And  https://javapapers.com/core-java/serialversionuid-in-java-serialization/ 

It's a basic need so we don't get `InvalidClassException`

This PR  solves  Error `The serializable class Nutriments does not declare a static final serialVersionUID field of type long`