### PR TITLE
feat: Added option to unmask/unhide the password

### DIFF
--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -38,6 +38,7 @@
         </android.support.design.widget.TextInputLayout>
 
         <android.support.design.widget.TextInputLayout
+            app:passwordToggleEnabled="true"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 


### PR DESCRIPTION

## Description

Currently in login activity there is no option to unhide/unmask the password if the user want's to check whether he has typed the password correctly or not. This feature although very basic is very useful to the users.

## Related issues and discussion
fixes #816 
 
 ## Screen-shots, if any
<img src=https://user-images.githubusercontent.com/21264401/36421501-a94e66f2-165e-11e8-8058-2ad05e885f96.jpeg  width="300" height="500">

<img src=https://user-images.githubusercontent.com/21264401/36421504-aa73822e-165e-11e8-90e2-085ffeb44d46.jpeg  width="300" height="500">

 
 ## Checklist 
 
  - [x] If you have multiple commits please combine them into one commit by squashing them.
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 
- [x] Read and understood the contribution guidelines .
