### PR TITLE
Fixed #1157 : OPFF menu entry to OFF wrong behavior 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,7 +41,7 @@ android {
             applicationId "org.openpetfoodfacts.scanner"
             resValue "string", "app_name", "Open Pet Food Facts"
             buildConfigField 'String', 'HOST', '"https://ssl-api.openpetfoodfacts.org"'
-            buildConfigField 'String', 'OFOTHERLINKAPP', '"org.openfoodfacts.scanner"'
+            buildConfigField 'String', 'OFOTHERLINKAPP', '"openfoodfacts.github.scrachx.openfood"'
             buildConfigField 'String', 'OFWEBSITE', '"https://world.openpetfoodfacts.org/"'
         }
     }


### PR DESCRIPTION
## Description

The OPFF menu now behaves correctly and opens OFF app if installed and opens the correct link in playstore if OFF app is not installed 

## Related issues and discussion
#1157 
 
 ## Screen-shots, if any

### If OFF is already installed
![off](https://user-images.githubusercontent.com/30733262/37127469-ea6229d2-229b-11e8-87b1-b22269394f12.png)

### If OFF is not already installed
Before the opened link was 
![opff](https://user-images.githubusercontent.com/30733262/37127483-032c58c0-229c-11e8-9bc9-eb16eb8ffbf0.png)
Now the opened link is 
![off_p](https://user-images.githubusercontent.com/30733262/37127495-0db06778-229c-11e8-8f54-d6d20ba91392.png)

