### PR TITLE
Closes #1060 : Removed null pointer exception

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
@@ -155,10 +155,8 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
         super.refreshView(state);
         mState = state;
 
-        try {
+        if(getArguments()!=null){
             mSendProduct = (SendProduct) getArguments().getSerializable("sendProduct");
-        } catch (NullPointerException e) {
-            e.printStackTrace();
         }
 
         mAdditiveDao = Utils.getAppDaoSession(getActivity()).getAdditiveDao();


### PR DESCRIPTION
## Description
try {
            mSendProduct = (SendProduct) getArguments().getSerializable("sendProduct");
        } catch (NullPointerException e) {
            e.printStackTrace();
        }

In IngredientsProductFragment.java at line 162, try & catch was creating a null pointer exception, so it is replaced with simple if condition, 
if(getArguments()!=null){
            mSendProduct = (SendProduct) getArguments().getSerializable("sendProduct");
        }

## Related issues and discussion
java.lang.IllegalStateException android.widget.RelativeLayout$DependencyGraph.getSortedViews
Issue Number :  #1060 
