### PR TITLE
Fixes #1203: Inconsistent spaces (minute vs hour)

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <plurals name="minutes">
-        <item quantity="one"> minute </item>
+        <item quantity="one"> minute</item>
         <item quantity="other"> minutes</item>
     </plurals>
     <plurals name="hours">


### PR DESCRIPTION
## Description

Fixed a typo in "minutes" line to make it consistent with hours and days.

## Related issues and discussion
#1203 
