### PR TITLE
Closes #1532 : Duplicated ingredient tab

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ProductActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ProductActivity.java
@@ -1,7 +1,6 @@
 package openfoodfacts.github.scrachx.openfood.views.product;
 
 import android.Manifest;
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -52,12 +51,9 @@ import butterknife.BindView;
 import butterknife.OnClick;
 import openfoodfacts.github.scrachx.openfood.BuildConfig;
 import openfoodfacts.github.scrachx.openfood.R;
-import openfoodfacts.github.scrachx.openfood.models.Nutriments;
-
-import openfoodfacts.github.scrachx.openfood.fragments.ProductPhotosFragment;
-import openfoodfacts.github.scrachx.openfood.models.Product;
 import openfoodfacts.github.scrachx.openfood.fragments.ContributorsFragment;
-import openfoodfacts.github.scrachx.openfood.models.Product;
+import openfoodfacts.github.scrachx.openfood.fragments.ProductPhotosFragment;
+import openfoodfacts.github.scrachx.openfood.models.Nutriments;
 import openfoodfacts.github.scrachx.openfood.models.State;
 import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient;
 import openfoodfacts.github.scrachx.openfood.utils.SearchType;
@@ -254,7 +250,6 @@ public class ProductActivity extends BaseActivity implements CustomTabActivityHe
 
         adapterResult = new ProductFragmentPagerAdapter(getSupportFragmentManager());
         adapterResult.addFragment(new SummaryProductFragment(), menuTitles[0]);
-        adapterResult.addFragment(new IngredientsProductFragment(), menuTitles[1]);
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(this);
         if (preferences.getBoolean("contributionTab", false)) {
             adapterResult.addFragment(new ContributorsFragment(), getString(R.string.contribution_tab));


### PR DESCRIPTION
## Description

adapterResult.addFragment(new IngredientsProductFragment(), menuTitles[1]);
This line is casing the problem, as there is already a If condition check in setupViewPager method so it was unnecessary and hence removed.

## Related issues and discussion
Duplicated ingredient tab
Issue Number: #1532 

 ## Screen-shots
![screenshot_1525533109](https://user-images.githubusercontent.com/32436867/39664699-c15e20cc-50a4-11e8-9afe-45bf83de38b8.png)
