### PR TITLE
restrict LoginActivity to portrait mode only #778

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,6 +67,7 @@
         </activity>
         <activity
             android:name=".views.LoginActivity"
+            android:screenOrientation="portrait"
             android:parentActivityName=".views.MainActivity">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"


### PR DESCRIPTION
## Description

the orientation of activity is restricted only in portrait mode not in landscape mode.

## Related issues and discussion
#778
 
 ## Screen-shots, if any
 
 ## Checklist
 
 Please make sure these boxes are checked before submitting your pull request - thanks!
 
 
 
 - [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 
 - [ ] If you have multiple commits please combine them into one commit by squashing them.
 
 - [ ] Read and understood the contribution guidelines .
