### PR TITLE
check for null values in language preference

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
@@ -92,7 +92,6 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements INa
             Configuration configuration = activity.getResources().getConfiguration();
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-
                 configuration.setLocale(LocaleHelper.getLocale((String) locale));
                 new GetAdditives().execute();
             }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
@@ -28,6 +28,7 @@ import org.apache.commons.text.WordUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
@@ -69,17 +70,21 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements INa
 
         String[] localeValues = getActivity().getResources().getStringArray(R.array.languages_array);
         String[] localeLabels = new String[localeValues.length];
+        List<String> finalLocalValues = new ArrayList<>();
+        List<String> finalLocalLabels = new ArrayList<>();
 
         for (int i = 0; i < localeValues.length; i++) {
             Locale current = LocaleHelper.getLocale(localeValues[i]);
 
             if (current != null) {
                 localeLabels[i] = WordUtils.capitalize(current.getDisplayName(current));
+                finalLocalLabels.add(localeLabels[i]);
+                finalLocalValues.add(localeValues[i]);
             }
         }
 
-        languagePreference.setEntries(localeLabels);
-        languagePreference.setEntryValues(localeValues);
+        languagePreference.setEntries(finalLocalLabels.toArray(new String[finalLocalLabels.size()]));
+        languagePreference.setEntryValues(finalLocalValues.toArray(new String[finalLocalValues.size()]));
 
         languagePreference.setOnPreferenceChangeListener((preference, locale) -> {
 
@@ -133,7 +138,8 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements INa
 
             CustomTabsIntent customTabsIntent = new CustomTabsIntent.Builder().build();
             customTabsIntent.intent.putExtra("android.intent.extra.REFERRER", Uri.parse("android-app://" + getContext().getPackageName()));
-            CustomTabActivityHelper.openCustomTab(getActivity(), customTabsIntent, Uri.parse(getString(R.string.translate_url)), new WebViewFallback());
+            CustomTabActivityHelper.openCustomTab(getActivity(), customTabsIntent, Uri.parse(getString(R.string.translate_url)), new
+                    WebViewFallback());
 
             return true;
         });


### PR DESCRIPTION
## Description

Many language locale codes are not available in android 4.4, many were added in android 5.0. So I checked for null, if not null only then added locale to preference. 

## Related issues and discussion
closes #1451 
 
 ## Screen-shots, if any

![preference-solved](https://user-images.githubusercontent.com/22943390/38813650-26dd52e4-41ad-11e8-9f07-cd780a20e41b.gif)

