### PR TITLE
Closes #1602 : Categories are hard to click on in the Categories Explorer.

### DIFF
--- a/app/src/main/res/layout/category_recycler_item.xml
+++ b/app/src/main/res/layout/category_recycler_item.xml
@@ -23,7 +23,6 @@
             android:layout_height="wrap_content"
             android:text="@{category.name}"
             android:textColor="@android:color/black"
-            android:textIsSelectable="true"
             android:textSize="@dimen/font_normal"
             android:textStyle="bold"
             app:layout_constraintLeft_toLeftOf="parent"

--- a/app/src/main/res/layout/fragment_category_list.xml
+++ b/app/src/main/res/layout/fragment_category_list.xml
@@ -24,7 +24,7 @@
 
         <openfoodfacts.github.scrachx.openfood.FastScroller
             android:id="@+id/fast_scroller"
-            android:layout_width="wrap_content"
+            android:layout_width="24dp"
             android:layout_height="match_parent"
             android:layout_gravity="end" />
 


### PR DESCRIPTION
## Description

As for the changes I've reduced the size of fast scroller bar from wrap_content to 24dp in fragment_category_list.xml and the code that was causing the problem was in the textView of category_recycler_item.xml. As the textView was selectable it doesn't allow proper clicking in the recyclerView so I removed (android:textIsSelectable="true") it in the XML. 

## Related issues and discussion
Categories are hard to click on in the Categories Explorer.
Issue Number: #1602 
 