### PR TITLE
Closes #1808 : Fix android.view.InflateException on pre lollipop devices

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
@@ -190,6 +190,9 @@ public class AddProductOverviewFragment extends BaseFragment {
             String currentLang = LocaleHelper.getLanguage(activity);
             setProductLanguage(currentLang);
             barcode.setText(R.string.txtBarcode);
+            language.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.ic_arrow_drop_down, 0);
+            sectionManufacturingDetails.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.ic_keyboard_arrow_down_grey_24dp, 0);
+            sectionPurchasingDetails.setCompoundDrawablesWithIntrinsicBounds(0, 0, R.drawable.ic_keyboard_arrow_down_grey_24dp, 0);
             if (product != null) {
                 code = product.getCode();
             }

--- a/app/src/main/res/layout/fragment_add_product_overview.xml
+++ b/app/src/main/res/layout/fragment_add_product_overview.xml
@@ -118,8 +118,6 @@
             android:layout_marginRight="@dimen/activity_horizontal_margin"
             android:layout_marginTop="@dimen/spacing_small"
             android:background="@drawable/bg_edittext"
-            android:drawableEnd="@drawable/ic_arrow_drop_down"
-            android:drawableRight="@drawable/ic_arrow_drop_down"
             android:gravity="center_vertical"
             android:paddingLeft="@dimen/spacing_small"
             android:paddingRight="@dimen/spacing_small"
@@ -127,6 +125,8 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/barcode"
+            tools:drawableEnd="@drawable/ic_arrow_drop_down"
+            tools:drawableRight="@drawable/ic_arrow_drop_down"
             tools:text="Product language : English" />
 
         <EditText
@@ -311,12 +311,12 @@
             android:layout_marginLeft="@dimen/activity_horizontal_margin"
             android:layout_marginRight="@dimen/activity_horizontal_margin"
             android:layout_marginTop="@dimen/spacing_small"
-            android:drawableEnd="@drawable/ic_keyboard_arrow_down_grey_24dp"
-            android:drawableRight="@drawable/ic_keyboard_arrow_down_grey_24dp"
             android:text="@string/manufacturing_details"
             android:textColor="#dd0b16"
             android:textStyle="bold"
-            app:layout_constraintTop_toBottomOf="@id/grey_line2" />
+            app:layout_constraintTop_toBottomOf="@id/grey_line2"
+            tools:drawableEnd="@drawable/ic_keyboard_arrow_down_grey_24dp"
+            tools:drawableRight="@drawable/ic_keyboard_arrow_down_grey_24dp" />
 
         <com.hootsuite.nachos.NachoTextView
             android:id="@+id/origin_of_ingredients"
@@ -462,12 +462,12 @@
             android:layout_marginLeft="@dimen/activity_horizontal_margin"
             android:layout_marginRight="@dimen/activity_horizontal_margin"
             android:layout_marginTop="@dimen/spacing_small"
-            android:drawableEnd="@drawable/ic_keyboard_arrow_down_grey_24dp"
-            android:drawableRight="@drawable/ic_keyboard_arrow_down_grey_24dp"
             android:text="@string/purchasing_details"
             android:textColor="#dd0b16"
             android:textStyle="bold"
-            app:layout_constraintTop_toBottomOf="@id/grey_line3" />
+            app:layout_constraintTop_toBottomOf="@id/grey_line3"
+            tools:drawableEnd="@drawable/ic_keyboard_arrow_down_grey_24dp"
+            tools:drawableRight="@drawable/ic_keyboard_arrow_down_grey_24dp" />
 
         <com.hootsuite.nachos.NachoTextView
             android:id="@+id/country_where_purchased"


### PR DESCRIPTION
## Description
- The crash occurred on pre lollipop devices since vector drawable was used in in the XML file (`            android:drawableRight="@drawable/ic_arrow_drop_down"`)
- Removed this line from the XML and added the drawable right in the activity, which fixes this crash.

## Related issues and discussion
Fixes #1808 
 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines.