### PR TITLE
Xml recyclerView improves

### DIFF
--- a/app/src/main/res/layout/activity_history_scan.xml
+++ b/app/src/main/res/layout/activity_history_scan.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
 
     <include layout="@layout/toolbar" />
@@ -15,6 +16,7 @@
             android:id="@+id/listHistoryScan"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            tools:listitem="@layout/history_list_item"
             android:layout_margin="@dimen/spacing_normal" />
 
         <LinearLayout

--- a/app/src/main/res/layout/activity_welcome.xml
+++ b/app/src/main/res/layout/activity_welcome.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
-                xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                tools:showIn="@layout/activity_welcome">
+                android:layout_height="match_parent">
 
     <android.support.v4.view.ViewPager
         android:id="@+id/view_pager"

--- a/app/src/main/res/layout/drawer_list_item.xml
+++ b/app/src/main/res/layout/drawer_list_item.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="48dp"
-    >
+    android:layout_height="48dp">
 
     <ImageView
         android:id="@+id/icon"
@@ -11,8 +10,7 @@
         android:layout_alignParentLeft="true"
         android:layout_marginLeft="12dp"
         android:layout_marginRight="12dp"
-        android:layout_centerVertical="true"
-        />
+        android:layout_centerVertical="true" />
 
     <TextView
         android:id="@+id/title"
@@ -23,8 +21,6 @@
         android:textAppearance="?android:attr/textAppearanceListItemSmall"
         android:gravity="center_vertical"
         android:textColor="@color/grey_50"
-        android:paddingRight="40dp"
-        />
-
+        android:paddingRight="40dp" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_alert_allergens.xml
+++ b/app/src/main/res/layout/fragment_alert_allergens.xml
@@ -1,13 +1,15 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:fab="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" >
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/allergens_recycle"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:paddingBottom="100dp"
+        tools:listitem="@layout/item_allergens"
         android:clipToPadding="false"/>
 
     <android.support.design.widget.FloatingActionButton

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_nutrition_info_product.xml
+++ b/app/src/main/res/layout/fragment_nutrition_info_product.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/swipeRefresh"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -61,6 +62,8 @@
                 android:id="@+id/nutriments_recycler_view"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                tools:listheader="@layout/nutriment_item_list_header"
+                tools:listitem="@layout/nutriment_item_list"
                 android:layout_below="@id/textPerPortion"
                 android:paddingBottom="60dp"
                 android:scrollbars="vertical" />

--- a/app/src/main/res/layout/fragment_nutrition_product.xml
+++ b/app/src/main/res/layout/fragment_nutrition_product.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/swipeRefresh"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -81,6 +82,7 @@
                 android:layout_marginRight="@dimen/spacing_normal"
                 android:background="@drawable/textview_full"
                 android:divider="@color/white"
+                tools:listitem="@layout/nutrient_lvl_list_item"
                 android:dividerHeight="0dp"
                 android:padding="@dimen/spacing_small"
                 android:paddingBottom="60dp"

--- a/app/src/main/res/layout/fragment_offline_edit.xml
+++ b/app/src/main/res/layout/fragment_offline_edit.xml
@@ -107,6 +107,7 @@
             android:id="@+id/listOfflineSave"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            tools:listitem="@layout/save_list_item"
             android:layout_margin="@dimen/spacing_normal" />
 
     </LinearLayout>

--- a/app/src/main/res/layout/item_allergens.xml
+++ b/app/src/main/res/layout/item_allergens.xml
@@ -17,7 +17,7 @@
         android:layout_margin="@dimen/spacing_small"
         android:layout_marginLeft="@dimen/spacing_normal"
         android:layout_marginRight="@dimen/spacing_normal"
-        tools:test="allergen name"/>
+        tools:text="allergen name"/>
 
     <Button
         android:id="@+id/delete_button"

--- a/app/src/main/res/layout/item_allergens.xml
+++ b/app/src/main/res/layout/item_allergens.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?><!--Fragment to display allergens being checked for-->
-<LinearLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:paddingTop="10dp"
-    android:paddingBottom="10dp"
-    >
+    android:paddingBottom="10dp">
 
     <TextView
         android:id="@+id/allergen_name"
@@ -18,7 +17,7 @@
         android:layout_margin="@dimen/spacing_small"
         android:layout_marginLeft="@dimen/spacing_normal"
         android:layout_marginRight="@dimen/spacing_normal"
-        />
+        tools:test="allergen name"/>
 
     <Button
         android:id="@+id/delete_button"
@@ -29,6 +28,5 @@
         android:textSize="13sp"
         android:background="@drawable/rounded_button"
         android:textColor="@color/white"
-        android:layout_margin="@dimen/spacing_normal"
-        />
+        android:layout_margin="@dimen/spacing_normal" />
 </LinearLayout>


### PR DESCRIPTION
## Description

tools:listitem / tools:listheader / tools:listfooter
Intended for: <AdapterView> (and subclasses like <ListView>)

Used by: Android Studio layout editor

These attributes specify which layout to show in the layout preview for a list's items, header, and footer. Any data fields in the layout are filled with numeric contents such as "Item 1" so that the list items are not repetitive.

For example:

<ListView xmlns:android="http://schemas.android.com/apk/res/android"
    xmlns:tools="http://schemas.android.com/tools"
    android:id="@android:id/list"
    android:layout_width="match_parent"
    android:layout_height="match_parent"
    **tools:listitem="@layout/sample_list_item"
    tools:listheader="@layout/sample_list_header"
    tools:listfooter="@layout/sample_list_footer"** />


 ## Screen-shots, if any

Editor without ListItem attribute 

![screenw whitout listitem](https://user-images.githubusercontent.com/4539769/39656072-287754e4-5006-11e8-86e1-2aace51d98b5.png)

Editor with  ListItem attribute 

![screen with listitem](https://user-images.githubusercontent.com/4539769/39656102-4a0dc692-5006-11e8-83dc-fb0935fa6511.png)






 
