### PR TITLE
Fix #1343 OBF crash on startup

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -21,4 +21,8 @@
 -keep class **$$JsonObjectMapper { *; }
 -keep class openfoodfacts.github.scrachx.openfood.models.** { *; }
 -ignorewarnings
+#Keep Jackson classes ( https://sourceforge.net/p/proguard/discussion/182456/thread/e4d73acf/ )
+-keepnames class org.codehaus.jackson.** {
+    *;
+}
 


### PR DESCRIPTION
## Description

Keeps jackson classes. Tests seem fine on my J5 and emulators, but would like more people to test please.
Proguard configuration appeared to be removing classes necessary for Jackson operations.

## Related issues and discussion
#1343 
 

