### PR TITLE
Closes #1626, #1627 : Remove the whitespace between cards.

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
@@ -16,6 +16,7 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.preference.PreferenceManager;
+import android.support.v7.widget.CardView;
 import android.text.SpannableStringBuilder;
 import android.text.method.LinkMovementMethod;
 import android.text.style.ClickableSpan;
@@ -103,6 +104,24 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
     TextView aminoAcidTagsTextView;
     @BindView(R.id.otherNutritionTags)
     TextView otherNutritionTagTextView;
+    @BindView(R.id.cvTextIngredientProduct)
+    CardView textIngredientProductCardView;
+    @BindView(R.id.cvTextSubstanceProduct)
+    CardView textSubstanceProductCardView;
+    @BindView(R.id.cvTextTraceProduct)
+    CardView textTraceProductCardView;
+    @BindView(R.id.cvTextAdditiveProduct)
+    CardView textAdditiveProductCardView;
+    @BindView(R.id.cvTextPalmOilProduct)
+    CardView textPalmOilProductCardView;
+    @BindView(R.id.cvVitaminsTagsText)
+    CardView vitaminsTagsTextCardView;
+    @BindView(R.id.cvAminoAcidTagsText)
+    CardView aminoAcidTagsTextCardView;
+    @BindView(R.id.cvMineralTagsText)
+    CardView mineralTagsTextCardView;
+    @BindView(R.id.cvOtherNutritionTags)
+    CardView otherNutritionTagsCardView;
 
     private Product product;
     private OpenFoodAPIClient api;
@@ -187,6 +206,7 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
             vitaminTagsTextView.append(vitaminStringBuilder.toString());
         } else {
             vitaminTagsTextView.setVisibility(View.GONE);
+            vitaminsTagsTextCardView.setVisibility(View.GONE);
         }
 
         if (!aminoAcidTagsList.isEmpty()) {
@@ -201,6 +221,7 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
             aminoAcidTagsTextView.append(aminoAcidStringBuilder.toString());
         } else {
             aminoAcidTagsTextView.setVisibility(View.GONE);
+            aminoAcidTagsTextCardView.setVisibility(View.GONE);
         }
 
         if (!mineralTags.isEmpty()) {
@@ -215,6 +236,7 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
             mineralTagsTextView.append(mineralsStringBuilder);
         } else {
             mineralTagsTextView.setVisibility(View.GONE);
+            mineralTagsTextCardView.setVisibility(View.GONE);
         }
 
         if (!otherNutritionTags.isEmpty()) {
@@ -229,6 +251,7 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
             otherNutritionTagTextView.append(otherNutritionStringBuilder.toString());
         } else {
             otherNutritionTagTextView.setVisibility(View.GONE);
+            otherNutritionTagsCardView.setVisibility(View.GONE);
         }
 
         additiveProduct.setText(bold(getString(R.string.txtAdditives)));
@@ -266,6 +289,7 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
                 ingredientsProduct.setText(txtIngredients);
             } else {
                 ingredientsProduct.setVisibility(View.GONE);
+                textIngredientProductCardView.setVisibility(View.GONE);
             }
         }
 
@@ -285,10 +309,12 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
             substanceProduct.append(Utils.getClickableText(allergen, allergen, SearchType.ALLERGEN, getActivity(), customTabsIntent));
         } else {
             substanceProduct.setVisibility(View.GONE);
+            textSubstanceProductCardView.setVisibility(View.GONE);
         }
 
         if (isBlank(product.getTraces())) {
             traceProduct.setVisibility(View.GONE);
+            textTraceProductCardView.setVisibility(View.GONE);
         } else {
             traceProduct.setMovementMethod(LinkMovementMethod.getInstance());
             traceProduct.setText(bold(getString(R.string.txtTraces)));
@@ -309,6 +335,7 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
         if (product.getIngredientsFromPalmOilN() == 0 && product.getIngredientsFromOrThatMayBeFromPalmOilN() == 0) {
             palmOilProduct.setVisibility(View.GONE);
             mayBeFromPalmOilProduct.setVisibility(View.GONE);
+            textPalmOilProductCardView.setVisibility(View.GONE);
         } else {
             if (!product.getIngredientsFromPalmOilTags().isEmpty()) {
                 palmOilProduct.setText(bold(getString(R.string.txtPalmOilProduct)));
@@ -420,6 +447,7 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
             }
             case EMPTY: {
                 additiveProduct.setVisibility(View.GONE);
+                textAdditiveProductCardView.setVisibility(View.GONE);
                 break;
             }
         }

--- a/app/src/main/res/layout/fragment_ingredients_product.xml
+++ b/app/src/main/res/layout/fragment_ingredients_product.xml
@@ -44,9 +44,12 @@
                 android:textStyle="bold" />
 
             <android.support.v7.widget.CardView
+                android:id="@+id/cvTextIngredientProduct"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="16dp"
                 app:cardElevation="4dp">
 
                 <TextView
@@ -65,9 +68,12 @@
             </android.support.v7.widget.CardView>
 
             <android.support.v7.widget.CardView
+                android:id="@+id/cvTextSubstanceProduct"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="16dp"
                 app:cardElevation="4dp">
 
                 <TextView
@@ -87,9 +93,12 @@
             </android.support.v7.widget.CardView>
 
             <android.support.v7.widget.CardView
+                android:id="@+id/cvTextTraceProduct"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="16dp"
                 app:cardElevation="4dp">
 
                 <TextView
@@ -109,9 +118,12 @@
             </android.support.v7.widget.CardView>
 
             <android.support.v7.widget.CardView
+                android:id="@+id/cvTextAdditiveProduct"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="16dp"
                 app:cardElevation="4dp">
 
                 <TextView
@@ -131,9 +143,12 @@
             </android.support.v7.widget.CardView>
 
             <android.support.v7.widget.CardView
+                android:id="@+id/cvTextPalmOilProduct"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="16dp"
                 app:cardElevation="4dp">
 
                 <TextView
@@ -165,9 +180,12 @@
             </android.support.v7.widget.CardView>
 
             <android.support.v7.widget.CardView
+                android:id="@+id/cvVitaminsTagsText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="16dp"
                 app:cardElevation="4dp">
 
                 <TextView
@@ -186,9 +204,12 @@
             </android.support.v7.widget.CardView>
 
             <android.support.v7.widget.CardView
+                android:id="@+id/cvMineralTagsText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="16dp"
                 app:cardElevation="4dp">
 
                 <TextView
@@ -207,9 +228,12 @@
             </android.support.v7.widget.CardView>
 
             <android.support.v7.widget.CardView
+                android:id="@+id/cvAminoAcidTagsText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="16dp"
                 app:cardElevation="4dp">
 
                 <TextView
@@ -228,9 +252,12 @@
             </android.support.v7.widget.CardView>
 
             <android.support.v7.widget.CardView
+                android:id="@+id/cvOtherNutritionTags"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginTop="16dp"
                 app:cardElevation="4dp">
 
                 <TextView


### PR DESCRIPTION
## Description

Visibility of the Card View is not changed which was creating whitespace when there's no data in the ingredients tab, So the visibility of the CardView is set to GONE.

## Related issues and discussion
Remove the whitespace between cards & Remove the whitespace between ingredients and additives cards

Issue Number: #1627 & #1626 
 
 ## Screen-shots, if any
 
![screenshot_1527260470](https://user-images.githubusercontent.com/32436867/40551817-9cc44fcc-605b-11e8-994f-f8a0d9362f23.png)
![screenshot_1527260905](https://user-images.githubusercontent.com/32436867/40551818-9d00063e-605b-11e8-9a1c-0abf5fbae40e.png)
