### PR TITLE
Fixed #1104 : Make categories clickable on Product Page

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SummaryProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SummaryProductFragment.java
@@ -251,11 +251,18 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
             ingredientsOrigin.append(' ' + product.getOrigins());
         }
 
-        String categ;
         if (isNotBlank(product.getCategories())) {
-            categ = product.getCategories().replace(",", ", ");
+
+            categoryProduct.setClickable(true);
+            categoryProduct.setMovementMethod(LinkMovementMethod.getInstance());
             categoryProduct.setText(bold(getString(R.string.txtCategories)));
-            categoryProduct.append(' ' + categ);
+            String[] categories = product.getCategories().split(",");
+            for (String category : categories) {
+
+                categoryProduct.append(getCategoriesTag(category));
+
+            }
+
         } else {
             categoryProduct.setVisibility(View.GONE);
         }
@@ -425,6 +432,28 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         spannableStringBuilder.setSpan(clickableSpan, 0, spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
         spannableStringBuilder.append(" ");
         return spannableStringBuilder;
+    }
+
+
+    private CharSequence getCategoriesTag(String category) {
+
+        SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
+        ClickableSpan clickableSpan = new ClickableSpan() {
+            @Override
+            public void onClick(View view) {
+
+                CustomTabsIntent customTabsIntent = CustomTabsHelper.getCustomTabsIntent(getContext(),customTabActivityHelper.getSession());
+                CustomTabActivityHelper.openCustomTab(getActivity(), customTabsIntent, Uri.parse("https://world.openfoodfacts.org/category/" + category), new WebViewFallback());
+
+            }
+        };
+
+        spannableStringBuilder.append(category);
+        spannableStringBuilder.setSpan(clickableSpan, 0, spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
+        spannableStringBuilder.append(" ");
+        return spannableStringBuilder;
+
+
     }
 
     @OnClick(R.id.product_incomplete_message_dismiss_icon)


### PR DESCRIPTION
## Description

The categories are now clickable on product page . They open on a chrome custom tab.

## Related issues and discussion
#1104 
 
 ## Screen-shots, if any
 
 
![categories](https://user-images.githubusercontent.com/30733262/36945621-3f9b1066-1fd7-11e8-8d75-36d70d0d9de1.png)
![catweb](https://user-images.githubusercontent.com/30733262/36945626-45c3872a-1fd7-11e8-84f9-7061d907fda3.png)

