### PR TITLE
fix #734 App crashes on taping on the image of products

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/FullScreenImage.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/FullScreenImage.java
@@ -18,7 +18,7 @@ import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 public class FullScreenImage extends BaseActivity {
 
     @BindView(R.id.imageViewFullScreen)
-    ImageView mImageView;
+    PhotoView mPhotoView;
     PhotoViewAttacher mAttacher;
 
     @Override
@@ -30,12 +30,12 @@ public class FullScreenImage extends BaseActivity {
         Intent intent = getIntent();
         String imageurl = intent.getExtras().getString("imageurl");
 
-        mAttacher = new PhotoViewAttacher(mImageView);
+        mAttacher = new PhotoViewAttacher(mPhotoView);
 
         if (isNotEmpty(imageurl)) {
             Picasso.with(this)
                     .load(imageurl)
-                    .into(mImageView, new Callback() {
+                    .into(mPhotoView, new Callback() {
                         @Override
                         public void onSuccess() {
                             mAttacher.update();

--- a/app/src/main/res/layout/activity_full_screen_image.xml
+++ b/app/src/main/res/layout/activity_full_screen_image.xml
@@ -5,7 +5,7 @@
     android:background="@android:color/black"
     android:orientation="vertical">
 
-    <ImageView
+    <com.github.chrisbanes.photoview.PhotoView
         android:id="@+id/imageViewFullScreen"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
## Description

Implementation of chrisbanes PhotoView Library's PhotoView is used in place of imageView.
as in pull request #725 the bug was solved using imageView but still, we require more functionalities like

- Out of the box zooming, using multi-touch and double-tap.
- Scrolling, with smooth scrolling fling.

Related issues and discussion
#734 
#709
 