### PR TITLE
Fixed #1268: Resolved invaild item error and implemented swipe refresh properly

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
@@ -179,12 +179,12 @@ public class ProductBrowsingListActivity extends BaseActivity {
         apiClient = new OpenFoodAPIClient(ProductBrowsingListActivity.this, BuildConfig.OFWEBSITE);
         api = new OpenFoodAPIClient(ProductBrowsingListActivity.this);
         productsRecyclerView = (RecyclerView) findViewById(R.id.products_recycler_view);
+        progressBar.setVisibility(View.VISIBLE);
         setup();
     }
 
     @OnClick(R.id.buttonTryAgain)
     public void setup() {
-        progressBar.setVisibility(View.VISIBLE);
         offlineCloudLayout.setVisibility(View.INVISIBLE);
         countProductsView.setVisibility(View.INVISIBLE);
         getDataFromAPI();
@@ -310,6 +310,7 @@ public class ProductBrowsingListActivity extends BaseActivity {
                 }
             }
         } else {
+            swipeRefreshLayout.setRefreshing(false);
             productsRecyclerView.setVisibility(View.INVISIBLE);
             progressBar.setVisibility(View.INVISIBLE);
             offlineCloudLayout.setVisibility(View.VISIBLE);
@@ -321,6 +322,7 @@ public class ProductBrowsingListActivity extends BaseActivity {
     private void setUpRecyclerView() {
 
         progressBar.setVisibility(View.INVISIBLE);
+        swipeRefreshLayout.setRefreshing(false);
         countProductsView.setVisibility(View.VISIBLE);
 
         offlineCloudLayout.setVisibility(View.INVISIBLE);
@@ -333,7 +335,6 @@ public class ProductBrowsingListActivity extends BaseActivity {
         ProductsRecyclerViewAdapter adapter = new ProductsRecyclerViewAdapter(mProducts);
         productsRecyclerView.setAdapter(adapter);
 
-
         DividerItemDecoration dividerItemDecoration = new DividerItemDecoration(productsRecyclerView.getContext(),
                 DividerItemDecoration.VERTICAL);
         productsRecyclerView.addItemDecoration(dividerItemDecoration);
@@ -342,7 +343,7 @@ public class ProductBrowsingListActivity extends BaseActivity {
         scrollListener = new EndlessRecyclerViewScrollListener(mLayoutManager) {
             @Override
             public void onLoadMore(int page, int totalItemsCount, RecyclerView view) {
-                if (mProducts.size() < mCountProducts) {
+                if (mProducts.size() < mCountProducts && !swipeRefreshLayout.isRefreshing()) {
                     pageAddress = page;
                     getDataFromAPI();
                 }
@@ -377,14 +378,10 @@ public class ProductBrowsingListActivity extends BaseActivity {
         swipeRefreshLayout.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
             @Override
             public void onRefresh() {
-
-                mProducts.clear();
+                swipeRefreshLayout.setRefreshing(true);
                 countProductsView.setText(getResources().getString(R.string.number_of_results));
                 pageAddress = 1;
                 setup();
-                if (swipeRefreshLayout.isRefreshing()) {
-                    swipeRefreshLayout.setRefreshing(false);
-                }
             }
         });
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
@@ -129,6 +129,7 @@ public class ProductBrowsingListActivity extends BaseActivity {
 
         searchType = extras.getString(SEARCH_TYPE);
         key = extras.getString(KEY);
+        
         newSearchQuery();
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
@@ -129,7 +129,6 @@ public class ProductBrowsingListActivity extends BaseActivity {
 
         searchType = extras.getString(SEARCH_TYPE);
         key = extras.getString(KEY);
-        
         newSearchQuery();
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
@@ -129,7 +129,6 @@ public class ProductBrowsingListActivity extends BaseActivity {
 
         searchType = extras.getString(SEARCH_TYPE);
         key = extras.getString(KEY);
-
         newSearchQuery();
     }
 


### PR DESCRIPTION
## Description

When the list was refreshed the `list<products>` were cleared so when user swipes app tries to access the next element from an empty products list that's why the error, there was no need for the `products.clear()` statement as the products was assigned a empty product list ,so I removed it. The swipe refresh was not implemented properly I also corrected it by using  ` swipeRefreshLayout.setRefreshing(false);`  after data loads from API which is not done currently. 

## Related issues and discussion
closes #1268 
 
 ## Screen-shots

Initial
![swiperefresh-faulty](https://user-images.githubusercontent.com/22943390/37622498-ccced456-2be7-11e8-9ce7-23474a74ef30.gif)

After changes

![swiperefresh](https://user-images.githubusercontent.com/22943390/37622503-d4332e36-2be7-11e8-9895-13e928b0a86b.gif)


 
