### PR TITLE
Fixes #332: Let the user decide if products should be sent on mobile data or Wifi

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/BarCodeScannerFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/BarCodeScannerFragment.java
@@ -8,6 +8,7 @@ import android.media.ToneGenerator;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.view.MenuItemCompat;
 import android.util.Log;
@@ -179,7 +180,7 @@ public class BarCodeScannerFragment extends BaseFragment implements MessageDialo
             return;
         }
 
-        if (Utils.isNetworkConnected(getContext())) {
+        if (Utils.isNetworkConnected(getContext()) && PreferenceManager.getDefaultSharedPreferences(getContext()).getBoolean("enableMobileDataUpload", true)) {
             api.getProduct(rawResult.getText(), getActivity(), mScannerView, this);
         } else {
             Intent intent = new Intent(getActivity(), SaveProductOfflineActivity.class);

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/OfflineEditFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/OfflineEditFragment.java
@@ -6,6 +6,7 @@ import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -33,6 +34,7 @@ import openfoodfacts.github.scrachx.openfood.models.SendProduct;
 import openfoodfacts.github.scrachx.openfood.models.SendProductDao;
 import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient;
 import openfoodfacts.github.scrachx.openfood.utils.Utils;
+import openfoodfacts.github.scrachx.openfood.views.MainActivity;
 import openfoodfacts.github.scrachx.openfood.views.SaveProductOfflineActivity;
 import openfoodfacts.github.scrachx.openfood.views.adapters.SaveListAdapter;
 
@@ -111,7 +113,7 @@ public class OfflineEditFragment extends BaseFragment {
 
     @OnClick(R.id.buttonSendAll)
     protected void onSendAllProducts() {
-        if (!Utils.isAirplaneModeActive(getContext()) && Utils.isNetworkConnected(getContext())) {
+        if (!Utils.isAirplaneModeActive(getContext()) && Utils.isNetworkConnected(getContext()) && PreferenceManager.getDefaultSharedPreferences(getContext()).getBoolean("enableMobileDataUpload", true)) {
             new MaterialDialog.Builder(getActivity())
                     .title(R.string.txtDialogsTitle)
                     .content(R.string.txtDialogsContentSend)
@@ -163,9 +165,7 @@ public class OfflineEditFragment extends BaseFragment {
                     .content(R.string.airplane_mode_active_dialog_message)
                     .positiveText(R.string.airplane_mode_active_dialog_positive)
                     .negativeText(R.string.airplane_mode_active_dialog_negative)
-                    .onPositive((dialog, which) -> {
-                        startActivity(new Intent(Settings.ACTION_AIRPLANE_MODE_SETTINGS));
-                    })
+                    .onPositive((dialog, which) -> startActivity(new Intent(Settings.ACTION_AIRPLANE_MODE_SETTINGS)))
                     .show();
         } else if (!Utils.isNetworkConnected(getContext())){
             new MaterialDialog.Builder(getActivity())
@@ -173,9 +173,15 @@ public class OfflineEditFragment extends BaseFragment {
                     .content(R.string.device_offline_dialog_message)
                     .positiveText(R.string.device_offline_dialog_positive)
                     .negativeText(R.string.device_offline_dialog_negative)
-                    .onPositive((dialog, which) -> {
-                        startActivity(new Intent(Settings.ACTION_SETTINGS));
-                    })
+                    .onPositive((dialog, which) -> startActivity(new Intent(Settings.ACTION_SETTINGS)))
+                    .show();
+        } else if (!PreferenceManager.getDefaultSharedPreferences(getContext()).getBoolean("enableMobileDataUpload", true) && Utils.isConnectedToMobileData(getContext())){
+            new MaterialDialog.Builder(getActivity())
+                    .title(R.string.device_on_mobile_data_warning_title)
+                    .content(R.string.device_on_mobile_data_warning_message)
+                    .positiveText(R.string.device_on_mobile_data_warning_positive)
+                    .negativeText(R.string.device_on_mobile_data_warning_negative)
+                    .onPositive((dialog, which) -> ((MainActivity)getActivity()).moveToPreferences())
                     .show();
         }
     }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
@@ -391,4 +391,40 @@ public class Utils {
         return activeNetwork != null && activeNetwork.isConnectedOrConnecting();
     }
 
+    /**
+     * Check if the user is connected to a mobile network.
+     * @param context of the application.
+     * @return true if connected to mobile data.
+     */
+    public static boolean isConnectedToMobileData(Context context){
+        return getNetworkType(context).equals("Mobile");
+    }
+
+    /**
+     * Get the type of network that the user is connected to.
+     *
+     * @param context of the application.
+     * @return the type of network that is connected.
+     */
+    private static String getNetworkType(Context context) {
+        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+
+        if (activeNetwork != null && activeNetwork.isConnectedOrConnecting()) {
+            switch (activeNetwork.getType()) {
+                case ConnectivityManager.TYPE_ETHERNET:
+                    return "Ethernet";
+                case ConnectivityManager.TYPE_MOBILE:
+                    return "Mobile";
+                case ConnectivityManager.TYPE_VPN:
+                    return "VPN";
+                case ConnectivityManager.TYPE_WIFI:
+                    return "WiFi";
+                case ConnectivityManager.TYPE_WIMAX:
+                    return "WiMax";
+            }
+        }
+
+        return "Other";
+    }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -639,4 +639,19 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
             Log.e("MainActivity", "Error in creating fragment");
         }
     }
+
+    /**
+     * This moves the main activity to the preferences fragment.
+     */
+    public void moveToPreferences(){
+        result.setSelection(8);
+        Fragment fragment = new PreferencesFragment();
+        getSupportActionBar().setTitle(R.string.action_preferences);
+
+        if (fragment != null){
+            getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container, fragment).commit();
+        } else {
+            Log.e(getClass().getSimpleName(), "Error in creating fragment");
+        }
+    }
 }

--- a/app/src/main/res/layout/fragment_offline_edit.xml
+++ b/app/src/main/res/layout/fragment_offline_edit.xml
@@ -30,6 +30,6 @@
         android:text="@string/txtSendAll"
         android:paddingStart="50dp"
         android:paddingEnd="50dp"
-        android:textSize="16sp"
-        app:drawableLeftCompat="@drawable/ic_done_all" />
+        android:textSize="16sp" />
+        <!--app:drawableLeftCompat="@drawable/ic_done_all" -->
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_offline_edit.xml
+++ b/app/src/main/res/layout/fragment_offline_edit.xml
@@ -31,5 +31,4 @@
         android:paddingStart="50dp"
         android:paddingEnd="50dp"
         android:textSize="16sp" />
-        <!--app:drawableLeftCompat="@drawable/ic_done_all" -->
 </RelativeLayout>

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -5,4 +5,5 @@
     <item type="id" name="menu_auto_focus" />
     <item type="id" name="menu_camera_selector" />
     <item type="id" name="menu_about" />
+    <item type="id" name="menu_problem_scanning" />
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -377,6 +377,7 @@
     <string name="contact_summary">Contact the team</string>
     <string name="off_mail">mailto:contact@openfoodfacts.org</string>
     <string name="email_not_found">No email applications found</string>
+
     <string name="airplane_mode_active_dialog_title">Airplane mode enabled</string>
     <string name="airplane_mode_active_dialog_message">Airplane mode is enabled, please disable this to continue.</string>
     <string name="airplane_mode_active_dialog_negative">Dismiss</string>
@@ -387,4 +388,15 @@
     <string name="device_offline_dialog_negative">Dismiss</string>
     <string name="device_offline_dialog_positive">Settings</string>
     <string name="saving">Saving…</string>
+
+    <string name="preference_enable_mobile_data_title">Upload on mobile data</string>
+    <string name="preference_enable_mobile_data_summary_on">Upload new products using mobile data &amp; WiFi</string>
+    <string name="preference_enable_mobile_data_summary_off">Upload new products using WiFi only</string>
+
+    <string name="device_on_mobile_data_warning_title">Information</string>
+    <string name="device_on_mobile_data_warning_message">Upload on mobile data is disabled, please connect to WiFi or change this in preferences</string>
+    <string name="device_on_mobile_data_warning_positive">Preferences</string>
+    <string name="device_on_mobile_data_warning_negative">Dismiss</string>
+
+    <string name="preference_choose_language_dialog_title">Choose language</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -396,7 +396,7 @@
     <string name="device_on_mobile_data_warning_title">Information</string>
     <string name="device_on_mobile_data_warning_message">Upload on mobile data is disabled, please connect to WiFi or change this in preferences</string>
     <string name="device_on_mobile_data_warning_positive">Preferences</string>
-    <string name="device_on_mobile_data_warning_negative">Dismiss</string>
+    <string name="device_on_mobile_data_warning_negative">Upload anyway</string>
 
     <string name="preference_choose_language_dialog_title">Choose language</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,26 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <CheckBoxPreference android:defaultValue="false"
+    <CheckBoxPreference
+        android:defaultValue="false"
         android:key="startScan"
         android:summary="@string/prefs_scan_startup_summary"
-        android:title="@string/prefs_scan_startup"/>
+        android:title="@string/prefs_scan_startup" />
 
-    <CheckBoxPreference android:defaultValue="false"
+    <CheckBoxPreference
+        android:defaultValue="false"
         android:key="powerMode"
         android:summary="@string/prefs_power_mode_summary"
-        android:title="@string/prefs_power_mode"/>
+        android:title="@string/prefs_power_mode" />
+
+    <CheckBoxPreference
+        android:defaultValue="true"
+        android:key="enableMobileDataUpload"
+        android:summaryOff="@string/preference_enable_mobile_data_summary_off"
+        android:summaryOn="@string/preference_enable_mobile_data_summary_on"
+        android:title="@string/preference_enable_mobile_data_title" />
 
     <ListPreference
         android:defaultValue="en"
-        android:dialogTitle="Choose language"
+        android:dialogTitle="@string/preference_choose_language_dialog_title"
         android:key="Locale.Helper.Selected.Language"
         android:summary="@string/prefs_language_summary"
         android:title="@string/prefs_language" />
 
     <Preference
-        android:title="@string/contact"
         android:key="@string/contact_key"
-        android:summary="@string/contact_summary"/>
+        android:summary="@string/contact_summary"
+        android:title="@string/contact" />
 
 </PreferenceScreen>


### PR DESCRIPTION
## Description

- Added the option to disable uploading on mobile networks
- User will be sent to offline product edit when scanning
- User will be informed of this when uploading offline products
- Added more network check settings in Utils
- Temporarily removed drawable from "upload all" button as this as causing crashes

Bonus: Added string resource for change language preference

Phrasing may need to be altered on some of this

## Related issues and discussion
#332 & #972 
 
 ## Screen-shots, if any

![screenshot_20180227-134717](https://user-images.githubusercontent.com/5596450/36732625-2c2ae070-1bc6-11e8-81ce-7943c0d3a367.jpg)
![screenshot_20180227-135559](https://user-images.githubusercontent.com/5596450/36732627-2e3a5f08-1bc6-11e8-9c16-4959a618ef07.jpg)
![screenshot_20180227-135553](https://user-images.githubusercontent.com/5596450/36732629-2f9005ba-1bc6-11e8-9f9e-f9855c82f319.jpg)

 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
