### PR TITLE
Closes #1759 Logo for Crop Button

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/ProductPhotosFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/ProductPhotosFragment.java
@@ -221,7 +221,9 @@ public class ProductPhotosFragment extends BaseFragment {
 
             @Override
             public void onImagesPicked(List<File> imageFiles, EasyImage.ImageSource source, int type) {
-                CropImage.activity(Uri.fromFile(imageFiles.get(0))).setAllowFlipping(false)
+                CropImage.activity(Uri.fromFile(imageFiles.get(0)))
+                        .setCropMenuCropButtonIcon(R.drawable.ic_check_white_24dp)
+                        .setAllowFlipping(false)
                         .start(getContext(), mFragment);
             }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SaveOfflineSummaryFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/SaveOfflineSummaryFragment.java
@@ -312,8 +312,10 @@ public class SaveOfflineSummaryFragment extends BaseFragment {
             }
 
             @Override
-            public void onImagesPicked(List<File> imageFiles, EasyImage.ImageSource source, int type) {
-                CropImage.activity(Uri.fromFile(imageFiles.get(0))).setAllowFlipping(false)
+            public void onImagesPicked(List<       File> imageFiles, EasyImage.ImageSource source, int type) {
+                CropImage.activity(Uri.fromFile(imageFiles.get(0)))
+                        .setCropMenuCropButtonIcon(R.drawable.ic_check_white_24dp)
+                        .setAllowFlipping(false)
                         .setOutputUri(Utils.getOutputPicUri(getContext())).start(getContext(), mFragment);
             }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
@@ -523,7 +523,10 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
 
             @Override
             public void onImagesPicked(List<File> imageFiles, EasyImage.ImageSource source, int type) {
-                CropImage.activity(Uri.fromFile(imageFiles.get(0))).setAllowFlipping(false).setOutputUri(Utils.getOutputPicUri(getContext()))
+                CropImage.activity(Uri.fromFile(imageFiles.get(0)))
+                        .setCropMenuCropButtonIcon(R.drawable.ic_check_white_24dp)
+                        .setAllowFlipping(false)
+                        .setOutputUri(Utils.getOutputPicUri(getContext()))
                         .start(getContext(), mFragment);
             }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition_details/NutritionInfoProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition_details/NutritionInfoProductFragment.java
@@ -316,7 +316,10 @@ public class NutritionInfoProductFragment extends BaseFragment {
 
             @Override
             public void onImagesPicked(List<File> imageFiles, EasyImage.ImageSource source, int type) {
-                CropImage.activity(Uri.fromFile(imageFiles.get(0))).setAllowFlipping(false).setOutputUri(Utils.getOutputPicUri(getContext()))
+                CropImage.activity(Uri.fromFile(imageFiles.get(0)))
+                        .setCropMenuCropButtonIcon(R.drawable.ic_check_white_24dp)
+                        .setAllowFlipping(false)
+                        .setOutputUri(Utils.getOutputPicUri(getContext()))
                         .start(getContext(), mFragment);
             }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
@@ -714,7 +714,9 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
 
             @Override
             public void onImagesPicked(List<File> imageFiles, EasyImage.ImageSource source, int type) {
-                CropImage.activity(Uri.fromFile(imageFiles.get(0))).setAllowFlipping(false)
+                CropImage.activity(Uri.fromFile(imageFiles.get(0)))
+                        .setCropMenuCropButtonIcon(R.drawable.ic_check_white_24dp)
+                        .setAllowFlipping(false)
                         .start(getContext(), mFragment);
             }
 


### PR DESCRIPTION
## Description

In the Crop Activity, the "crop" text is now replaced by a logo.

## Related issues and discussion
#1759 
 
 ## Screenshot
 
![screenshot_20180713-234309](https://user-images.githubusercontent.com/5424656/42715626-1ed6b992-86f8-11e8-99f3-251d6131087f.png)

