### PR TITLE
Fix add photo not clickable in no results screen

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SearchProductsResultsFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SearchProductsResultsFragment.java
@@ -162,6 +162,7 @@ public class SearchProductsResultsFragment extends BaseFragment {
                                 countProductsView.setVisibility(View.INVISIBLE);
                                 offlineCloudLayout.setVisibility(View.INVISIBLE);
                                 noResultsLayout.setVisibility(View.VISIBLE);
+                                noResultsLayout.bringToFront();
                             } else {
                                 countProductsView.setVisibility(View.INVISIBLE);
                                 noResultsLayout.setVisibility(View.INVISIBLE);


### PR DESCRIPTION
## Description

Add photo is now clickable in the "no results" screen.

## Related issues and discussion
Fix #1070 
 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines . 
