### PR TITLE
Fix for : File provider is preventing the app from launching on earlier Android versions

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/OFFApplication.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/OFFApplication.java
@@ -1,10 +1,9 @@
 package openfoodfacts.github.scrachx.openfood.views;
 
 
-import android.app.Application;
+import android.support.multidex.MultiDexApplication;
 
 import org.greenrobot.greendao.database.Database;
-import org.greenrobot.greendao.database.DatabaseOpenHelper;
 import org.greenrobot.greendao.query.QueryBuilder;
 
 import openfoodfacts.github.scrachx.openfood.BuildConfig;
@@ -14,7 +13,7 @@ import openfoodfacts.github.scrachx.openfood.models.DaoMaster;
 import openfoodfacts.github.scrachx.openfood.models.DaoSession;
 import openfoodfacts.github.scrachx.openfood.models.DatabaseHelper;
 
-public class OFFApplication extends Application {
+public class OFFApplication extends MultiDexApplication {
 
     private DaoSession daoSession;
     private boolean DEBUG = false;


### PR DESCRIPTION
## Description
Multidex was not implemented completely, Base application class must extend MultiDexApplication.
[Read here](https://android.jlelse.eu/how-to-configure-multidex-in-an-application-android-f221198707ed)

## Related issues and discussion
#693 
 
 ## Checklist
 
 - [X] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 
 - [X] If you have multiple commits please combine them into one commit by squashing them.
 
 - [X] Read and understood the contribution guidelines .
