### PR TITLE
Fix mikepenz material drawer dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -209,7 +209,7 @@ dependencies {
     }
 
     //UI Component : Material Drawer
-    implementation('com.mikepenz:materialdrawer:6.0.2@aar') {
+    implementation('com.mikepenz:materialdrawer:6.0.3@aar') {
         transitive = true
     }
 


### PR DESCRIPTION
## Description

Changed to version 6.0.3. This fixes the failing travis build. The version can be updated to the latest one once the [issue](https://github.com/mikepenz/MaterialDrawer/issues/2312) as been fixed in the library.
 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
