### PR TITLE
Fix App Crash in MainActivity.java

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -12,6 +12,7 @@ import android.graphics.Color;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.provider.Settings;
 import android.support.annotation.NonNull;
 import android.support.customtabs.CustomTabsIntent;
 import android.support.v4.app.ActivityCompat;
@@ -261,6 +262,11 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
                                     startActivity(LaunchIntent);
                                 }else{
                                     Toast.makeText(this, R.string.app_disabled_text, Toast.LENGTH_SHORT).show();
+                                    Intent intent = new Intent();
+                                    intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                                    Uri uri = Uri.fromParts("package", BuildConfig.OFOTHERLINKAPP, null);
+                                    intent.setData(uri);
+                                    startActivity(intent);
                                 }
                             } else {
                                 try {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -257,7 +257,11 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
                             if (otherOFAppInstalled) {
                                 Intent LaunchIntent = getPackageManager()
                                         .getLaunchIntentForPackage(BuildConfig.OFOTHERLINKAPP);
-                                startActivity(LaunchIntent);
+                                if (LaunchIntent != null) {
+                                    startActivity(LaunchIntent);
+                                }else{
+                                    Toast.makeText(this, "App Disabled", Toast.LENGTH_SHORT).show();
+                                }
                             } else {
                                 try {
                                     startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse
@@ -303,7 +307,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
                     }
 
                     if (fragment != null) {
-                             getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container, fragment).addToBackStack(null).commit();
+                        getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container, fragment).addToBackStack(null).commit();
                     } else {
                         // error in creating fragment
                         Log.e("MainActivity", "Error in creating fragment");
@@ -493,8 +497,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         } else {
             if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
                 getSupportFragmentManager().popBackStack(getSupportFragmentManager().getBackStackEntryAt(0).getId(), getSupportFragmentManager().POP_BACK_STACK_INCLUSIVE);
-            }
-            else {
+            } else {
                 super.onBackPressed();
             }
         }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -260,7 +260,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
                                 if (LaunchIntent != null) {
                                     startActivity(LaunchIntent);
                                 }else{
-                                    Toast.makeText(this, "App Disabled", Toast.LENGTH_SHORT).show();
+                                    Toast.makeText(this, R.string.app_disabled_text, Toast.LENGTH_SHORT).show();
                                 }
                             } else {
                                 try {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -486,6 +486,6 @@
     <string name="category_string">Category</string>
     <string name="connection">Connected</string>
     <string name="contributor_string">Contributor</string>
-    <string name="app_disabled_text">Application Is Not Installed</string>
+    <string name="app_disabled_text">Application Is Disabled</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -486,5 +486,6 @@
     <string name="category_string">Category</string>
     <string name="connection">Connected</string>
     <string name="contributor_string">Contributor</string>
+    <string name="app_disabled_text">Application Is Not Installed</string>
 
 </resources>


### PR DESCRIPTION
## Description

I put a null checking condition when firing an Intent in MainActivity.class to open the OpenFoodFacts app via The OpenBeautyApp.
Because If the OpenFoodFacts app is installed but disabled and the normal intent is fired, it crashes the app.

Describe the changes made and why they were made instead of how they were made.

## Related issues and discussion
#1285
 
 ## Screen-shots, if any
 
![screenshot_2018-03-19-13-27-03](https://user-images.githubusercontent.com/22130093/37612600-0a3f84dc-2b7c-11e8-96b2-e364fcea6ffd.png)

