### PR TITLE
fix #571 Resources$NotFoundException: File res/drawable-hdpi-v4/error…

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/NutrientLevelListAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/NutrientLevelListAdapter.java
@@ -2,7 +2,6 @@ package openfoodfacts.github.scrachx.openfood.views.adapters;
 
 import android.app.Activity;
 import android.content.Context;
-import android.support.graphics.drawable.VectorDrawableCompat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -57,7 +56,7 @@ public class NutrientLevelListAdapter extends BaseAdapter {
         if (nutrientLevelItem.getIcon() <= 0) {
             imgIcon.setVisibility(View.GONE);
         } else {
-            imgIcon.setImageDrawable(VectorDrawableCompat.create(context.getResources(), nutrientLevelItem.getIcon(), null));
+            imgIcon.setImageResource(nutrientLevelItem.getIcon());
             imgIcon.setVisibility(View.VISIBLE);
         }
 


### PR DESCRIPTION
## Description

The bug was present because `VectorDrawableCompat.create()` was not able to load imageDrawable of `nutrientLevelItem.getIcon()` so that's why `setImageResource()` is used to fix the issue.

## Related issues and discussion
#571 
 
 