### PR TITLE
Closes #1432 : Fix swiping bug in onboarding slide

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/WelcomeActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/WelcomeActivity.java
@@ -32,13 +32,14 @@ public class WelcomeActivity extends AppCompatActivity {
     private Button btnSkip, btnNext;
     private PrefManager prefManager;
     private boolean lastPage = false;
+    private int currentState;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
 
         requestWindowFeature(Window.FEATURE_NO_TITLE);
         super.onCreate(savedInstanceState);
-        if(getResources().getBoolean(R.bool.portrait_only)){
+        if (getResources().getBoolean(R.bool.portrait_only)) {
             setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         }
         setContentView(R.layout.activity_welcome);
@@ -127,19 +128,30 @@ public class WelcomeActivity extends AppCompatActivity {
             } else {
                 btnNext.setText(getString(R.string.next));
                 btnSkip.setVisibility(View.VISIBLE);
+                lastPage = false;
             }
         }
 
+        /*
+        If user is on the last page and tries to swipe towards the next page on right then the value of
+        positionOffset returned is always 0, on the other hand if the user tries to swipe towards the
+        previous page on the left then the value of positionOffset returned is 0.999 and decreases as the
+        user continues to swipe in the same direction. Also whenever a user tries to swipe in any
+        direction the state is changed from idle to dragging and onPageScrollStateChanged is called.
+        Therefore if the user is on the last page and the value of positionOffset is 0 and state is
+        dragging it means that the user is trying to go to the next page on right from the last page and
+        hence MainActivity is started in this case.
+        */
         @Override
-        public void onPageScrolled(int arg0, float arg1, int arg2) {
-
+        public void onPageScrolled(int arg0, float positionOffset, int positionOffsetPixels) {
+            if (lastPage && positionOffset == 0f && currentState == ViewPager.SCROLL_STATE_DRAGGING) {
+                startActivity(new Intent(WelcomeActivity.this, MainActivity.class));
+            }
         }
 
         @Override
         public void onPageScrollStateChanged(int arg0) {
-            if (lastPage && arg0 == ViewPager.SCROLL_STATE_DRAGGING) {
-                startActivity(new Intent(WelcomeActivity.this, MainActivity.class));
-            }
+            currentState = arg0;
         }
     };
 


### PR DESCRIPTION
## Description
`onPageScrolled` is used to check if the user is on the last page and is trying to swipe left (i.e. trying to move towards the next slide on right), if this is the case then `MainActivity` is stared.

## Related issues and discussion
Fixes #1432 
 
 ## Screen-shots, if any
From the below gif it is clearly visible that the user can go back to the previous slide even from the last slide which was not possible earlier.
![videotogif_2018 04 10_23 20 14](https://user-images.githubusercontent.com/10832531/38574918-b74364d0-3d17-11e8-8743-f43dbd4030e9.gif)

 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
