### PR TITLE
Fixes #1495 - incorrectly spaced commas are aligned properly

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/ContributorsFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/ContributorsFragment.java
@@ -103,10 +103,9 @@ public class ContributorsFragment extends BaseFragment {
             String otherEditorsTxt = getString(R.string.other_editors);
             otherEditorsText.setMovementMethod(LinkMovementMethod.getInstance());
             otherEditorsText.setText(otherEditorsTxt + " ");
-
             for (int i = 0; i < product.getEditors().size() - 1; i++) {
-                otherEditorsText.append(getContributorsTag(product.getEditors().get(i)));
-                otherEditorsText.append(",");
+                otherEditorsText.append(getContributorsTag(product.getEditors().get(i)).subSequence(0, product.getEditors().get(i).length()));
+                otherEditorsText.append(", ");
             }
             otherEditorsText.append(getContributorsTag(product.getEditors().get(product.getEditors().size() - 1)));
         } else {


### PR DESCRIPTION
## Description

Per issue #1495, contributor names in other editors portion of the Contributor Fragment had misaligned commas when separating the list of additional contributors (besides original contr. and last edited contr.). These changes fix the extra space after the name and add a space after the comma while maintaining the underlying activity link in each contributor's name.

## Related issues and discussion
#1495 
 
 ## Screen-shots, if any
![image](https://user-images.githubusercontent.com/29528527/39449151-24937de0-4c7c-11e8-91d0-c2aa7cf67c2a.png)

