### PR TITLE
Closes #1256 : Many Travis build are failing, exceeding the time limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-install: travis_wait 90 mvn install
 language: android
 
 jdk: oraclejdk8
@@ -39,13 +38,22 @@ android:
     - 'google-gdk-license-.+'
     - '.*intel.+'
 
+  before_cache:
+    # Do not cache a few Gradle files/directories (see https://docs.travis-ci.com/user/languages/java/#Caching)
+    - rm -f  ${TRAVIS_BUILD_DIR}/gradle/caches/modules-2/modules-2.lock
+    - rm -fr ${TRAVIS_BUILD_DIR}/gradle/caches/*/plugin-resolution/
+
 cache:
   directories:
+    # Gradle dependencies
     - ${TRAVIS_BUILD_DIR}/gradle/caches/
     - ${TRAVIS_BUILD_DIR}/gradle/wrapper/dists/
 
+    # Cache maven
+    - $HOME/.m2
+
 before_script:
-# Create and start emulator
+# Create and start emulator.
   - echo no | android create avd --force -n test -t "android-"$ANDROID_EMULATOR_LEVEL --abi $ANDROID_ABI --tag $ANDROID_TAG
   - emulator -avd test -no-window &
   - android-wait-for-emulator
@@ -54,11 +62,23 @@ before_script:
 before_install:
   - yes | sdkmanager "platforms;android-27"
 
-install:
-  - ./gradlew assembleDebug --stacktrace
+jobs:
+ include:
+  - stage: test
+    script:
+      - ./gradlew connectedObfDebugAndroidTest --stacktrace
 
-script:
-  - ./gradlew build connectedCheck --stacktrace
+  - stage: test
+    script:
+      - ./gradlew connectedOffDebugAndroidTest --stacktrace
+
+  - stage: test
+    script:
+      - ./gradlew connectedOpfDebugAndroidTest --stacktrace
+
+  - stage: test
+    script:
+      - ./gradlew connectedOpffDebugAndroidTest --stacktrace
 
 branches:
   only:
@@ -69,7 +89,7 @@ notifications:
   slack: openfoodfacts:mXLLSlWjBKA9e03ELQ83rNvB
   webhooks: https://www.travisbuddy.com/
 
-sudo: true
+sudo: required
 
 addons:
   artifacts: true


### PR DESCRIPTION
## Description
Tweak Travis script to fix Travis builds
- removed `- ./gradlew assembleDebug --stacktrace` from _install_
- speedup travis by caching maven
- removed `build` as it was redundant with `connectedCheck` 
- **reduced build time by 15-20 mins** by adding Build Stages and performing checks for all the flavors in parallel

#### **Time Analysis** 

- Approximately **4-5 mins** are spent in **installing Android dependencies** 
- **6-10 mins** are spent in **creating emulator**
- **10-12 mins** are spent in **downloading from maven**.
- The compiling, installing and running tests for each flavour takes approximately **6-7 mins**.

## Related issues and discussion
Fixes #1256 
 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
