### PR TITLE
Closes #1309 : Product Image gets stretched in full-screen after transition

### DIFF
--- a/app/src/main/res/layout/activity_full_screen_image.xml
+++ b/app/src/main/res/layout/activity_full_screen_image.xml
@@ -9,8 +9,9 @@
         android:id="@+id/imageViewFullScreen"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:adjustViewBounds="true"
         android:gravity="center"
-        android:scaleType="fitXY"
+        android:scaleType="fitCenter"
         android:transitionName="@string/product_transition" />
 
 </LinearLayout>


### PR DESCRIPTION
## Description
Fixed stretching of the product image in full-screen view. The image now maintains its original aspect ratio.

## Related issues and discussion
Fixes #1309 
 
 ## Screen-shots, if any
![videotogif_2018 03 21_23 43 03](https://user-images.githubusercontent.com/10832531/37729302-a3810e9e-2d62-11e8-8236-e143d050883c.gif)

 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines.
