### PR TITLE
Removed extra comma at the end of the list. Fixes #703.

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SummaryProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SummaryProductFragment.java
@@ -174,9 +174,16 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         if (isNotBlank(labels)) {
             labelProduct.append(bold(getString(R.string.txtLabels)));
             labelProduct.append(" ");
-            for (String label : labels.split(",")) {
-                labelProduct.append(label.trim());
-                labelProduct.append(", ");
+            String[] label = labels.split(",");
+            int labelCount = label.length;
+            if(labelCount>1) {
+                for (int i = 0; i < (labelCount - 1); i++) {
+                    labelProduct.append(label[i].trim());
+                    labelProduct.append(", ");
+                }
+                labelProduct.append(label[labelCount-1].trim());
+            } else {
+                labelProduct.append(label[0].trim());
             }
         } else {
             labelProduct.setVisibility(View.GONE);


### PR DESCRIPTION
## Description

Removed extra comma at the end of list of product with 1 label. It was not required.

## Related issues and discussion
Fixes #703 
 
 ## Screen-shots, if any

![screenshot_20180215-025932](https://user-images.githubusercontent.com/10832531/36229847-8ef19ac2-11fe-11e8-8813-08d4ea0c3030.png)
 
 ## Checklist
 
 Please make sure these boxes are checked before submitting your pull request - thanks!
 
 
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 
 - [x] Read and understood the contribution guidelines .
