### PR TITLE
 Fixes #1300 some words weren't shown on the intro slides

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/WelcomeActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/WelcomeActivity.java
@@ -30,6 +30,7 @@ public class WelcomeActivity extends AppCompatActivity {
     private int[] layouts;
     private Button btnSkip, btnNext;
     private PrefManager prefManager;
+    private boolean lastPage = false;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -129,6 +130,7 @@ public class WelcomeActivity extends AppCompatActivity {
             if (position == layouts.length - 1) {
                 btnNext.setText(getString(R.string.start));
                 btnSkip.setVisibility(View.GONE);
+                lastPage = true;
             } else {
                 btnNext.setText(getString(R.string.next));
                 btnSkip.setVisibility(View.VISIBLE);
@@ -142,7 +144,9 @@ public class WelcomeActivity extends AppCompatActivity {
 
         @Override
         public void onPageScrollStateChanged(int arg0) {
-
+            if (lastPage && arg0 == ViewPager.SCROLL_STATE_DRAGGING) {
+                startActivity(new Intent(WelcomeActivity.this, MainActivity.class));
+            }
         }
     };
 

--- a/app/src/opff/res/values/strings.xml
+++ b/app/src/opff/res/values/strings.xml
@@ -14,9 +14,9 @@
     <string name="slide_1_title">Contribute to Pet Food transparency</string>
     <string name="slide_1_desc">Scan products, take them in picture, make pet food transparency happen</string>
     <string name="slide_2_title">Get the facts</string>
-    <string name="slide_2_desc">Extensive information about the product you've scanned, deciphered for you</string>
+    <string name="slide_2_desc">Extensive information about the product you\'ve scanned, deciphered for you</string>
     <string name="slide_3_title">Keep track of the product you use</string>
     <string name="slide_3_desc">All the cosmetic you use, in one handy list you can export</string>
     <string name="slide_4_title">Works offline</string>
-    <string name="slide_4_desc">You can add new products, even if you don't have an Internet connexion right now</string>
+    <string name="slide_4_desc">You can add new products, even if you don\'t have an Internet connection right now</string>
 </resources>


### PR DESCRIPTION
## Description

there was a missing backward slash before the single quotation mark, this prevented the remaining text from being shown.

## Related issues and discussion
#1300 
