### PR TITLE
Fix "Help translate OFF" displayed twice in Preferences

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -62,20 +62,12 @@
         <Preference
             android:key="FAQ"
             android:summary="@string/FrequentlyAskedQuestions"
-                    android:title="@string/FAQ"/>
+            android:title="@string/FAQ" />
 
-            
-           <Preference android:title="@string/translate_help_title"
-        android:key="@string/lang_translate"
-        android:summary="@string/translate_help_summary"/>
-    <Preference
-
-        android:title="@string/Terms"
-        android:summary="@string/TermsOfUse"
-        android:key="@string/Terms"/>
-
-          
-
+        <Preference
+            android:key="@string/Terms"
+            android:summary="@string/TermsOfUse"
+            android:title="@string/Terms" />
 
     </PreferenceCategory>
 </PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -65,7 +65,7 @@
             android:title="@string/FAQ" />
 
         <Preference
-            android:key="@string/Terms"
+            android:key="Terms"
             android:summary="@string/TermsOfUse"
             android:title="@string/Terms" />
 


### PR DESCRIPTION
## Description
"Help translate Open Food Facts" option is displayed only under the 'Contributing' category. Reformatted the code.

## Related issues and discussion
Fixes #1121 
 
 ## Screen-shots, if any
![screenshot_20180305-163646](https://user-images.githubusercontent.com/10832531/36972075-d80d8f24-2093-11e8-9c2e-7f41e574e326.png)

 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
