### PR TITLE
Closes #1494 : Offline notification needs to have a singular/plurial variant.

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/WifiUploadReceiver.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/WifiUploadReceiver.java
@@ -1,6 +1,5 @@
 package openfoodfacts.github.scrachx.openfood.utils;
 
-import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.app.Service;
@@ -13,12 +12,9 @@ import android.os.IBinder;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
 
-import com.mikepenz.google_material_typeface_library.GoogleMaterial;
-
 import java.util.List;
 
 import openfoodfacts.github.scrachx.openfood.R;
-import openfoodfacts.github.scrachx.openfood.fragments.OfflineEditFragment;
 import openfoodfacts.github.scrachx.openfood.models.SendProduct;
 import openfoodfacts.github.scrachx.openfood.models.SendProductDao;
 
@@ -81,10 +77,10 @@ public class WifiUploadReceiver extends BroadcastReceiver {
 
             Intent intent = new Intent(this, UploadService.class);
             intent.setAction("UploadJob");
-
+            String contentText = this.getResources().getQuantityString(R.plurals.offline_notification_count, listSaveProduct.size(), listSaveProduct.size());
             NotificationCompat.Builder builder = new NotificationCompat.Builder(this)
                     .setContentTitle(this.getString(R.string.offline_notification_title))
-                    .setContentText(this.getString(R.string.offline_notification_context, listSaveProduct.size()))
+                    .setContentText(contentText)
                     .setSmallIcon(R.mipmap.ic_launcher)
                     .addAction(R.drawable.ic_cloud_upload, "Upload", PendingIntent.getService(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT));
 
@@ -92,11 +88,6 @@ public class WifiUploadReceiver extends BroadcastReceiver {
             NotificationManager mNotificationManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
 
             mNotificationManager.notify(9, builder.build());
-
-
         }
-
     }
-
-
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,10 @@
 <resources>
 
+    <plurals name="offline_notification_count">
+        <item quantity="one"> You have 1 offline product waiting to be contributed to Open Food Facts</item>
+        <item quantity="other"> You have %d offline products waiting to be contributed to Open Food Facts</item>
+    </plurals>
+
     <plurals name="minutes">
         <item quantity="one"> minute</item>
         <item quantity="other"> minutes</item>
@@ -585,7 +590,6 @@
     <string name="products_to_be_completed">Products to be completed</string>
     <string name="modified_history">Product added on %1$s at %2$s by %3$s.  Last edit of product page on %4$s at %5$s by %6$s.  Product page also edited by %7$s</string>
     <string name="offline_notification_title">Offline contributions you need to send</string>
-    <string name="offline_notification_context">You have %1$d offline products waiting to be contributed to Open Food Facts</string>
     <string name="creator_history">Product added on %1$s at %2$s CET by</string>
     <string name="last_editor_history">Last edit of product page on %1$s at %2$s CEST by </string>
     <string name="other_editors">Product page also edited by </string>


### PR DESCRIPTION
## Description
Converted the offline notification string into a singular/plural variant.

**Previous string version**: You have %1$d offline products waiting to be contributed to Open Food Facts
**Singular**: You have 1 offline product waiting to be contributed to Open Food Facts.
**Plural**: You have %d offline products waiting to be contributed to Open Food Facts 

## Related issues and discussion
 Offline notification needs to have a singular/plural variant.

Issue Number: #1494  