### PR TITLE
fixes compatibility and png issues

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/CustomButtonView.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/CustomButtonView.java
@@ -5,7 +5,7 @@ import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.v7.content.res.AppCompatResources;
-import android.support.v7.widget.AppCompatEditText;
+import android.support.v7.widget.AppCompatButton;
 import android.util.AttributeSet;
 
 import openfoodfacts.github.scrachx.openfood.R;
@@ -13,19 +13,22 @@ import openfoodfacts.github.scrachx.openfood.R;
 /**
  * Based on
  * <a href="http://stackoverflow.com/questions/35761636/is-it-possible-to-use-vectordrawable-in-buttons-and-textviews-using-androiddraw></a>
+ * and <a href="https://medium.com/@elye.project/better-way-of-declaring-custom-view-attributes-23f876c28534>this</a>
  */
-public class CustomEditTextView extends AppCompatEditText {
 
-    public CustomEditTextView(Context context) {
+public class CustomButtonView extends AppCompatButton {
+
+
+    public CustomButtonView(Context context) {
         super(context);
     }
 
-    public CustomEditTextView(Context context, AttributeSet attrs) {
+    public CustomButtonView(Context context, AttributeSet attrs) {
         super(context, attrs);
         initAttrs(context, attrs);
     }
 
-    public CustomEditTextView(Context context, AttributeSet attrs, int defStyleAttr) {
+    public CustomButtonView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
         initAttrs(context, attrs);
     }
@@ -34,22 +37,22 @@ public class CustomEditTextView extends AppCompatEditText {
         if (attrs != null) {
             TypedArray attributeArray = context.obtainStyledAttributes(
                     attrs,
-                    R.styleable.CustomEditTextView);
+                    R.styleable.CustomButtonView);
 
             Drawable drawableLeft = null;
             Drawable drawableRight = null;
             Drawable drawableBottom = null;
             Drawable drawableTop = null;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                drawableLeft = attributeArray.getDrawable(R.styleable.CustomEditTextView_drawableLeftCompat);
-                drawableRight = attributeArray.getDrawable(R.styleable.CustomEditTextView_drawableRightCompat);
-                drawableBottom = attributeArray.getDrawable(R.styleable.CustomEditTextView_drawableBottomCompat);
-                drawableTop = attributeArray.getDrawable(R.styleable.CustomEditTextView_drawableTopCompat);
+                drawableLeft = attributeArray.getDrawable(R.styleable.CustomButtonView_drawableLeftCompat);
+                drawableRight = attributeArray.getDrawable(R.styleable.CustomButtonView_drawableRightCompat);
+                drawableBottom = attributeArray.getDrawable(R.styleable.CustomButtonView_drawableBottomCompat);
+                drawableTop = attributeArray.getDrawable(R.styleable.CustomButtonView_drawableTopCompat);
             } else {
-                final int drawableLeftId = attributeArray.getResourceId(R.styleable.CustomEditTextView_drawableLeftCompat, -1);
-                final int drawableRightId = attributeArray.getResourceId(R.styleable.CustomEditTextView_drawableRightCompat, -1);
-                final int drawableBottomId = attributeArray.getResourceId(R.styleable.CustomEditTextView_drawableBottomCompat, -1);
-                final int drawableTopId = attributeArray.getResourceId(R.styleable.CustomEditTextView_drawableTopCompat, -1);
+                final int drawableLeftId = attributeArray.getResourceId(R.styleable.CustomButtonView_drawableLeftCompat, -1);
+                final int drawableRightId = attributeArray.getResourceId(R.styleable.CustomButtonView_drawableRightCompat, -1);
+                final int drawableBottomId = attributeArray.getResourceId(R.styleable.CustomButtonView_drawableBottomCompat, -1);
+                final int drawableTopId = attributeArray.getResourceId(R.styleable.CustomButtonView_drawableTopCompat, -1);
 
                 if (drawableLeftId != -1)
                     drawableLeft = AppCompatResources.getDrawable(context, drawableLeftId);
@@ -60,8 +63,11 @@ public class CustomEditTextView extends AppCompatEditText {
                 if (drawableTopId != -1)
                     drawableTop = AppCompatResources.getDrawable(context, drawableTopId);
             }
-            setCompoundDrawablesWithIntrinsicBounds(drawableLeft, drawableTop, drawableRight, drawableBottom);
+            setCompoundDrawablesWithIntrinsicBounds(drawableLeft, drawableTop, drawableRight,
+                    drawableBottom);
             attributeArray.recycle();
         }
     }
+
+
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/CustomTextView.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/CustomTextView.java
@@ -1,0 +1,68 @@
+package openfoodfacts.github.scrachx.openfood.utils;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.support.v7.content.res.AppCompatResources;
+import android.support.v7.widget.AppCompatTextView;
+import android.util.AttributeSet;
+
+import openfoodfacts.github.scrachx.openfood.R;
+
+
+public class CustomTextView extends AppCompatTextView {
+
+
+    public CustomTextView(Context context) {
+        super(context);
+    }
+
+    public CustomTextView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        initAttrs(context, attrs);
+    }
+
+    public CustomTextView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        initAttrs(context, attrs);
+    }
+
+    void initAttrs(Context context, AttributeSet attrs) {
+        if (attrs != null) {
+            TypedArray attributeArray = context.obtainStyledAttributes(
+                    attrs,
+                    R.styleable.CustomTextView);
+
+            Drawable drawableLeft = null;
+            Drawable drawableRight = null;
+            Drawable drawableBottom = null;
+            Drawable drawableTop = null;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                drawableLeft = attributeArray.getDrawable(R.styleable.CustomTextView_drawableLeftCompat);
+                drawableRight = attributeArray.getDrawable(R.styleable.CustomTextView_drawableRightCompat);
+                drawableBottom = attributeArray.getDrawable(R.styleable.CustomTextView_drawableBottomCompat);
+                drawableTop = attributeArray.getDrawable(R.styleable.CustomTextView_drawableTopCompat);
+            } else {
+                final int drawableLeftId = attributeArray.getResourceId(R.styleable.CustomTextView_drawableLeftCompat, -1);
+                final int drawableRightId = attributeArray.getResourceId(R.styleable.CustomTextView_drawableRightCompat, -1);
+                final int drawableBottomId = attributeArray.getResourceId(R.styleable.CustomTextView_drawableBottomCompat, -1);
+                final int drawableTopId = attributeArray.getResourceId(R.styleable.CustomTextView_drawableTopCompat, -1);
+
+                if (drawableLeftId != -1)
+                    drawableLeft = AppCompatResources.getDrawable(context, drawableLeftId);
+                if (drawableRightId != -1)
+                    drawableRight = AppCompatResources.getDrawable(context, drawableRightId);
+                if (drawableBottomId != -1)
+                    drawableBottom = AppCompatResources.getDrawable(context, drawableBottomId);
+                if (drawableTopId != -1)
+                    drawableTop = AppCompatResources.getDrawable(context, drawableTopId);
+            }
+            setCompoundDrawablesWithIntrinsicBounds(drawableLeft, drawableTop, drawableRight,
+                    drawableBottom);
+            attributeArray.recycle();
+        }
+    }
+
+
+}

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
@@ -10,8 +10,8 @@ import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.annotation.DrawableRes;
-import android.support.graphics.drawable.VectorDrawableCompat;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.content.res.AppCompatResources;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.Spanned;
@@ -38,16 +38,15 @@ import static android.text.TextUtils.isEmpty;
 public class Utils {
 
     public static final int MY_PERMISSIONS_REQUEST_CAMERA = 1;
-    public static final int MY_PERMISSIONS_REQUEST_STORAGE= 2;
+    public static final int MY_PERMISSIONS_REQUEST_STORAGE = 2;
 
     /**
      * Returns a CharSequence that concatenates the specified array of CharSequence
      * objects and then applies a list of zero or more tags to the entire range.
      *
      * @param content an array of character sequences to apply a style to
-     * @param tags the styled span objects to apply to the content
-     *        such as android.text.style.StyleSpan
-     *
+     * @param tags    the styled span objects to apply to the content
+     *                such as android.text.style.StyleSpan
      */
     private static CharSequence apply(CharSequence[] content, Object... tags) {
         SpannableStringBuilder text = new SpannableStringBuilder();
@@ -170,21 +169,19 @@ public class Utils {
     /**
      * Check if a certain application is installed on a device.
      *
-     * @param context the applications context.
+     * @param context     the applications context.
      * @param packageName the package name that you want to check.
-     *
      * @return true if the application is installed, false otherwise.
      */
 
     public static boolean isApplicationInstalled(Context context, String packageName) {
-    //private boolean isApplicationInstalled(Context context, String packageName) {
+        //private boolean isApplicationInstalled(Context context, String packageName) {
         PackageManager pm = context.getPackageManager();
         try {
             // Check if the package name exists, if exception is thrown, package name does not exist.
             pm.getPackageInfo(packageName, PackageManager.GET_ACTIVITIES);
             return true;
-        }
-        catch (PackageManager.NameNotFoundException e) {
+        } catch (PackageManager.NameNotFoundException e) {
             return false;
         }
     }
@@ -221,7 +218,7 @@ public class Utils {
     }
 
     public static Bitmap getBitmapFromDrawable(Context context, @DrawableRes int drawableId) {
-        Drawable drawable = VectorDrawableCompat.create(context.getResources(), drawableId, null);
+        Drawable drawable = AppCompatResources.getDrawable(context, drawableId);
         Bitmap bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
         Canvas canvas = new Canvas(bitmap);
         drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
@@ -250,7 +247,7 @@ public class Utils {
             return value;
         }
 
-        return  String.format(Locale.getDefault(), "%.2f", Double.valueOf(value));
+        return String.format(Locale.getDefault(), "%.2f", Double.valueOf(value));
     }
 
     public static DaoSession getAppDaoSession(Activity activity) {
@@ -259,6 +256,7 @@ public class Utils {
 
     /**
      * Check if the device has a camera installed.
+     *
      * @return true if installed, false otherwise.
      */
     public static boolean isHardwareCameraInstalled(Context context) {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/OFFApplication.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/OFFApplication.java
@@ -2,6 +2,7 @@ package openfoodfacts.github.scrachx.openfood.views;
 
 
 import android.support.multidex.MultiDexApplication;
+import android.support.v7.app.AppCompatDelegate;
 
 import org.greenrobot.greendao.database.Database;
 import org.greenrobot.greendao.query.QueryBuilder;
@@ -27,6 +28,7 @@ public class OFFApplication extends MultiDexApplication {
     @Override
     public void onCreate() {
         super.onCreate();
+        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
 
         // Use only during development: DaoMaster.DevOpenHelper (Drops all table on Upgrade!)
         // Use only during production: DatabaseHelper (see on Upgrade!)

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/NavDrawerListAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/NavDrawerListAdapter.java
@@ -1,16 +1,17 @@
 package openfoodfacts.github.scrachx.openfood.views.adapters;
 
-import java.util.ArrayList;
-
 import android.app.Activity;
 import android.content.Context;
-import android.support.graphics.drawable.VectorDrawableCompat;
+import android.support.v7.content.res.AppCompatResources;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
+
+import java.util.ArrayList;
+
 import openfoodfacts.github.scrachx.openfood.R;
 import openfoodfacts.github.scrachx.openfood.models.NavDrawerItem;
 
@@ -19,7 +20,7 @@ public class NavDrawerListAdapter extends BaseAdapter {
     private Context context;
     private ArrayList<NavDrawerItem> navDrawerItems;
 
-    public NavDrawerListAdapter(Context context, ArrayList<NavDrawerItem> navDrawerItems){
+    public NavDrawerListAdapter(Context context, ArrayList<NavDrawerItem> navDrawerItems) {
         this.context = context;
         this.navDrawerItems = navDrawerItems;
     }
@@ -50,7 +51,7 @@ public class NavDrawerListAdapter extends BaseAdapter {
         ImageView imgIcon = (ImageView) convertView.findViewById(R.id.icon);
         TextView txtTitle = (TextView) convertView.findViewById(R.id.title);
 
-        imgIcon.setImageDrawable(VectorDrawableCompat.create(context.getResources(), navDrawerItems.get(position).getIcon(), null));
+        imgIcon.setImageDrawable(AppCompatResources.getDrawable(context, navDrawerItems.get(position).getIcon()));
         txtTitle.setText(navDrawerItems.get(position).getTitle());
 
         return convertView;

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/NutrientLevelListAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/NutrientLevelListAdapter.java
@@ -2,7 +2,7 @@ package openfoodfacts.github.scrachx.openfood.views.adapters;
 
 import android.app.Activity;
 import android.content.Context;
-import android.support.graphics.drawable.VectorDrawableCompat;
+import android.support.v7.content.res.AppCompatResources;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -22,7 +22,7 @@ public class NutrientLevelListAdapter extends BaseAdapter {
     private Context context;
     private List<NutrientLevelItem> nutrientLevelItems;
 
-    public NutrientLevelListAdapter(Context context, List<NutrientLevelItem> navDrawerItems){
+    public NutrientLevelListAdapter(Context context, List<NutrientLevelItem> navDrawerItems) {
         this.context = context;
         this.nutrientLevelItems = navDrawerItems;
     }
@@ -57,7 +57,7 @@ public class NutrientLevelListAdapter extends BaseAdapter {
         if (nutrientLevelItem.getIcon() <= 0) {
             imgIcon.setVisibility(View.GONE);
         } else {
-            imgIcon.setImageDrawable(VectorDrawableCompat.create(context.getResources(), nutrientLevelItem.getIcon(), null));
+            imgIcon.setImageDrawable(AppCompatResources.getDrawable(context, nutrientLevelItem.getIcon()));
             imgIcon.setVisibility(View.VISIBLE);
         }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/SaveListAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/SaveListAdapter.java
@@ -2,7 +2,7 @@ package openfoodfacts.github.scrachx.openfood.views.adapters;
 
 import android.app.Activity;
 import android.content.Context;
-import android.support.graphics.drawable.VectorDrawableCompat;
+import android.support.v7.content.res.AppCompatResources;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -20,7 +20,7 @@ public class SaveListAdapter extends BaseAdapter {
     private final Context context;
     private final List<SaveItem> saveItems;
 
-    public SaveListAdapter(Context context, List<SaveItem> saveItems){
+    public SaveListAdapter(Context context, List<SaveItem> saveItems) {
         this.context = context;
         this.saveItems = saveItems;
     }
@@ -50,15 +50,15 @@ public class SaveListAdapter extends BaseAdapter {
 
         ImageView imgIcon = (ImageView) convertView.findViewById(R.id.iconSave);
         TextView txtTitle = (TextView) convertView.findViewById(R.id.titleSave);
-        TextView txtBarcode= (TextView) convertView.findViewById(R.id.barcodeSave);
+        TextView txtBarcode = (TextView) convertView.findViewById(R.id.barcodeSave);
         ImageView imgProduct = (ImageView) convertView.findViewById(R.id.imgSaveProduct);
 
         SaveItem item = saveItems.get(position);
 
-        imgIcon.setImageDrawable(VectorDrawableCompat.create(context.getResources(), item.getIcon(), null));
+        imgIcon.setImageDrawable(AppCompatResources.getDrawable(context, item.getIcon()));
         txtTitle.setText(item.getTitle());
         imgProduct.setImageBitmap(item.getUrl());
-        txtBarcode.setText( item.getBarcode());
+        txtBarcode.setText(item.getBarcode());
 
         return convertView;
     }

--- a/app/src/main/res/drawable/selector.xml
+++ b/app/src/main/res/drawable/selector.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:drawable="@drawable/ic_done_all" />
+
+</selector>

--- a/app/src/main/res/layout/activity_save_product_offline.xml
+++ b/app/src/main/res/layout/activity_save_product_offline.xml
@@ -19,20 +19,20 @@
             android:focusableInTouchMode="true"
             android:orientation="vertical">
 
-            <TextView
+            <openfoodfacts.github.scrachx.openfood.utils.CustomTextView
                 android:id="@+id/barcodeDoubleCheck"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:layout_margin="@dimen/spacing_normal"
                 android:layout_weight="1"
-                android:drawableLeft="@drawable/ic_add_a_photo"
                 android:gravity="center"
                 android:text="@string/txtBarcode"
                 android:textAlignment="center"
                 android:textIsSelectable="true"
                 android:textSize="@dimen/font_larger"
-                android:textStyle="bold" />
+                android:textStyle="bold"
+                app:drawableLeftCompat="@drawable/ic_add_a_photo" />
 
             <LinearLayout
                 android:id="@+id/FrontImageGroup"

--- a/app/src/main/res/layout/custom_spinner_item.xml
+++ b/app/src/main/res/layout/custom_spinner_item.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+<openfoodfacts.github.scrachx.openfood.utils.CustomTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@android:id/text1"
     style="?android:attr/spinnerItemStyle"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:ellipsize="marquee"
     android:gravity="center"
-    android:drawableRight="@drawable/ic_arrow_down"
-    android:textSize="20sp"
     android:textColor="#fff"
+    android:textSize="20sp"
     android:textStyle="bold"
-    />
+    app:drawableRightCompat="@drawable/ic_arrow_down" />

--- a/app/src/main/res/layout/fragment_offline_edit.xml
+++ b/app/src/main/res/layout/fragment_offline_edit.xml
@@ -1,32 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
     <LinearLayout
-        android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@+id/buttonSendAll">
+        android:layout_above="@+id/buttonSendAll"
+        android:orientation="vertical">
 
         <ListView
+            android:id="@+id/listOfflineSave"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_margin="@dimen/spacing_normal"
-            android:id="@+id/listOfflineSave" />
+            android:layout_margin="@dimen/spacing_normal" />
 
     </LinearLayout>
 
-    <Button
+    <openfoodfacts.github.scrachx.openfood.utils.CustomButtonView
+        android:id="@+id/buttonSendAll"
+        style="@style/DefaultButtonText"
         android:layout_width="match_parent"
         android:layout_height="70dp"
-        android:layout_margin="@dimen/spacing_normal"
-        android:drawableLeft="@drawable/ic_done_all"
-        android:background="@color/blue"
-        style="@style/DefaultButtonText"
-        android:layout_gravity="center"
-        android:gravity="center"
         android:layout_alignParentBottom="true"
+        android:layout_gravity="center"
+        android:layout_margin="@dimen/spacing_normal"
+        android:background="@color/blue"
+        android:gravity="center"
         android:text="@string/txtSendAll"
-        android:id="@+id/buttonSendAll"
-            />
+        app:drawableLeftCompat="@drawable/ic_done_all" />
 </RelativeLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,10 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
-    <declare-styleable name="CustomEditTextView">
-        <attr name="drawableLeftCompat" format="reference"/>
-        <attr name="drawableRightCompat" format="reference"/>
-        <attr name="drawableTopCompat" format="reference"/>
-        <attr name="drawableBottomCompat" format="reference"/>
+    <declare-styleable name="CustomView">
+    <attr name="drawableLeftCompat" format="reference"/>
+    <attr name="drawableRightCompat" format="reference"/>
+    <attr name="drawableTopCompat" format="reference"/>
+    <attr name="drawableBottomCompat" format="reference"/>
     </declare-styleable>
+    <declare-styleable name="CustomEditTextView" parent="CustomView">
+        <attr name="drawableLeftCompat" />
+        <attr name="drawableRightCompat" />
+        <attr name="drawableTopCompat" />
+        <attr name="drawableBottomCompat" />
+    </declare-styleable>
+    <declare-styleable name="CustomButtonView" parent="CustomView">
+        <attr name="drawableLeftCompat" />
+        <attr name="drawableRightCompat" />
+        <attr name="drawableTopCompat" />
+        <attr name="drawableBottomCompat" />
+    </declare-styleable>
+    <declare-styleable name="CustomTextView" parent="CustomView">
+        <attr name="drawableLeftCompat" />
+        <attr name="drawableRightCompat" />
+        <attr name="drawableTopCompat" />
+        <attr name="drawableBottomCompat" />
+    </declare-styleable>
+
 </resources>


### PR DESCRIPTION
fixes compatibility and png issues

compatibility below 21

## Description

As ` android:drawableRight` is not compatible with lower versions I added custom text view and custom button view to make `app:drawableRightCompat` which is compatible. 
`VectorDrawableCompat.create()` cannot load png images it will only inflate vector drawables, so when png is encountered it throws an error. 
This is resolved using `AppCompatDrawable.getDrawable()` . For more info [see here](https://stackoverflow.com/questions/40241018/appcompatdrawablemanager-get-vs-vectordrawablecompat-create).

## Related issues and discussion
closes #753
closes #571
closes #621 
 
 ## Checklist

 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 
 - [x] Read and understood the contribution guidelines .
