### PR TITLE
fix: Wrong title in various Activities #839

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,7 @@
         </activity>
         <activity
             android:name=".views.LoginActivity"
+            android:label="Sign In"
             android:screenOrientation="portrait"
             android:parentActivityName=".views.MainActivity">
             <meta-data
@@ -88,6 +89,7 @@
             android:screenOrientation="portrait" />
         <activity
             android:name=".views.HistoryScanActivity"
+            android:label="History"
             android:parentActivityName=".views.MainActivity"
             android:screenOrientation="portrait"
             android:windowSoftInputMode="stateUnchanged|adjustResize">


### PR DESCRIPTION
## Description

Currently in various screens like History,Sign in etc the name of the app in the title instead of
the name of that particular activity is shown.

## Related issues and discussion
fixes #839
 
 ## Screen-shots, if any
<img src=https://user-images.githubusercontent.com/21264401/36478650-8726d366-172b-11e8-8f42-b883baf55a8b.jpeg width="300" height="500">

<img src=https://user-images.githubusercontent.com/21264401/36478665-930ea1f4-172b-11e8-8c97-79ec7e9ee76a.jpeg width="300" height="500">

 ## Checklist
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 
 - [x] Read and understood the contribution guidelines .
