### PR TITLE
updated scannerfragment intent flags

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
@@ -71,6 +71,7 @@ public class HomeFragment extends NavigationBaseFragment {
                 }
             } else {
                 Intent intent = new Intent(getActivity(), ScannerFragmentActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 startActivity(intent);
             }
         } else {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
@@ -165,7 +165,6 @@ public class HistoryScanActivity extends BaseActivity implements SwipeController
 
         menu.findItem(R.id.action_export_all_history)
                 .setVisible(!emptyHistory);
-
         menu.findItem(R.id.action_remove_all_history)
                 .setVisible(!emptyHistory);
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
@@ -111,7 +111,6 @@ public class HistoryScanActivity extends BaseActivity implements SwipeController
         }
     }
 
-
     public void exportCSV() {
         String folder_main = " ";
         String appname = " ";

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
@@ -372,6 +372,7 @@ public class HistoryScanActivity extends BaseActivity implements SwipeController
                 }
             } else {
                 Intent intent = new Intent(HistoryScanActivity.this, ScannerFragmentActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 startActivity(intent);
             }
         }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -409,6 +409,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
                 ());
         if (settings.getBoolean("startScan", false)) {
             Intent cameraIntent = new Intent(MainActivity.this, ScannerFragmentActivity.class);
+            cameraIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(cameraIntent);
         }
 
@@ -465,6 +466,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
             }
         } else {
             Intent intent = new Intent(MainActivity.this, ScannerFragmentActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
             startActivity(intent);
         }
     }
@@ -604,6 +606,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
                 if (grantResults.length > 0 && grantResults[0] == PackageManager
                         .PERMISSION_GRANTED) {
                     Intent intent = new Intent(MainActivity.this, ScannerFragmentActivity.class);
+                    intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                     startActivity(intent);
                 }
             }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductActivity.java
@@ -183,6 +183,7 @@ public class ProductActivity extends BaseActivity implements CustomTabActivityHe
                 }
             } else {
                 Intent intent = new Intent(this, ScannerFragmentActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 startActivity(intent);
             }
         }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/SaveProductOfflineActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/SaveProductOfflineActivity.java
@@ -181,6 +181,7 @@ public class SaveProductOfflineActivity extends BaseActivity {
                 }
             } else {
                 Intent intent = new Intent(this, ScannerFragmentActivity.class);
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                 startActivity(intent);
             }
         }


### PR DESCRIPTION
## Description

Added clear top flag for scanner fragment so that only the first one is stored and give us the required functionality.

## Related issues and discussion
closes #1408 
 
 ## Screen-shots, if any
 
previously we had to press multiple times to go to home after scanning many products, something like below

![backstack-bugged](https://user-images.githubusercontent.com/22943390/38623574-a70ac30e-3dc3-11e8-8a3b-9ea139d40424.gif)





After adding flags

![backstacksolved](https://user-images.githubusercontent.com/22943390/38623592-b0367d2e-3dc3-11e8-9a4b-a7a319dba39b.gif)

