### PR TITLE
Closes #1526 : Layout issue on the Chinese onboarding slides

### DIFF
--- a/app/src/main/res/layout/welcome_slide2.xml
+++ b/app/src/main/res/layout/welcome_slide2.xml
@@ -15,7 +15,7 @@
 
     <TextView
         android:id="@+id/slide_2_title"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/slide_2_image"
         android:layout_centerHorizontal="true"
@@ -23,17 +23,19 @@
         android:text="@string/slide_2_title"
         android:textColor="@android:color/white"
         android:textSize="20sp"
-        android:textStyle="bold" />
+        android:textStyle="bold"
+        android:gravity="center"
+        />
 
     <TextView
         android:id="@+id/slide_2_desc"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/slide_2_title"
         android:layout_marginLeft="@dimen/activity_horizontal_margin"
         android:layout_marginRight="@dimen/activity_horizontal_margin"
         android:layout_marginTop="20dp"
-        android:gravity="center_horizontal"
+        android:gravity="center"
         android:text="@string/slide_2_desc"
         android:textAlignment="center"
         android:textColor="@android:color/white"


### PR DESCRIPTION
## Description

Changes are done in welcome slide 2 where both title and description width is set to match parent and layout gravity is set to center. 

## Related issues and discussion
Layout issue on the Chinese onboarding slides
Issue Number: #1526 
 
 ## Screen-shots, if any
![screenshot_1526144390](https://user-images.githubusercontent.com/32436867/39959782-b666ae42-5634-11e8-9623-0a19707e3fc5.png)
