### PR TITLE
GreenDao upgrade

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/ProductRepository.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/ProductRepository.java
@@ -1,6 +1,7 @@
 package openfoodfacts.github.scrachx.openfood.repositories;
 
 import org.greenrobot.greendao.AbstractDao;
+import org.greenrobot.greendao.database.Database;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -53,6 +54,7 @@ public class ProductRepository implements IProductRepository {
     private ProductApiService productApi;
     private OpenFoodAPIService openFooApi;
 
+    private Database db;
     private LabelDao labelDao;
     private LabelNameDao labelNameDao;
     private TagDao tagDao;
@@ -78,6 +80,7 @@ public class ProductRepository implements IProductRepository {
         openFooApi = CommonApiManager.getInstance().getOpenFoodApiService();
 
         DaoSession daoSession = OFFApplication.getInstance().getDaoSession();
+        db = daoSession.getDatabase();
         labelDao = daoSession.getLabelDao();
         labelNameDao = daoSession.getLabelNameDao();
         tagDao = daoSession.getTagDao();
@@ -209,11 +212,20 @@ public class ProductRepository implements IProductRepository {
      */
     @Override
     public void saveLabels(List<Label> labels) {
-        for (Label label : labels) {
-            labelDao.insertOrReplaceInTx(label);
-            for (LabelName labelName : label.getNames()) {
-                labelNameDao.insertOrReplace(labelName);
+        db.beginTransaction();
+        try {
+            for (Label label : labels) {
+                labelDao.insertOrReplace(label);
+                for (LabelName labelName : label.getNames()) {
+                    labelNameDao.insertOrReplace(labelName);
+                }
             }
+
+            db.setTransactionSuccessful();
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            db.endTransaction();
         }
     }
 
@@ -233,11 +245,20 @@ public class ProductRepository implements IProductRepository {
      */
     @Override
     public void saveAllergens(List<Allergen> allergens) {
-        for (Allergen allergen : allergens) {
-            allergenDao.insertOrReplaceInTx(allergen);
-            for (AllergenName allergenName : allergen.getNames()) {
-                allergenNameDao.insertOrReplace(allergenName);
+        db.beginTransaction();
+        try {
+            for (Allergen allergen : allergens) {
+                allergenDao.insertOrReplace(allergen);
+                for (AllergenName allergenName : allergen.getNames()) {
+                    allergenNameDao.insertOrReplace(allergenName);
+                }
             }
+
+            db.setTransactionSuccessful();
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            db.endTransaction();
         }
     }
 
@@ -248,11 +269,20 @@ public class ProductRepository implements IProductRepository {
      */
     @Override
     public void saveAdditives(List<Additive> additives) {
-        for (Additive additive : additives) {
-            additiveDao.insertOrReplaceInTx(additive);
-            for (AdditiveName additiveName : additive.getNames()) {
-                additiveNameDao.insertOrReplace(additiveName);
+        db.beginTransaction();
+        try {
+            for (Additive additive : additives) {
+                additiveDao.insertOrReplace(additive);
+                for (AdditiveName allergenName : additive.getNames()) {
+                    additiveNameDao.insertOrReplace(allergenName);
+                }
             }
+
+            db.setTransactionSuccessful();
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            db.endTransaction();
         }
     }
 
@@ -263,11 +293,20 @@ public class ProductRepository implements IProductRepository {
      */
     @Override
     public void saveCountries(List<Country> countries) {
-        for (Country country : countries) {
-            countryDao.insertOrReplaceInTx(country);
-            for (CountryName countryName : country.getNames()) {
-                countryNameDao.insertOrReplace(countryName);
+        db.beginTransaction();
+        try {
+            for (Country country : countries) {
+                countryDao.insertOrReplace(country);
+                for (CountryName countryName : country.getNames()) {
+                    countryNameDao.insertOrReplace(countryName);
+                }
             }
+
+            db.setTransactionSuccessful();
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            db.endTransaction();
         }
     }
 
@@ -278,11 +317,20 @@ public class ProductRepository implements IProductRepository {
      */
     @Override
     public void saveCategories(List<Category> categories) {
-        for (Category category : categories) {
-            categoryDao.insertOrReplaceInTx(category);
-            for (CategoryName categoryName : category.getNames()) {
-                categoryNameDao.insertOrReplace(categoryName);
+        db.beginTransaction();
+        try {
+            for (Category category : categories) {
+                categoryDao.insertOrReplace(category);
+                for (CategoryName categoryName : category.getNames()) {
+                    categoryNameDao.insertOrReplace(categoryName);
+                }
             }
+
+            db.setTransactionSuccessful();
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            db.endTransaction();
         }
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/splash/SplashPresenter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/splash/SplashPresenter.java
@@ -2,6 +2,8 @@ package openfoodfacts.github.scrachx.openfood.views.splash;
 
 import android.content.SharedPreferences;
 
+import java.util.Arrays;
+
 import io.reactivex.Completable;
 import io.reactivex.Single;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -47,37 +49,19 @@ public class SplashPresenter implements ISplashPresenter.Actions {
                         productRepository.getCountries(true),
                         productRepository.getAdditives(true),
                         productRepository.getCategories(true), (labels, tags, allergens, countries, additives, categories) -> {
-                            Completable.fromAction(() -> productRepository.saveLabels(labels))
-                                    .subscribeOn(Schedulers.computation())
+                            Completable.merge(
+                                    Arrays.asList(
+                                            Completable.fromAction(() -> productRepository.saveLabels(labels)),
+                                            Completable.fromAction(() -> productRepository.saveTags(tags)),
+                                            Completable.fromAction(() -> productRepository.saveAllergens(allergens)),
+                                            Completable.fromAction(() -> productRepository.saveCountries(countries)),
+                                            Completable.fromAction(() -> productRepository.saveAdditives(additives)),
+                                            Completable.fromAction(() -> productRepository.saveCategories(categories))
+                                    )
+                            ).subscribeOn(Schedulers.computation())
                                     .subscribe(() -> {
+                                        settings.edit().putLong(LAST_REFRESH_DATE, System.currentTimeMillis()).apply();
                                     }, Throwable::printStackTrace);
-
-                            Completable.fromAction(() -> productRepository.saveTags(tags))
-                                    .subscribeOn(Schedulers.computation())
-                                    .subscribe(() -> {
-                                    }, Throwable::printStackTrace);
-
-                            Completable.fromAction(() -> productRepository.saveAllergens(allergens))
-                                    .subscribeOn(Schedulers.computation())
-                                    .subscribe(() -> {
-                                    }, Throwable::printStackTrace);
-
-                            Completable.fromAction(() -> productRepository.saveCountries(countries))
-                                    .subscribeOn(Schedulers.computation())
-                                    .subscribe(() -> {
-                                    }, Throwable::printStackTrace);
-
-                            Completable.fromAction(() -> productRepository.saveAdditives(additives))
-                                    .subscribeOn(Schedulers.computation())
-                                    .subscribe(() -> {
-                                    }, Throwable::printStackTrace);
-
-                            Completable.fromAction(() -> productRepository.saveCategories(categories))
-                                    .subscribeOn(Schedulers.computation())
-                                    .subscribe(() -> {
-                                    }, Throwable::printStackTrace);
-
-                            settings.edit().putLong(LAST_REFRESH_DATE, System.currentTimeMillis()).apply();
 
                             return true;
                         })


### PR DESCRIPTION
Implemented faster way to save taxonomies translations.
Previously, to save each record, GreenDao used a new transaction, it had awful effect on performance.
At the moment, GreenDao saves records using only 1 transaction.
Look at "Performance" header: http://greenrobot.org/greendao/documentation/technical-faq/