### PR TITLE
Message shown on empty Username.

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoginActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoginActivity.java
@@ -95,17 +95,18 @@ public class LoginActivity extends BaseActivity implements CustomTabActivityHelp
         String login = loginView.getText().toString();
         String password = passwordView.getText().toString();
 
+        if (TextUtils.isEmpty(login)) {
+            loginView.setError(getString(R.string.error_field_required));
+            loginView.requestFocus();
+            return;
+        }
+
         if (!(password.length() >= 6)) {
             passwordView.setError(getString(R.string.error_invalid_password));
             passwordView.requestFocus();
             return;
         }
 
-        if (TextUtils.isEmpty(login)) {
-            loginView.setError(getString(R.string.error_field_required));
-            loginView.requestFocus();
-            return;
-        }
 
         final LoadToast lt = new LoadToast(this);
         save.setClickable(false);


### PR DESCRIPTION
## Description
Message will be shown First for Username when user will try to sign in without filling data for Username and Password. Previously when username and Password field were empty and user tries to sign in error message was for the password field ,not for the Username field.
 
 ## Screen-shots
<h4>Previously</h4>

![whatsapp image 2018-03-01 at 7 21 48 pm 1](https://user-images.githubusercontent.com/22103919/36848091-35af00ba-1d86-11e8-83a6-623bd574dcc4.jpeg)

<h4>Expected</h4>

![whatsapp image 2018-03-01 at 7 21 48 pm](https://user-images.githubusercontent.com/22103919/36848203-8fd65b74-1d86-11e8-83e9-169530094c9b.jpeg)