### PR TITLE
Fix NPE in method isNetworkConnected

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
@@ -428,7 +428,10 @@ public class Utils {
      */
     public static boolean isNetworkConnected(Context context) {
         ConnectivityManager cm = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+        NetworkInfo activeNetwork = null;
+        if (cm != null) {
+            activeNetwork = cm.getActiveNetworkInfo();
+        }
 
         return activeNetwork != null && activeNetwork.isConnectedOrConnecting();
     }


### PR DESCRIPTION
## Description
Added null check in method `isNetworkConnected`.
It is used [here](https://github.com/openfoodfacts/openfoodfacts-androidapp/blob/master/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/SaveProductOfflineActivity.java#L213) which is in the log report.

## Related issues and discussion
Should fix #1658 
 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines.
