### PR TITLE
Closes #1624 : The Share to Open Food Facts barcode screen should show a keypad.

### DIFF
--- a/app/src/main/res/layout/alert_barcode.xml
+++ b/app/src/main/res/layout/alert_barcode.xml
@@ -19,7 +19,9 @@
         android:padding="10dp"
         android:visibility="gone"
         android:layout_gravity="center_horizontal"
-        android:textSize="@dimen/font_normal" />
+        android:textSize="@dimen/font_normal"
+        android:inputType="number"
+        />
 
 
 


### PR DESCRIPTION
## Description
Add input type = number in alert_barcode.xml.

## Related issues and discussion
The "Share to Open Food Facts" barcode screen should show a keypad.
Issue Number: #1624 
 
 ## Screen-shots, if any
 
![screenshot_1527273519](https://user-images.githubusercontent.com/32436867/40561116-a19998b8-6079-11e8-8447-9366535ef72a.png)