### PR TITLE
Fixed #864 : Remove "no data" Toast from Offline edit fragment

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/OfflineEditFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/OfflineEditFragment.java
@@ -24,6 +24,8 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -63,6 +65,10 @@ public class OfflineEditFragment extends NavigationBaseFragment implements SaveL
     private String loginS, passS;
     private SendProductDao mSendProductDao;
     private int size;
+    @BindView(R.id.noDataImg)
+    ImageView noDataImage;
+    @BindView(R.id.noDataText)
+    TextView noDataText;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -156,6 +162,9 @@ public class OfflineEditFragment extends NavigationBaseFragment implements SaveL
                     .onNegative((dialog, which) -> uploadProducts())
                     .show();
         }
+        SharedPreferences.Editor editor = getContext().getSharedPreferences("usage", 0).edit();
+        editor.putBoolean("firstUpload", true);
+        editor.apply();
     }
 
     @Override
@@ -267,11 +276,32 @@ public class OfflineEditFragment extends NavigationBaseFragment implements SaveL
         protected void onPreExecute() {
             saveItems.clear();
             List<SendProduct> listSaveProduct = mSendProductDao.loadAll();
+            SharedPreferences settingsUsage = getContext().getSharedPreferences("usage", 0);
+            boolean firstUpload = settingsUsage.getBoolean("firstUpload", false);
+            boolean msgdismissed= settingsUsage.getBoolean("is_offline_msg_dismissed",false);
             if (listSaveProduct.size() == 0) {
-                Toast toast = Toast.makeText(getActivity(), R.string.txtNoData, Toast.LENGTH_LONG);
-                toast.setGravity(Gravity.CENTER, 0, 0);
-                toast.show();
+                if(msgdismissed) {
+
+                    noDataImage.setVisibility(View.VISIBLE);
+                    mRecyclerView.setVisibility(View.GONE);
+                    noDataText.setVisibility(View.VISIBLE);
+                    noDataText.setText(R.string.no_offline_data);
+                    buttonSend.setVisibility(View.GONE);
+                    if (!firstUpload) {
+                        noDataImage.setImageResource(R.drawable.ic_cloud_upload);
+                        noDataText.setText(R.string.first_offline);
+                    }
+                }
+                else{
+                    noDataImage.setVisibility(View.INVISIBLE);
+                    noDataText.setVisibility(View.INVISIBLE);
+                }
             } else {
+
+                noDataImage.setVisibility(View.GONE);
+                mRecyclerView.setVisibility(View.VISIBLE);
+                noDataText.setVisibility(View.GONE);
+                buttonSend.setVisibility(View.VISIBLE);
                 mCardView.setVisibility(View.GONE);
                 Toast toast = Toast.makeText(getActivity(), R.string.txtLoading, Toast.LENGTH_LONG);
                 toast.setGravity(Gravity.CENTER, 0, 0);

--- a/app/src/main/res/drawable/ic_cloud_done.xml
+++ b/app/src/main/res/drawable/ic_cloud_done.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM10,17l-3.5,-3.5 1.41,-1.41L10,14.17 15.18,9l1.41,1.41L10,17z"
+        android:fillColor="#9E9E9E"/>
+</vector>

--- a/app/src/main/res/drawable/ic_cloud_upload.xml
+++ b/app/src/main/res/drawable/ic_cloud_upload.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM14,13v4h-4v-4H7l5,-5 5,5h-3z"
+        android:fillColor="#9E9E9E"/>
+</vector>

--- a/app/src/main/res/layout/fragment_offline_edit.xml
+++ b/app/src/main/res/layout/fragment_offline_edit.xml
@@ -62,6 +62,36 @@
         </RelativeLayout>
     </android.support.v7.widget.CardView>
 
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/noDataImg"
+            android:layout_width="@dimen/img_width_height"
+            android:layout_height="@dimen/img_width_height"
+            android:layout_margin="@dimen/padding_normal"
+            android:paddingTop="@dimen/padding_large"
+            android:layout_centerHorizontal="true"
+            android:visibility="visible"
+            app:srcCompat="@drawable/ic_cloud_done" />
+
+        <TextView
+            android:id="@+id/noDataText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/noDataImg"
+            android:layout_centerHorizontal="true"
+            android:gravity="center"
+            android:layout_margin="@dimen/padding_normal"
+            android:text="@string/no_offline_data"
+            android:textColor="@color/grey_500"
+            android:textSize="35sp"
+            android:visibility="visible" />
+
+    </RelativeLayout>
+
     <LinearLayout
         android:id="@+id/linearLayout2"
         android:layout_width="0dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,7 +20,8 @@
     <string name="text_barcode">Type the barcode :</string>
     <string name="message_in_activity_save_product_offline">Only one photo is compulsory to send a new product.</string>
     <string name="product_incomplete_message">This product is not complete. As a result, we couldn\'t do the allergen check.</string>
-
+    <string name="no_offline_data">You\'re all done</string>
+    <string name="first_offline">Products added offline will appear here</string>
 
     <!-- Image Upload -->
     <string-array name="upload_image" translatable="false">


### PR DESCRIPTION
## Description

- Added an ImageView and a TextView in the OfflineEditFragment layout
- Added Code to toggle the visibility of the elements in the layout based whether the no. of offline products are "zero" or not

- Added code for "first offline fragment" that changes the text and image in the layout based on "firstUpload" boolean value stored in the shared prefference "usage"

## Related issues and discussion
#864 Rmoved "no data" Toast from offline fragment
 
 ## Screen-shots, if any
![firstoffline](https://user-images.githubusercontent.com/22811731/37558159-bb2e3dd0-2a35-11e8-877f-e9c36edafae6.jpeg)
![alldone](https://user-images.githubusercontent.com/22811731/37558160-bb6a5e5a-2a35-11e8-8e34-b8a261081e02.jpeg)
