### PR TITLE
Fixed #1166: Remove language codes in country switcher

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
@@ -75,11 +75,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements INa
             Locale current = LocaleHelper.getLocale(localeValues[i]);
 
             if (current != null) {
-                localeLabels[i] = String.format("%s - %s",
-                        // current.getDisplayName(current), // native form
-                        WordUtils.capitalize(current.getDisplayName(current)),
-                        localeValues[i].toUpperCase(Locale.getDefault())
-                );
+                localeLabels[i] = WordUtils.capitalize(current.getDisplayName(current));
             }
         }
 


### PR DESCRIPTION
Due to lack of progress I've resolved this issue #1166.
I removed language codes from country switcher on Preferences screen