### PR TITLE
Closes #1590 : Fix resource not found exception

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -596,7 +596,8 @@
     <string name="contribution_tab">Contributions</string>
     <string name="contribution_tab_summary">Show user contributions tab with products</string>
     <string name="contribution_tab_title">Show Contribution Tab</string>
-     <string name="product">Edit</string>
+    <string name="product">Edit</string>
+    <string name="txtDialogsTitle">Information</string>
 
 
 </resources>


### PR DESCRIPTION
## Description
String _txtDialogsTitle_ was missing from the main resources and was present only in the resource file of few selected languages like English. Added it to the main resource.

## Related issues and discussion
Fixes #1590 
 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
