### PR TITLE
Fixes #773 Camera Scan button making it difficult to view the nutrition facts for some products

### DIFF
--- a/app/src/main/res/layout/fragment_ingredients_product.xml
+++ b/app/src/main/res/layout/fragment_ingredients_product.xml
@@ -13,7 +13,8 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:paddingBottom="65dp">
 
         <ImageButton
             android:id="@+id/imageViewIngredients"
@@ -110,7 +111,8 @@
             android:background="@drawable/textview_full"
             android:padding="@dimen/spacing_small"
             android:textIsSelectable="true"
-            android:textSize="@dimen/font_normal" />
+            android:textSize="@dimen/font_normal"
+            />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_nutrition_info_product.xml
+++ b/app/src/main/res/layout/fragment_nutrition_info_product.xml
@@ -53,6 +53,7 @@
             android:layout_below="@id/textPerPortion"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:paddingBottom="60dp"
          />
 
     </RelativeLayout>

--- a/app/src/main/res/layout/fragment_nutrition_product.xml
+++ b/app/src/main/res/layout/fragment_nutrition_product.xml
@@ -79,7 +79,8 @@
             android:background="@drawable/textview_full"
             android:divider="@color/white"
             android:dividerHeight="0dp"
-            android:padding="@dimen/spacing_small" />
+            android:padding="@dimen/spacing_small"
+            android:paddingBottom="60dp"/>
 
     </LinearLayout>
 </android.support.v4.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_summary_product.xml
+++ b/app/src/main/res/layout/fragment_summary_product.xml
@@ -11,7 +11,8 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        android:paddingBottom="65dp">
 
         <ImageButton
             android:id="@+id/imageViewFront"
@@ -219,7 +220,9 @@
             android:layout_marginTop="@dimen/spacing_tiny"
             android:layout_gravity="center_horizontal"
             android:layout_height="wrap_content"
-            android:text="@string/take_more_pictures" />
+            android:text="@string/take_more_pictures"
+            />
+
 
     </LinearLayout>
 


### PR DESCRIPTION
## Description

Added bottom padding of 60 dp (since floating button is 56dp, it would make it more comfortable to view). Now the size of view pager is the same as before.

 ## Screen-shots, if any
 
![screenshot_20180218-124102](https://user-images.githubusercontent.com/18038492/36349327-e0f17aba-14a9-11e8-8c86-08892c0a80e2.png)


 
 