### PR TITLE
added break statements

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/DatabaseHelper.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/DatabaseHelper.java
@@ -37,7 +37,7 @@ public class DatabaseHelper extends DaoMaster.OpenHelper {
      * left untouched just fix the code in the version case and push a new
      * release
      *
-     * @param db database
+     * @param db             database
      * @param migrateVersion
      */
     private void upgrade(Database db, int migrateVersion) {
@@ -47,11 +47,14 @@ public class DatabaseHelper extends DaoMaster.OpenHelper {
                 break;
             case 3:
                 ToUploadProductDao.createTable(db, true);
+                break;
             case 4:
                 TagDao.createTable(db, true);
+                break;
             case 5: {
                 db.execSQL("ALTER TABLE history_product ADD COLUMN 'quantity' TEXT NOT NULL DEFAULT '';");
                 db.execSQL("ALTER TABLE history_product ADD COLUMN 'nutrition_grade' TEXT NOT NULL DEFAULT '';");
+                break;
             }
         }
     }


### PR DESCRIPTION
## Description
There were no `break;` statements after each schema change upgrade, so in our case when someone upgrades app from schema 3 to 5 the last `case :` runs two times and tries to create column two times and so the exception.
## Related issues and discussion
closes #1066 

 
 ## Checklist
 
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
