### PR TITLE
fix #Bug on getting back from findProductFragment to homeFragment

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -519,9 +519,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
             Bundle args = new Bundle();
             args.putString("query", query);
             newFragment.setArguments(args);
-
             transaction.replace(R.id.fragment_container, newFragment);
-            transaction.addToBackStack(null);
             transaction.commit();
         }
     }


### PR DESCRIPTION
## Description

On the current version of app, this issue arises because on **fragmentTransaction from HomeFragment** to **SearchedProductFragment** `addToBackStack()` method is used which adds searchedProductFragment to stack, so that's why when we come back to homeFragment and do transition to other fragments the respective bug occurs. On removing the use of this method `addToBackStack()` this bug is solved.

## Related issues and discussion
#731
