### PR TITLE
fix: 867 Hide status bar in Splash Screen

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -20,8 +20,12 @@
         <item name="searchViewStyle">@style/customSearchView</item>
     </style>
 
-    <style name="SplashTheme" parent="Theme.AppCompat.NoActionBar">
+    <style name="SplashTheme" parent="@style/Theme.AppCompat.Light">
         <item name="android:windowBackground">@drawable/background_splash</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowFullscreen">true</item>
+        <item name="android:windowContentOverlay">@null</item>
     </style>
 
     <style name="PreferenceThemeOverlay.v14">


### PR DESCRIPTION
## Description

It is usually considered better to hide the status bar in splash screen and in most of the apps the status bar is hidden in splash screen

## Related issues and discussion
Fixes #867 
 
 ## Screen-shots, if any
 
<img src=https://user-images.githubusercontent.com/21264401/36573127-56db21c2-1865-11e8-9fa0-c33a8ba958dd.jpeg width="300" height="500">

 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
