### PR TITLE
Fixes #1694 and partial sorting done

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
@@ -493,25 +493,15 @@ public class HistoryScanActivity extends BaseActivity implements SwipeController
                 Collections.sort(productItems, new Comparator<HistoryItem>() {
                     @Override
                     public int compare(HistoryItem historyItem, HistoryItem t1) {
-                        int y;
                         if(TextUtils.isEmpty(historyItem.getTitle()))
                         {
-                            historyItem.setTitle(getResources().getString(R.string.zzzzz));
+                            historyItem.setTitle(getResources().getString(R.string.no_title));
                         }
                         if(TextUtils.isEmpty(t1.getTitle()))
                         {
-                            t1.setTitle(getResources().getString(R.string.zzzz));
+                            t1.setTitle(getResources().getString(R.string.no_title));
                         }
-                        y = historyItem.getTitle().compareToIgnoreCase(t1.getTitle());
-                        if(historyItem.getTitle().equals(getResources().getString(R.string.zzzzz)))
-                        {
-                            historyItem.setTitle("");
-                        }
-                        if(t1.getTitle().equals(getResources().getString(R.string.zzzz)))
-                        {
-                            t1.setTitle("");
-                        }
-                        return y;
+                        return historyItem.getTitle().compareToIgnoreCase(t1.getTitle());
                     }
                 });
 
@@ -523,26 +513,15 @@ public class HistoryScanActivity extends BaseActivity implements SwipeController
                 Collections.sort(productItems, new Comparator<HistoryItem>() {
                     @Override
                     public int compare(HistoryItem historyItem, HistoryItem t1) {
-
-                        int x;
                         if(TextUtils.isEmpty(historyItem.getBrands()))
                         {
-                            historyItem.setBrands(getResources().getString(R.string.zzzzz));
+                            historyItem.setBrands(getResources().getString(R.string.no_brand));
                         }
                         if(TextUtils.isEmpty(t1.getBrands()))
                         {
-                            t1.setBrands(getResources().getString(R.string.zzzz));
+                            t1.setBrands(getResources().getString(R.string.no_brand));
                         }
-                        x = historyItem.getBrands().compareToIgnoreCase(t1.getBrands());
-                        if(historyItem.getBrands().equals(getResources().getString(R.string.zzzzz)))
-                        {
-                            historyItem.setBrands("");
-                        }
-                        if(t1.getBrands().equals(getResources().getString(R.string.zzzz)))
-                        {
-                            t1.setBrands("");
-                        }
-                        return x;
+                        return historyItem.getBrands().compareToIgnoreCase(t1.getBrands());
                     }
                 });
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
@@ -32,6 +32,7 @@ import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.support.v7.widget.helper.ItemTouchHelper;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -504,7 +505,26 @@ public class HistoryScanActivity extends BaseActivity implements SwipeController
                 Collections.sort(productItems, new Comparator<HistoryItem>() {
                     @Override
                     public int compare(HistoryItem historyItem, HistoryItem t1) {
-                        return historyItem.getBrands().compareToIgnoreCase(t1.getBrands());
+                        int x;
+                        if(TextUtils.isEmpty(historyItem.getBrands()))
+                        {
+                            historyItem.setBrands(getResources().getString(R.string.zzzzz));
+                        }
+                        if(TextUtils.isEmpty(t1.getBrands()))
+                        {
+                            t1.setBrands(getResources().getString(R.string.zzzz));
+                        }
+                        x = historyItem.getBrands().compareToIgnoreCase(t1.getBrands());
+                        if(historyItem.getBrands().equals(getResources().getString(R.string.zzzzz)))
+                        {
+                            historyItem.setBrands("");
+                        }
+                        if(t1.getBrands().equals(getResources().getString(R.string.zzzz)))
+                        {
+                            t1.setBrands("");
+                        }
+                        return x;
+
                     }
                 });
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
@@ -493,7 +493,25 @@ public class HistoryScanActivity extends BaseActivity implements SwipeController
                 Collections.sort(productItems, new Comparator<HistoryItem>() {
                     @Override
                     public int compare(HistoryItem historyItem, HistoryItem t1) {
-                        return historyItem.getTitle().compareToIgnoreCase(t1.getTitle());
+                        int y;
+                        if(TextUtils.isEmpty(historyItem.getTitle()))
+                        {
+                            historyItem.setTitle(getResources().getString(R.string.zzzzz));
+                        }
+                        if(TextUtils.isEmpty(t1.getTitle()))
+                        {
+                            t1.setTitle(getResources().getString(R.string.zzzz));
+                        }
+                        y = historyItem.getTitle().compareToIgnoreCase(t1.getTitle());
+                        if(historyItem.getTitle().equals(getResources().getString(R.string.zzzzz)))
+                        {
+                            historyItem.setTitle("");
+                        }
+                        if(t1.getTitle().equals(getResources().getString(R.string.zzzz)))
+                        {
+                            t1.setTitle("");
+                        }
+                        return y;
                     }
                 });
 
@@ -505,6 +523,7 @@ public class HistoryScanActivity extends BaseActivity implements SwipeController
                 Collections.sort(productItems, new Comparator<HistoryItem>() {
                     @Override
                     public int compare(HistoryItem historyItem, HistoryItem t1) {
+
                         int x;
                         if(TextUtils.isEmpty(historyItem.getBrands()))
                         {
@@ -524,7 +543,6 @@ public class HistoryScanActivity extends BaseActivity implements SwipeController
                             t1.setBrands("");
                         }
                         return x;
-
                     }
                 });
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -308,6 +308,8 @@
     <string name="txt_history_exported">History exported</string>
     <string name="permision_write_external_storage">Write external storage permission is needed to export history.</string>
     <string name="txt_nutrition_not_found">N/A</string>
+    <string name="zzzzz">ZZZZZ</string>
+    <string name="zzzz">ZZZZ</string>
 
     <!-- Nutrition info tab -->
     <string name="calculate_calories">Calculate Calories</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -308,8 +308,8 @@
     <string name="txt_history_exported">History exported</string>
     <string name="permision_write_external_storage">Write external storage permission is needed to export history.</string>
     <string name="txt_nutrition_not_found">N/A</string>
-    <string name="zzzzz">ZZZZZ</string>
-    <string name="zzzz">ZZZZ</string>
+    <string name="no_brand">No Brand</string>
+    <string name="no_title">No Title</string>
 
     <!-- Nutrition info tab -->
     <string name="calculate_calories">Calculate Calories</string>


### PR DESCRIPTION
## Description

Products were not sorting on brand names due to missing brand names and that created the exception so in order to do partial sorting ( products with no brands should be at the end ) we can assign a temporary brand name like "ZZZZ" and then do sorting so that such products come at the end and again set the brand name of products as empty ( only for products without brand name ). 
