### PR TITLE
Implement MainActivity.changeFragment()

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -25,6 +25,7 @@ import android.support.customtabs.CustomTabsIntent;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.SearchView;
@@ -71,6 +72,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Hashtable;
+import java.util.Objects;
 
 import butterknife.BindView;
 import openfoodfacts.github.scrachx.openfood.BuildConfig;
@@ -781,23 +783,16 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
      * This moves the main activity to the barcode entry fragment.
      */
     public void moveToBarcodeEntry() {
-        result.setSelection(ITEM_SEARCH_BY_CODE);
         Fragment fragment = new FindProductFragment();
-        getSupportActionBar().setTitle(getResources().getString(R.string.search_by_barcode_drawer));
-
-        getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container,
-                fragment).commit();
+        changeFragment(fragment, getResources().getString(R.string.search_by_barcode_drawer), ITEM_SEARCH_BY_CODE);
     }
 
     /**
      * This moves the main activity to the preferences fragment.
      */
     public void moveToPreferences() {
-        result.setSelection(ITEM_PREFERENCES);
         Fragment fragment = new PreferencesFragment();
-        getSupportActionBar().setTitle(R.string.action_preferences);
-
-        getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container, fragment).commit();
+        changeFragment(fragment, getString(R.string.preferences), ITEM_PREFERENCES);
     }
 
     /**
@@ -1027,6 +1022,51 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
             }
         });
     }
+
+    /**
+     * Used to navigate Fragments which are children of <code>MainActivity</code>.
+     * Use this method when the <code>Fragment</code> APPEARS in the <code>Drawer</code>.
+     *
+     * @param fragment   The fragment class to display.
+     * @param title      The title that should be displayed on the top toolbar.
+     * @param drawerName The fragment as it appears in the drawer. See {@link NavigationDrawerListener} for the value.
+     * @author ross-holloway94
+     * @see <a href="https://stackoverflow.com/questions/45138446/calling-fragment-from-recyclerview-adapter">Related Stack Overflow article</a>
+     * @since 06/16/18
+     */
+    public void changeFragment(Fragment fragment, String title, long drawerName) {
+        changeFragment(fragment, title);
+        result.setSelection(drawerName);
+    }
+
+    /**
+     * Used to navigate Fragments which are children of <code>MainActivity</code>.
+     * Use this method when the <code>Fragment</code> DOES NOT APPEAR in the <code>Drawer</code>.
+     *
+     * @param fragment The fragment class to display.
+     * @param title    The title that should be displayed on the top toolbar.
+     * @author ross-holloway94
+     * @see <a href="https://stackoverflow.com/questions/45138446/calling-fragment-from-recyclerview-adapter">Related Stack Overflow article</a>
+     * @since 06/16/18
+     */
+    public void changeFragment(Fragment fragment, String title) {
+
+        String backStateName = fragment.getClass().getName();
+        FragmentManager manager = getSupportFragmentManager();
+        boolean fragmentPopped = manager.popBackStackImmediate(backStateName, 0);
+
+        if (!fragmentPopped && manager.findFragmentByTag(backStateName) == null) {
+            FragmentTransaction ft = manager.beginTransaction();
+            ft.replace(R.id.fragment_container, fragment, backStateName);
+            ft.addToBackStack(backStateName);
+            ft.commit();
+        }
+
+
+        Objects.requireNonNull(getSupportActionBar()).setTitle(title);
+
+    }
+
 
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -612,5 +612,6 @@
     <string name="switch_camera">Switch camera</string>
     <string name="autofocus">Autofocus</string>
     <string name="initial_loading">Initial loading</string>
+    <string name="preferences">Preferences</string>
 
 </resources>


### PR DESCRIPTION
## Description

I have created a new method in MainActivity called changeFragment().

This is designed to allow fragment transitions where the parent activity is MainActivity, and therefore should eliminate the need of having one method each for fragment transitions (eg. moveToBarcodeEntry(), moveToPreferences()).

Note that a Fragment object is required as an argument, so this object will need to be created before using this method.

## Related issues and discussion
N/A - minor refactor, so did not create
  
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is **_well_** documented
 - [ ] Include unit tests for new functionality [N/A - refactor]
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
