### PR TITLE
Fixed #1201: app crash if a product link doesn't have an "HTTP" part to it

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SummaryProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SummaryProductFragment.java
@@ -134,6 +134,7 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
     private TagDao mTagDao;
     private SummaryProductFragment mFragment;
     private IProductRepository productRepository;
+    private Uri manufactureUri;
 
     @Override
     public void onAttach(Context context) {
@@ -356,7 +357,9 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
             storeProduct.setVisibility(View.GONE);
         }
         if (isNotBlank(product.getManufactureUrl())) {
-            Uri manufactureUri = Uri.parse(product.getManufactureUrl());
+            manufactureUri = Uri.parse(product.getManufactureUrl());
+            if (manufactureUri.getScheme() == null)
+                manufactureUri = Uri.parse("http://" + product.getManufactureUrl());
             customTabActivityHelper.mayLaunchUrl(manufactureUri, null, null);
 
             String manufactureUrlTitle = getString(R.string.txtManufactureUrl);


### PR DESCRIPTION
## Description
If there was no "HTTP" part to a URL then the app crashed with an error "No Activity found to handle Intent". The crash happens when scheme component of the [URI](https://developer.android.com/reference/java/net/URI.html) is missing. Therefore I checked for the scheme component rather than just checking if the URL starts with "HTTP". If the scheme is null then we can safely add an "HTTP" part to it.

## Related issues and discussion
Fixes #1201 
 
 ## Screen-shots, if any
![videotogif_2018 03 12_00 34 28](https://user-images.githubusercontent.com/10832531/37257367-73183a74-258e-11e8-97c4-853da8230951.gif)
 

 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines.
