### PR TITLE
Fix problem that ui is not visible on android editor

### DIFF
--- a/app/src/main/res/layout/activity_welcome.xml
+++ b/app/src/main/res/layout/activity_welcome.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
-                xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                tools:showIn="@layout/activity_welcome">
+                android:layout_height="match_parent">
 
     <android.support.v4.view.ViewPager
         android:id="@+id/view_pager"


### PR DESCRIPTION
## Description

Problem to see the layout on my editor:

The surrounding layout (@layout/activity_welcome) did not actually include this layout. Remove tools:showIn=... from the root tag.

 ## Screen-shots, if any

![xmlerror](https://user-images.githubusercontent.com/4539769/39606279-53c67f90-4f3d-11e8-8993-9d1d9d3ef5d6.png)

