### PR TITLE
Closes #173 Added ability to rotate and crop images (before sending)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -195,6 +195,7 @@ dependencies {
     implementation "com.mikepenz:material-design-iconic-typeface:$rootProject.materialFontVersion"
     implementation "com.mikepenz:fontawesome-typeface:$rootProject.awesomeFontVersion"
 
+    implementation "com.theartofdev.edmodo:android-image-cropper:2.6.+"
     //Testing
     testImplementation "junit:junit:$rootProject.jUnitVersion"
     testImplementation "org.mockito:mockito-core:$rootProject.mockitoVersion"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -112,6 +112,9 @@
         <activity android:name=".views.WelcomeActivity">
         </activity>
 
+        <activity android:name="com.theartofdev.edmodo.cropper.CropImageActivity"
+            android:theme="@style/Base.Theme.AppCompat"/>
+
         <service android:name=".jobs.SavedProductUploadJob"
             android:exported="false">
             <intent-filter>

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/IngredientsProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/IngredientsProductFragment.java
@@ -20,6 +20,7 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.squareup.picasso.Picasso;
+import com.theartofdev.edmodo.cropper.CropImage;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -40,10 +41,12 @@ import openfoodfacts.github.scrachx.openfood.models.State;
 import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient;
 import openfoodfacts.github.scrachx.openfood.utils.Utils;
 import openfoodfacts.github.scrachx.openfood.views.FullScreenImage;
+import openfoodfacts.github.scrachx.openfood.views.SaveProductOfflineActivity;
 import pl.aprilapps.easyphotopicker.DefaultCallback;
 import pl.aprilapps.easyphotopicker.EasyImage;
 
 import static android.Manifest.permission.CAMERA;
+import static android.app.Activity.RESULT_OK;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static android.text.Spanned.SPAN_EXCLUSIVE_EXCLUSIVE;
 import static openfoodfacts.github.scrachx.openfood.models.ProductImageField.INGREDIENTS;
@@ -55,14 +58,22 @@ public class IngredientsProductFragment extends BaseFragment {
 
     public static final Pattern INGREDIENT_PATTERN = Pattern.compile("[\\p{L}\\p{Nd}(),.-]+");
     public static final Pattern ALLERGEN_PATTERN = Pattern.compile("[\\p{L}\\p{Nd}]+");
-    @BindView(R.id.textIngredientProduct) TextView ingredientsProduct;
-    @BindView(R.id.textSubstanceProduct) TextView substanceProduct;
-    @BindView(R.id.textTraceProduct) TextView traceProduct;
-    @BindView(R.id.textAdditiveProduct) TextView additiveProduct;
-    @BindView(R.id.textPalmOilProduct) TextView palmOilProduct;
-    @BindView(R.id.textMayBeFromPalmOilProduct) TextView mayBeFromPalmOilProduct;
-    @BindView(R.id.imageViewIngredients) ImageView mImageIngredients;
-    @BindView(R.id.addPhotoLabel) TextView addPhotoLabel;
+    @BindView(R.id.textIngredientProduct)
+    TextView ingredientsProduct;
+    @BindView(R.id.textSubstanceProduct)
+    TextView substanceProduct;
+    @BindView(R.id.textTraceProduct)
+    TextView traceProduct;
+    @BindView(R.id.textAdditiveProduct)
+    TextView additiveProduct;
+    @BindView(R.id.textPalmOilProduct)
+    TextView palmOilProduct;
+    @BindView(R.id.textMayBeFromPalmOilProduct)
+    TextView mayBeFromPalmOilProduct;
+    @BindView(R.id.imageViewIngredients)
+    ImageView mImageIngredients;
+    @BindView(R.id.addPhotoLabel)
+    TextView addPhotoLabel;
 
     private OpenFoodAPIClient api;
     private String mUrlImage;
@@ -99,18 +110,18 @@ public class IngredientsProductFragment extends BaseFragment {
 
         List<String> allergens = getAllergens();
 
-        if(mState != null && product.getIngredientsText() != null) {
-            SpannableStringBuilder txtIngredients = new SpannableStringBuilder(product.getIngredientsText().replace("_",""));
+        if (mState != null && product.getIngredientsText() != null) {
+            SpannableStringBuilder txtIngredients = new SpannableStringBuilder(product.getIngredientsText().replace("_", ""));
             txtIngredients = setSpanBoldBetweenTokens(txtIngredients, allergens);
             int ingredientsListAt = Math.max(0, txtIngredients.toString().indexOf(":"));
-            if(!txtIngredients.toString().substring(ingredientsListAt).trim().isEmpty()) {
+            if (!txtIngredients.toString().substring(ingredientsListAt).trim().isEmpty()) {
                 ingredientsProduct.setText(txtIngredients);
             } else {
                 ingredientsProduct.setVisibility(View.GONE);
             }
         }
 
-        if(!allergens.isEmpty()) {
+        if (!allergens.isEmpty()) {
             substanceProduct.append(bold(getString(R.string.txtSubstances)));
             substanceProduct.append(" ");
             String delim = "";
@@ -128,7 +139,7 @@ public class IngredientsProductFragment extends BaseFragment {
             traceProduct.setVisibility(View.GONE);
         } else {
             traces = product.getTraces().replace(",", ", ");
-            if(traces.isEmpty()) {
+            if (traces.isEmpty()) {
                 traceProduct.setVisibility(View.GONE);
             } else {
                 traceProduct.append(bold(getString(R.string.txtTraces)));
@@ -137,7 +148,7 @@ public class IngredientsProductFragment extends BaseFragment {
             }
         }
 
-        if(!product.getAdditivesTags().isEmpty()) {
+        if (!product.getAdditivesTags().isEmpty()) {
             additiveProduct.setMovementMethod(LinkMovementMethod.getInstance());
             additiveProduct.append(bold(getString(R.string.txtAdditives)));
             additiveProduct.append(" ");
@@ -198,7 +209,7 @@ public class IngredientsProductFragment extends BaseFragment {
                 }
             };*/
             ssb.append(tag);
-           // ssb.setSpan(clickableSpan, 0, ssb.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
+            // ssb.setSpan(clickableSpan, 0, ssb.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
             ssb.append(" ");
         }
         return ssb;
@@ -211,14 +222,14 @@ public class IngredientsProductFragment extends BaseFragment {
             final String tm = m.group();
             final String allergenValue = tm.replaceAll("[(),.-]+", "");
 
-            for (String allergen: allergens) {
-                if(allergen.equalsIgnoreCase(allergenValue)) {
+            for (String allergen : allergens) {
+                if (allergen.equalsIgnoreCase(allergenValue)) {
                     int start = m.start();
                     int end = m.end();
 
-                    if(tm.contains("(")) {
+                    if (tm.contains("(")) {
                         start += 1;
-                    } else if(tm.contains(")")) {
+                    } else if (tm.contains(")")) {
                         end -= 1;
                     }
 
@@ -242,7 +253,7 @@ public class IngredientsProductFragment extends BaseFragment {
             boolean canAdd = true;
 
             for (String allergen : list) {
-                if(tma.equalsIgnoreCase(allergen)){
+                if (tma.equalsIgnoreCase(allergen)) {
                     canAdd = false;
                     break;
                 }
@@ -289,6 +300,15 @@ public class IngredientsProductFragment extends BaseFragment {
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
+            CropImage.ActivityResult result = CropImage.getActivityResult(data);
+            if (resultCode == RESULT_OK) {
+                Uri resultUri = result.getUri();
+                onPhotoReturned(new File(resultUri.getPath()));
+            } else if (resultCode == CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE) {
+                Exception error = result.getError();
+            }
+        }
 
         EasyImage.handleActivityResult(requestCode, resultCode, data, getActivity(), new DefaultCallback() {
             @Override
@@ -298,7 +318,8 @@ public class IngredientsProductFragment extends BaseFragment {
 
             @Override
             public void onImagesPicked(List<File> imageFiles, EasyImage.ImageSource source, int type) {
-                onPhotoReturned(imageFiles.get(0));
+                CropImage.activity(Uri.fromFile(imageFiles.get(0))).setAllowFlipping(false)
+                        .start(getActivity());
             }
 
             @Override

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/NutritionInfoProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/NutritionInfoProductFragment.java
@@ -20,6 +20,7 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.squareup.picasso.Picasso;
+import com.theartofdev.edmodo.cropper.CropImage;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -45,6 +46,7 @@ import pl.aprilapps.easyphotopicker.DefaultCallback;
 import pl.aprilapps.easyphotopicker.EasyImage;
 
 import static android.Manifest.permission.CAMERA;
+import static android.app.Activity.RESULT_OK;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static android.support.v7.widget.DividerItemDecoration.VERTICAL;
 import static android.text.TextUtils.isEmpty;
@@ -263,6 +265,16 @@ public class NutritionInfoProductFragment extends BaseFragment {
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
+        if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
+            CropImage.ActivityResult result = CropImage.getActivityResult(data);
+            if (resultCode == RESULT_OK) {
+                Uri resultUri = result.getUri();
+                onPhotoReturned(new File(resultUri.getPath()));
+            } else if (resultCode == CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE) {
+                Exception error = result.getError();
+            }
+        }
+
         EasyImage.handleActivityResult(requestCode, resultCode, data, getActivity(), new DefaultCallback() {
             @Override
             public void onImagePickerError(Exception e, EasyImage.ImageSource source, int type) {
@@ -271,7 +283,8 @@ public class NutritionInfoProductFragment extends BaseFragment {
 
             @Override
             public void onImagesPicked(List<File> imageFiles, EasyImage.ImageSource source, int type) {
-                onPhotoReturned(imageFiles.get(0));
+                CropImage.activity(Uri.fromFile(imageFiles.get(0))).setAllowFlipping(false)
+                        .start(getActivity());
             }
 
             @Override

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SummaryProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SummaryProductFragment.java
@@ -26,6 +26,7 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.squareup.picasso.Picasso;
+import com.theartofdev.edmodo.cropper.CropImage;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -46,6 +47,7 @@ import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient;
 import openfoodfacts.github.scrachx.openfood.utils.Utils;
 import openfoodfacts.github.scrachx.openfood.views.FullScreenImage;
 import openfoodfacts.github.scrachx.openfood.views.MainActivity;
+import openfoodfacts.github.scrachx.openfood.views.SaveProductOfflineActivity;
 import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabActivityHelper;
 import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabsHelper;
 import openfoodfacts.github.scrachx.openfood.views.customtabs.WebViewFallback;
@@ -55,6 +57,7 @@ import pl.aprilapps.easyphotopicker.EasyImage;
 import static android.Manifest.permission.CAMERA;
 import static android.Manifest.permission.READ_EXTERNAL_STORAGE;
 import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
+import static android.app.Activity.RESULT_OK;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 import static openfoodfacts.github.scrachx.openfood.models.ProductImageField.FRONT;
 import static openfoodfacts.github.scrachx.openfood.models.ProductImageField.OTHER;
@@ -427,6 +430,21 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
+        if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
+            CropImage.ActivityResult result = CropImage.getActivityResult(data);
+            if (resultCode == RESULT_OK) {
+                Uri resultUri = result.getUri();
+                if (!sendOther) {
+                    onPhotoReturned(new File(resultUri.getPath()));
+                } else {
+                    ProductImage image = new ProductImage(barcode, OTHER, new  File(resultUri.getPath()));
+                    image.setFilePath(resultUri.getPath());
+                    api.postImg(getContext(), image);
+                }
+            } else if (resultCode == CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE) {
+                Exception error = result.getError();
+            }
+        }
         EasyImage.handleActivityResult(requestCode, resultCode, data, getActivity(), new DefaultCallback() {
             @Override
             public void onImagePickerError(Exception e, EasyImage.ImageSource source, int type) {
@@ -435,13 +453,8 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
 
             @Override
             public void onImagesPicked(List<File> imageFiles, EasyImage.ImageSource source, int type) {
-                if (!sendOther) {
-                    onPhotoReturned(imageFiles.get(0));
-                } else {
-                    ProductImage image = new ProductImage(barcode, OTHER, new  File(imageFiles.get(0).getAbsolutePath()));
-                    image.setFilePath(imageFiles.get(0).getAbsolutePath());
-                    api.postImg(getContext(), image);
-                }
+                CropImage.activity(Uri.fromFile(imageFiles.get(0))).setAllowFlipping(false)
+                        .start(getActivity());
             }
 
             @Override

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/SaveProductOfflineActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/SaveProductOfflineActivity.java
@@ -27,7 +27,11 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.github.chrisbanes.photoview.PhotoView;
+import com.github.chrisbanes.photoview.PhotoViewAttacher;
+import com.squareup.picasso.Callback;
 import com.squareup.picasso.Picasso;
+import com.theartofdev.edmodo.cropper.CropImage;
 
 import java.io.File;
 import java.util.List;
@@ -61,11 +65,11 @@ public class SaveProductOfflineActivity extends BaseActivity {
     @BindView(R.id.barcodeDoubleCheck)
     TextView barcodeText;
     @BindView(R.id.imageSaveFront)
-    ImageView imgSaveFront;
+    PhotoView imgSaveFront;
     @BindView(R.id.imageSaveNutrition)
-    ImageView imgSaveNutrition;
+    PhotoView imgSaveNutrition;
     @BindView(R.id.imageSaveIngredients)
-    ImageView imgSaveIngredients;
+    PhotoView imgSaveIngredients;
     @BindView(R.id.editTextName)
     EditText name;
     @BindView(R.id.editTextBrand)
@@ -86,6 +90,10 @@ public class SaveProductOfflineActivity extends BaseActivity {
     CardView mContainerView;
     @BindView(R.id.message_dismiss_icon)
     ImageButton mDismissButton;
+
+    PhotoViewAttacher mAttacherimgSaveFront;
+    PhotoViewAttacher mAttacherimgSaveNutrition;
+    PhotoViewAttacher mAttacherimageSaveIngredients;
 
     private SendProduct mProduct;
     private String mBarcode;
@@ -336,6 +344,16 @@ public class SaveProductOfflineActivity extends BaseActivity {
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
 
+        if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
+            CropImage.ActivityResult result = CropImage.getActivityResult(data);
+            if (resultCode == RESULT_OK) {
+                Uri resultUri = result.getUri();
+                onPhotoReturned(new File(resultUri.getPath()));
+            } else if (resultCode == CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE) {
+                Exception error = result.getError();
+            }
+        }
+
         EasyImage.handleActivityResult(requestCode, resultCode, data, this, new DefaultCallback() {
             @Override
             public void onImagePickerError(Exception e, EasyImage.ImageSource source, int type) {
@@ -344,7 +362,9 @@ public class SaveProductOfflineActivity extends BaseActivity {
 
             @Override
             public void onImagesPicked(List<File> imageFiles, EasyImage.ImageSource source, int type) {
-                onPhotoReturned(imageFiles.get(0));
+                CropImage.activity(Uri.fromFile(imageFiles.get(0))).setAllowFlipping(false)
+                        .start(SaveProductOfflineActivity.this);
+
             }
 
             @Override
@@ -362,27 +382,50 @@ public class SaveProductOfflineActivity extends BaseActivity {
         if (imageTaken.equals("front")) {
             mProduct.setImgupload_front(photoFile.getAbsolutePath());
             imgSaveFront.setVisibility(View.VISIBLE);
-            Picasso.with(this)
-                    .load(photoFile)
-                    .fit()
-                    .centerCrop()
-                    .into(imgSaveFront);
-        } else if (imageTaken.equals("nutrition")) {
+            mAttacherimgSaveFront = new PhotoViewAttacher(imgSaveFront);
+                Picasso.with(this)
+                        .load(photoFile)
+                        .into(imgSaveFront, new Callback() {
+                            @Override
+                            public void onSuccess() {
+                                mAttacherimgSaveFront.update();
+                            }
+
+                            @Override
+                            public void onError() {
+                            }
+                        });
+            }
+         else if (imageTaken.equals("nutrition")) {
             mProduct.setImgupload_nutrition(photoFile.getAbsolutePath());
             imgSaveNutrition.setVisibility(View.VISIBLE);
+            mAttacherimgSaveNutrition = new PhotoViewAttacher(imgSaveNutrition);
             Picasso.with(this)
                     .load(photoFile)
-                    .fit()
-                    .centerCrop()
-                    .into(imgSaveNutrition);
+                    .into(imgSaveNutrition, new Callback() {
+                        @Override
+                        public void onSuccess() {
+                            mAttacherimgSaveNutrition.update();
+                        }
+                        @Override
+                        public void onError() {
+                        }
+                    });
         } else if (imageTaken.equals("ingredients")) {
             mProduct.setImgupload_ingredients(photoFile.getAbsolutePath());
             imgSaveIngredients.setVisibility(View.VISIBLE);
+            mAttacherimageSaveIngredients = new PhotoViewAttacher(imgSaveIngredients);
             Picasso.with(this)
                     .load(photoFile)
-                    .fit()
-                    .centerCrop()
-                    .into(imgSaveIngredients);
+                    .into(imgSaveIngredients, new Callback() {
+                        @Override
+                        public void onSuccess() {
+                            mAttacherimageSaveIngredients.update();
+                        }
+                        @Override
+                        public void onError() {
+                        }
+                    });
         }
     }
 

--- a/app/src/main/res/layout/activity_save_product_offline.xml
+++ b/app/src/main/res/layout/activity_save_product_offline.xml
@@ -101,7 +101,7 @@
                     android:textSize="@dimen/font_large"
                     android:textStyle="bold" />
 
-                <ImageView
+                <com.github.chrisbanes.photoview.PhotoView
                     android:id="@+id/imageSaveFront"
                     android:layout_width="match_parent"
                     android:layout_height="250dp"
@@ -160,7 +160,7 @@
                     android:textSize="@dimen/font_large"
                     android:textStyle="bold" />
 
-                <ImageView
+                <com.github.chrisbanes.photoview.PhotoView
                     android:id="@+id/imageSaveIngredients"
                     android:layout_width="match_parent"
                     android:layout_height="250dp"
@@ -218,7 +218,7 @@
                     android:textSize="@dimen/font_large"
                     android:textStyle="bold" />
 
-                <ImageView
+                <com.github.chrisbanes.photoview.PhotoView
                     android:id="@+id/imageSaveNutrition"
                     android:layout_width="match_parent"
                     android:layout_height="250dp"


### PR DESCRIPTION
## Description

**Android Image Cropper Library** is used to implement the functionality of Cropping and Rotation of images.
 
https://github.com/ArthurHub/Android-Image-Cropper

**This feature is implemented in following Activities or Fragments:**

- SaveProductOfflineActivity
- NutritionInfoProductFragment
- IngredientsProductFragment
- SummaryProductFragment

In `SaveProductOfflineActivity` Chrisbanes Photoview is used instead of ImageView for better user experience.

## Related issues and discussion
Closes #173 
 
 ## Screen-shots, if any

![demo](https://user-images.githubusercontent.com/25099208/36696121-5a6100b2-1b69-11e8-8c67-c0c962734ef7.gif)
 