### PR TITLE
Closes #1594 : Use placeholders for time as well

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/HistoryListAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/HistoryListAdapter.java
@@ -140,9 +140,9 @@ public class HistoryListAdapter extends RecyclerView.Adapter<HistoryScanHolder> 
         long days = TimeUnit.MILLISECONDS.toDays(now.getTime() - date.getTime());
 
         String secText = String.valueOf(seconds) + " seconds ago";
-        String hourText = res.getString(R.string.last_seen_string, hours, res.getQuantityString(R.plurals.hours, (int) hours));
-        String minText = res.getString(R.string.last_seen_string, minutes, res.getQuantityString(R.plurals.minutes, (int) minutes));
-        String dayText = res.getString(R.string.last_seen_string, days, res.getQuantityString(R.plurals.days, (int) days));
+        String hourText = res.getQuantityString(R.plurals.hours, (int) hours, (int) hours);
+        String minText = res.getQuantityString(R.plurals.minutes, (int) minutes,(int) minutes);
+        String dayText = res.getQuantityString(R.plurals.days, (int) days, (int) days);
         if (seconds < 60) {
             holder.txtDate.setText(secText);
         } else if (minutes < 60) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,16 +6,16 @@
     </plurals>
 
     <plurals name="minutes">
-        <item quantity="one"> minute</item>
-        <item quantity="other"> minutes</item>
+        <item quantity="one">1 minute ago</item>
+        <item quantity="other">%d minutes ago</item>
     </plurals>
     <plurals name="hours">
-        <item quantity="one"> hour</item>
-        <item quantity="other"> hours</item>
+        <item quantity="one">1 hour ago</item>
+        <item quantity="other">%d hours ago</item>
     </plurals>
     <plurals name="days">
-        <item quantity="one"> day</item>
-        <item quantity="other"> days</item>
+        <item quantity="one">1 day ago</item>
+        <item quantity="other">%d days ago</item>
     </plurals>
     <string name="action_settings">Settings</string>
     <string name="action_about">About</string>


### PR DESCRIPTION
## Description
Updated plurals so as to use in the timestamp instead of hardcoding string with plurals. 

## Related issues and discussion
Use placeholders for time as well.
Issue Number: #1594 
 
 ## Screen-shots, if any
 
![screenshot_1526836940](https://user-images.githubusercontent.com/32436867/40281567-28033780-5c81-11e8-9703-eb750b6c1e71.png)
