### PR TITLE
Fixed #1107 : Make labels clickable on product page

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SummaryProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SummaryProductFragment.java
@@ -263,17 +263,19 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         String labels = product.getLabels();
         if (isNotBlank(labels)) {
             labelProduct.append(bold(getString(R.string.txtLabels)));
+            labelProduct.setClickable(true);
+            labelProduct.setMovementMethod(LinkMovementMethod.getInstance());
             labelProduct.append(" ");
             String[] label = labels.split(",");
             int labelCount = label.length;
             if (labelCount > 1) {
                 for (int i = 0; i < (labelCount - 1); i++) {
-                    labelProduct.append(label[i].trim());
+                    labelProduct.append(getLabelTag(label[i].trim()));
                     labelProduct.append(", ");
                 }
-                labelProduct.append(label[labelCount - 1].trim());
+                labelProduct.append(getLabelTag(label[labelCount - 1].trim()));
             } else {
-                labelProduct.append(label[0].trim());
+                labelProduct.append(getLabelTag(label[0].trim()));
             }
         } else {
             labelProduct.setVisibility(View.GONE);
@@ -425,6 +427,29 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         spannableStringBuilder.setSpan(clickableSpan, 0, spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
         spannableStringBuilder.append(" ");
         return spannableStringBuilder;
+    }
+
+    private CharSequence getLabelTag(String label) {
+
+        SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
+
+        ClickableSpan clickableSpan = new ClickableSpan() {
+            @Override
+            public void onClick(View view) {
+
+                CustomTabsIntent customTabsIntent = CustomTabsHelper.getCustomTabsIntent(getContext(), customTabActivityHelper.getSession());
+                CustomTabActivityHelper.openCustomTab(getActivity(), customTabsIntent, Uri.parse("https://world.openfoodfacts.org/label/" + label), new WebViewFallback());
+
+            }
+
+        };
+
+        spannableStringBuilder.append(label);
+        spannableStringBuilder.setSpan(clickableSpan, 0, spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
+        spannableStringBuilder.append(" ");
+        return spannableStringBuilder;
+
+
     }
 
     @OnClick(R.id.product_incomplete_message_dismiss_icon)


### PR DESCRIPTION
## Description

The labels are now clickable and open in a chrome custom tab.

## Related issues and discussion
#1107 
 
 ## Screen-shots, if any
 
![label](https://user-images.githubusercontent.com/30733262/36946111-ba7a0cdc-1fdd-11e8-8392-8eb6f5f27855.png)
![labelweb](https://user-images.githubusercontent.com/30733262/36946113-c0410012-1fdd-11e8-8283-49dd0f504c67.png)
