### PR TITLE
fixes #917 App is getting crash due to java.lang.RuntimeException on …

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/WelcomeActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/WelcomeActivity.java
@@ -32,7 +32,10 @@ public class WelcomeActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+
+        requestWindowFeature(Window.FEATURE_NO_TITLE);
         super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_welcome);
 
         prefManager = new PrefManager(this);
         if (!prefManager.isFirstTimeLaunch()) {
@@ -43,9 +46,8 @@ public class WelcomeActivity extends AppCompatActivity {
         if (Build.VERSION.SDK_INT >= 21) {
             getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN);
         }
-        requestWindowFeature(Window.FEATURE_NO_TITLE);
-        this.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        setContentView(R.layout.activity_welcome);
+        this.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
+
 
         viewPager = (ViewPager) findViewById(R.id.view_pager);
         dotsLayout = (LinearLayout) findViewById(R.id.layoutDots);


### PR DESCRIPTION
fixes #917 

**Changes in this PR:**

 For AppCompat library, it's necessary to call `requestFeature()` before `super.onCreate()`
So, `requestWindowFeature(Window.FEATURE_NO_TITLE)` is called before ` super.onCreate()`
        
