### PR TITLE
Closes #1597 : Contributor results load in and then disappear.

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
@@ -428,6 +428,7 @@ public class ProductBrowsingListActivity extends BaseActivity {
                         api.getProductsByContributor(searchQuery, pageAddress, this::loadData);
                         break;
                 }
+                break;
             }
 
 


### PR DESCRIPTION
## Description

There's a switch case in which a break statement was missing, so I put a break statement and tested the results thoroughly and everything looks good.

## Related issues and discussion
Contributor results load in and then disappear.
Issue Number: #1597 
 
 ## Screen-shots, if any
 
![screenshot_1527018541](https://user-images.githubusercontent.com/32436867/40386844-7bdf6416-5e28-11e8-933d-79d45d2f11ec.png)
