### PR TITLE
Fixes #519 Share icon is grey while edit icon is black

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/FullScreenImage.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/FullScreenImage.java
@@ -3,7 +3,6 @@ package openfoodfacts.github.scrachx.openfood.views;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.widget.Toast;
 
 import com.github.chrisbanes.photoview.PhotoView;
 import com.github.chrisbanes.photoview.PhotoViewAttacher;
@@ -26,7 +25,6 @@ public class FullScreenImage extends BaseActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_full_screen_image);
-        Toast.makeText(this,"ey",Toast.LENGTH_SHORT).show();
         Intent intent = getIntent();
         String imageurl = intent.getExtras().getString("imageurl");
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/FullScreenImage.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/FullScreenImage.java
@@ -3,6 +3,7 @@ package openfoodfacts.github.scrachx.openfood.views;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.widget.Toast;
 
 import com.github.chrisbanes.photoview.PhotoView;
 import com.github.chrisbanes.photoview.PhotoViewAttacher;
@@ -25,7 +26,7 @@ public class FullScreenImage extends BaseActivity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_full_screen_image);
-
+        Toast.makeText(this,"ey",Toast.LENGTH_SHORT).show();
         Intent intent = getIntent();
         String imageurl = intent.getExtras().getString("imageurl");
 

--- a/app/src/main/res/layout/activity_product.xml
+++ b/app/src/main/res/layout/activity_product.xml
@@ -16,6 +16,7 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
+            app:theme="@style/BlackShareButton"
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
             app:layout_scrollFlags="scroll|enterAlways" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
 
 
     <!-- Basic OpenFoodFacts colors -->
+    <color name="black">#FF000000</color>
     <color name="green">#00D400</color>
     <color name="blue">#0066FF</color>
     <color name="orange">#FFCC00</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,6 +9,9 @@
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 
+    <style name="BlackShareButton" parent="AppTheme">
+        <item name="android:textColorSecondary">@color/black</item>
+    </style>
     <style name="customSearchView" parent="Widget.AppCompat.Light.SearchView">
         <item name="submitBackground">@color/md_light_appbar</item>
         <item name="queryBackground">@color/md_light_appbar</item>


### PR DESCRIPTION
## Description

Did changes in the styles.xml file. This was done to create rules for the action menu items for the preffered style. 

Now the share button is also black. 
 ## Screen-shots, if any
 
![screenshot_20180216-021535](https://user-images.githubusercontent.com/18038492/36280236-abb07bd0-12bf-11e8-9093-8681f247a62a.png)


