### PR TITLE
Fixed #990 : Open FAQ in Chrome Custom Tab

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
@@ -108,9 +108,10 @@ public class PreferencesFragment extends PreferenceFragmentCompat {
         faqbutton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
-                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("https://world.openfoodfacts.org/faq"));
-                startActivity(browserIntent);
-                return false;
+
+                CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
+                CustomTabActivityHelper.openCustomTab(getActivity(),customTabsIntent,Uri.parse(getString(R.string.faq_url)),new WebViewFallback());
+                return true;
             }
         });
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -408,5 +408,6 @@
     <string name="translate_url" translatable="false">https://crowdin.com/project/openfoodfacts</string>
     <string name="translate_help_title">Help translate Open Food Facts</string>
     <string name="translate_help_summary">Bring the Open Food Facts database to your language - no technical knowledge required</string>
+    <string name="faq_url" translatable="false">https://world.openfoodfacts.org/faq</string>
 
 </resources>


### PR DESCRIPTION
## Description

1. The FAQ is now opened in a chrome custom tab. 
2. The FAQ Url is extracted as a string resource .
3. The FAQ Url is made non-translatable

## Related issues and discussion
#990 
 
 ## Screen-shots, if any
 
![chrome](https://user-images.githubusercontent.com/30733262/36795775-e349df6e-1cc9-11e8-9cb5-d68ccc32c03a.png)
