### PR TITLE
Closes #287 : Change wording of offline mode warning popup for Open Beauty Facts.

### DIFF
--- a/app/src/obf/res/values/strings.xml
+++ b/app/src/obf/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="Donation">Click here to donate to Open Beauty Facts</string>
     <string name="translate_help_title">Help translate Open Beauty Facts</string>
     <string name="translate_help_summary">Bring the Open Beauty Facts database to your language - no technical knowledge required</string>
-    <string name="text_offline_info_dialog">You can scan products when you\'re offline to add them to Open Beauty Facts later. All the products you scan will appear here, and you\'ll be able to send them using the button below.</string>
+    <string name="text_offline_info_dialog">Scan the products even when you are offline so as to add them to Open Beauty Facts later. The scanned products will appear here and you will be able to send them using the button below.</string>
     <string name="warning_alert_data">Your allergies info will never be sent to the Open Beauty Facts server. Also, be careful that product data may not be accurate, and detection might not be 100% accurate, so please double-check by yourself! </string>
 
     <!-- OBF tagline in different languages -->

--- a/app/src/off/res/values/strings.xml
+++ b/app/src/off/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="Donation">Click here to donate to Open Food Facts</string>
     <string name="translate_help_title">Help translate Open Food Facts</string>
     <string name="translate_help_summary">Bring the Open Food Facts database to your language - no technical knowledge required</string>
-    <string name="text_offline_info_dialog">You can scan products when you\'re offline to add them to Open Food Facts later. All the products you scan will appear here, and you\'ll be able to send them using the button below.</string>
+    <string name="text_offline_info_dialog">Scan the products even when you are offline so as to add them to Open Food Facts later. The scanned products will appear here and you will be able to send them using the button below.</string>
     <string name="warning_alert_data">Your allergies info will never be sent to the Open Food Facts server. Also, be careful that product data may not be accurate, and detection might not be 100% accurate, so please double-check by yourself! </string>
 
     <!-- OFF tagline in different languages -->

--- a/app/src/opf/res/values/strings.xml
+++ b/app/src/opf/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="Donation">Click here to donate to Open Products Facts</string>
     <string name="translate_help_title">Help translate Open Products Facts</string>
     <string name="translate_help_summary">Bring the Open Products Facts database to your language - no technical knowledge required</string>
-    <string name="text_offline_info_dialog">You can scan products when you\'re offline to add them to Open Products Facts later. All the products you scan will appear here, and you\'ll be able to send them using the button below.</string>
+    <string name="text_offline_info_dialog">Scan the products even when you are offline so as to add them to Open Products Facts later. The scanned products will appear here and you will be able to send them using the button below.</string>
     <string name="warning_alert_data">Your allergies info will never be sent to the Open Products Facts server. Also, be careful that product data may not be accurate, and detection might not be 100% accurate, so please double-check by yourself! </string>
 
     <!-- OPF tagline in different languages -->

--- a/app/src/opff/res/values/strings.xml
+++ b/app/src/opff/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="Donation">Click here to donate to Open Food Facts</string>
     <string name="translate_help_title">Help translate Open Food Facts</string>
     <string name="translate_help_summary">Bring the Open Food Facts database to your language - no technical knowledge required</string>
-    <string name="text_offline_info_dialog">Scan the products even when you are offline so as to add them to Open Food Facts later. The scanned products will appear here and you will be able to send them using the button below.</string>
+    <string name="text_offline_info_dialog">Scan the products even when you are offline so as to add them to Open Pet Food Facts later. The scanned products will appear here and you will be able to send them using the button below.</string>
     <string name="warning_alert_data">Your allergies info will never be sent to the Open Food Facts server. Also, be careful that product data may not be accurate, and detection might not be 100% accurate, so please double-check by yourself! </string>
 
     <!-- OPFF tagline in different languages -->

--- a/app/src/opff/res/values/strings.xml
+++ b/app/src/opff/res/values/strings.xml
@@ -27,7 +27,7 @@
     <string name="Donation">Click here to donate to Open Food Facts</string>
     <string name="translate_help_title">Help translate Open Food Facts</string>
     <string name="translate_help_summary">Bring the Open Food Facts database to your language - no technical knowledge required</string>
-    <string name="text_offline_info_dialog">You can scan products when you\'re offline to add them to Open Food Facts later. All the products you scan will appear here, and you\'ll be able to send them using the button below.</string>
+    <string name="text_offline_info_dialog">Scan the products even when you are offline so as to add them to Open Food Facts later. The scanned products will appear here and you will be able to send them using the button below.</string>
     <string name="warning_alert_data">Your allergies info will never be sent to the Open Food Facts server. Also, be careful that product data may not be accurate, and detection might not be 100% accurate, so please double-check by yourself! </string>
 
     <!-- OPFF tagline in different languages -->


### PR DESCRIPTION
## Description
Changed wording of offline mode warning popup for Open Beauty Facts and other 4 versions from "You can scan products when you're offline to add them to Open Food Facts later. All the products you scan will appear here, and you'll be able to send them using the button below." to "Scan the products even when you are offline so as to add them to Open Beauty Facts later. The scanned products will appear here and you will be able to send them using the button below. " and other changes according to respective versions.

## Related issues and discussion
Change wording of offline mode warning popup for Open Beauty Facts
Issue Number: #287