### PR TITLE
Fixed #962: Wrong title when moving from a fragment to MainActivity

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AlertUserFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AlertUserFragment.java
@@ -169,19 +169,11 @@ public class AlertUserFragment extends BaseFragment {
 
         super.onResume();
 
-        AppCompatActivity activity = (AppCompatActivity)getActivity();
-
-        ActionBar actionBar;
-
-        if(activity!=null){
-            actionBar =activity.getSupportActionBar();
-
-            if(actionBar!=null){
-                actionBar.setTitle(getString(R.string
-                        .alert_drawer));
-            }
+        try {
+            ((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(getString(R.string.alert_drawer));
+        } catch (NullPointerException e) {
+            e.printStackTrace();
         }
-
 
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AlertUserFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AlertUserFragment.java
@@ -6,6 +6,8 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -161,6 +163,26 @@ public class AlertUserFragment extends BaseFragment {
             }
         }
         return key;
+    }
+
+    public void onResume() {
+
+        super.onResume();
+
+        AppCompatActivity activity = (AppCompatActivity)getActivity();
+
+        ActionBar actionBar;
+
+        if(activity!=null){
+            actionBar =activity.getSupportActionBar();
+
+            if(actionBar!=null){
+                actionBar.setTitle(getString(R.string
+                        .alert_drawer));
+            }
+        }
+
+
     }
 
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/FindProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/FindProductFragment.java
@@ -3,6 +3,8 @@ package openfoodfacts.github.scrachx.openfood.fragments;
 
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -48,5 +50,25 @@ public class FindProductFragment extends BaseFragment {
                 Toast.makeText(getActivity(), getResources().getString(R.string.txtBarcodeNotValid), Toast.LENGTH_LONG).show();
             }
         }
+    }
+
+    public void onResume() {
+
+        super.onResume();
+
+        AppCompatActivity activity = (AppCompatActivity)getActivity();
+
+        ActionBar actionBar;
+
+        if(activity!=null){
+            actionBar =activity.getSupportActionBar();
+
+            if(actionBar!=null){
+                actionBar.setTitle(getString(R.string
+                        .search_by_barcode_drawer));
+            }
+        }
+
+
     }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/FindProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/FindProductFragment.java
@@ -56,19 +56,11 @@ public class FindProductFragment extends BaseFragment {
 
         super.onResume();
 
-        AppCompatActivity activity = (AppCompatActivity)getActivity();
-
-        ActionBar actionBar;
-
-        if(activity!=null){
-            actionBar =activity.getSupportActionBar();
-
-            if(actionBar!=null){
-                actionBar.setTitle(getString(R.string
-                        .search_by_barcode_drawer));
-            }
+        try {
+            ((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(getString(R.string.search_by_barcode_drawer));
+        } catch (NullPointerException e) {
+            e.printStackTrace();
         }
-
 
     }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
@@ -9,6 +9,8 @@ import android.support.annotation.Nullable;
 import android.support.design.widget.FloatingActionButton;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -109,5 +111,25 @@ public class HomeFragment extends BaseFragment {
                 }
             });
         }
+    }
+
+
+    public void onResume() {
+
+        super.onResume();
+
+        AppCompatActivity activity = (AppCompatActivity)getActivity();
+
+        ActionBar actionBar;
+
+        if(activity!=null){
+            actionBar =activity.getSupportActionBar();
+
+            if(actionBar!=null){
+                actionBar.setTitle(getString(R.string.home_drawer));
+            }
+        }
+
+
     }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
@@ -71,7 +71,7 @@ public class HomeFragment extends BaseFragment {
                 startActivity(intent);
             }
         } else {
-            ((MainActivity)getContext()).moveToBarcodeEntry();
+            ((MainActivity) getContext()).moveToBarcodeEntry();
         }
     }
 
@@ -118,18 +118,11 @@ public class HomeFragment extends BaseFragment {
 
         super.onResume();
 
-        AppCompatActivity activity = (AppCompatActivity)getActivity();
-
-        ActionBar actionBar;
-
-        if(activity!=null){
-            actionBar =activity.getSupportActionBar();
-
-            if(actionBar!=null){
-                actionBar.setTitle(getString(R.string.home_drawer));
-            }
+        try {
+            ((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(getString(R.string.home_drawer));
+        } catch (NullPointerException e) {
+            e.printStackTrace();
         }
-
 
     }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/OfflineEditFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/OfflineEditFragment.java
@@ -218,17 +218,10 @@ public class OfflineEditFragment extends BaseFragment {
         super.onResume();
         new FillAdapter().execute(getActivity());
 
-        AppCompatActivity activity = (AppCompatActivity)getActivity();
-
-        ActionBar actionBar;
-
-        if(activity!=null){
-            actionBar =activity.getSupportActionBar();
-
-            if(actionBar!=null){
-                actionBar.setTitle(getString(R.string
-                        .offline_edit_drawer));
-            }
+        try {
+            ((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(getString(R.string.offline_edit_drawer));
+        } catch (NullPointerException e) {
+            e.printStackTrace();
         }
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/OfflineEditFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/OfflineEditFragment.java
@@ -11,6 +11,8 @@ import android.os.Bundle;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
 import android.support.annotation.Nullable;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -215,6 +217,19 @@ public class OfflineEditFragment extends BaseFragment {
     public void onResume() {
         super.onResume();
         new FillAdapter().execute(getActivity());
+
+        AppCompatActivity activity = (AppCompatActivity)getActivity();
+
+        ActionBar actionBar;
+
+        if(activity!=null){
+            actionBar =activity.getSupportActionBar();
+
+            if(actionBar!=null){
+                actionBar.setTitle(getString(R.string
+                        .offline_edit_drawer));
+            }
+        }
     }
 
     public class FillAdapter extends AsyncTask<Context, Void, Context> {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
@@ -12,10 +12,13 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.preference.ListPreference;
 import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 import android.util.Log;
+import android.view.View;
 import android.widget.Toast;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -149,5 +152,25 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
             lt.hide();
             getActivity().recreate();
         }
+    }
+
+
+    public void onResume() {
+
+        super.onResume();
+
+        AppCompatActivity activity = (AppCompatActivity)getActivity();
+
+        ActionBar actionBar;
+
+        if(activity!=null){
+            actionBar =activity.getSupportActionBar();
+
+            if(actionBar!=null){
+                actionBar.setTitle(getString(R.string.action_preferences));
+            }
+        }
+
+
     }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
@@ -159,18 +159,11 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
 
         super.onResume();
 
-        AppCompatActivity activity = (AppCompatActivity)getActivity();
-
-        ActionBar actionBar;
-
-        if(activity!=null){
-            actionBar =activity.getSupportActionBar();
-
-            if(actionBar!=null){
-                actionBar.setTitle(getString(R.string.action_preferences));
-            }
+        try {
+            ((AppCompatActivity) getActivity()).getSupportActionBar().setTitle(getString(R.string.action_preferences));
+        } catch (NullPointerException e) {
+            e.printStackTrace();
         }
-
 
     }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -18,6 +18,7 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.view.MenuItemCompat;
+import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.SearchView;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
@@ -205,13 +206,9 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
                     switch ((int) drawerItem.getIdentifier()) {
                         case 1:
                             fragment = new HomeFragment();
-                            getSupportActionBar().setTitle(getResources().getString(R.string
-                                    .home_drawer));
                             break;
                         case 2:
                             fragment = new FindProductFragment();
-                            getSupportActionBar().setTitle(getResources().getString(R.string
-                                    .search_by_barcode_drawer));
                             break;
                         case 3:
                             startActivity(CategoryActivity.getIntent(this));
@@ -228,16 +225,13 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
                             break;
                         case 7:
                             fragment = new AlertUserFragment();
-                            getSupportActionBar().setTitle(R.string.alert_drawer);
                             break;
                         case 8:
                             fragment = new PreferencesFragment();
-                            getSupportActionBar().setTitle(R.string.action_preferences);
                             break;
                         case 9:
                             fragment = new OfflineEditFragment();
-                            getSupportActionBar().setTitle(getResources().getString(R.string
-                                    .offline_edit_drawer));
+
                             break;
                         case ABOUT:
                             CustomTabActivityHelper.openCustomTab(MainActivity.this,


### PR DESCRIPTION
## Description

When going back from Fragment to MainActivity , the title of the SupportActionBar now changes

## Related issues and discussion
#962 
 
 ## Screen-shots, if any
 
![title1](https://user-images.githubusercontent.com/30733262/36739223-6f6cd46c-1c05-11e8-87a9-1f86688e1897.png)

The title now changes 

![title2](https://user-images.githubusercontent.com/30733262/36739224-706fd9fe-1c05-11e8-9df3-99a97247ab16.png)