### PR TITLE
Fixes #519 Share icon is grey and of different size

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductActivity.java
@@ -156,6 +156,11 @@ public class ProductActivity extends BaseActivity {
             case android.R.id.home:
                 NavUtils.navigateUpFromSameTask(this);
                 return true;
+
+            case R.id.menu_item_share:
+                showShareDialog();
+                return super.onOptionsItemSelected(item);
+
             case R.id.action_edit_product:
                 String url = getString(R.string.website) + "cgi/product.pl?type=edit&code=" + mState.getProduct().getCode();
                 if (mState.getProduct().getUrl() != null) {
@@ -170,32 +175,25 @@ public class ProductActivity extends BaseActivity {
         }
     }
 
-
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        getMenuInflater().inflate(R.menu.menu_product, menu);
-        MenuItem item = menu.findItem(R.id.menu_item_share);
-        mShareActionProvider = (ShareActionProvider) MenuItemCompat.getActionProvider(item);
-
-        Intent shareIntent = new Intent(Intent.ACTION_SEND);
+    private void showShareDialog() {
         String url = " " + getString(R.string.website_product) + mState.getProduct().getCode();
         if (mState.getProduct().getUrl() != null) {
             url = " " + mState.getProduct().getUrl();
         }
-        shareIntent.putExtra(Intent.EXTRA_TEXT, getResources().getString(R.string.msg_share) + url);
-        shareIntent.setType("text/plain");
-        setShareIntent(shareIntent);
+        Intent intent = new Intent();
+        intent.setAction(Intent.ACTION_SEND);
+        intent.setType("text/plain");
+        intent.putExtra(Intent.EXTRA_TEXT, getResources().getString(R.string.msg_share) + url);
 
+        startActivity(Intent.createChooser(intent, getString(R.string.share)));
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        getMenuInflater().inflate(R.menu.menu_product, menu);
         return true;
     }
-
-    // Call to update the share intent
-    private void setShareIntent(Intent shareIntent) {
-        if (mShareActionProvider != null) {
-            mShareActionProvider.setShareIntent(shareIntent);
-        }
-    }
-
+     
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] grantResults) {
         switch (requestCode) {

--- a/app/src/main/res/drawable/ic_share_black_48px.xml
+++ b/app/src/main/res/drawable/ic_share_black_48px.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-        android:width="48dp"
-        android:height="48dp"
+        android:width="24dp"
+        android:height="24dp"
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path

--- a/app/src/main/res/layout/activity_product.xml
+++ b/app/src/main/res/layout/activity_product.xml
@@ -17,6 +17,7 @@
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
             app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
+            app:theme="@style/BlackShareButton"
             app:layout_scrollFlags="scroll|enterAlways" />
 
         <android.support.design.widget.TabLayout

--- a/app/src/main/res/menu/menu_product.xml
+++ b/app/src/main/res/menu/menu_product.xml
@@ -5,7 +5,8 @@
         app:showAsAction="ifRoom"
         android:title="@string/share"
         android:icon="@drawable/ic_share_black_48px"
-        app:actionProviderClass="android.support.v7.widget.ShareActionProvider" />
+        android:checkable="true"
+        />
 
     <item android:id="@+id/action_edit_product"
         android:icon="@drawable/ic_mode_edit_black"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -3,6 +3,7 @@
 
 
     <!-- Basic OpenFoodFacts colors -->
+    <color name="black">#FF000000</color>
     <color name="green">#00D400</color>
     <color name="blue">#0066FF</color>
     <color name="orange">#FFCC00</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -9,6 +9,11 @@
         <item name="preferenceTheme">@style/PreferenceThemeOverlay.v14.Material</item>
     </style>
 
+    <style name="BlackShareButton" parent="AppTheme">
+        <item name="android:textColorSecondary">@color/black</item>
+        <item name="actionModeShareDrawable">@drawable/ic_share_black_48px</item>
+    </style>
+
     <style name="customSearchView" parent="Widget.AppCompat.Light.SearchView">
         <item name="submitBackground">@color/md_light_appbar</item>
         <item name="queryBackground">@color/md_light_appbar</item>


### PR DESCRIPTION
## Description

The share action provider was causing problem. Because of it the size of share button was bigger. So used Intent.create chooser instead of the share action provider. Also changed the styles.xml file to make the share button black by defining rules for the toolbar secondry text color.

Now both the share button and edit icon are of same color and same size.
 
 ## Screen-shots, if any
 
![screenshot_20180218-164338](https://user-images.githubusercontent.com/18038492/36351135-1d61a45e-14cb-11e8-9450-2520afbaae1d.png)
![screenshot_20180218-164346](https://user-images.githubusercontent.com/18038492/36351137-1f411cc8-14cb-11e8-9555-8aa47c00bef7.png)
