### PR TITLE
Closes #1753 : Reenable categories for Open Products Facts

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -468,7 +468,6 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         if (BuildConfig.FLAVOR.equals("opf")) {
             result.removeItem(ITEM_ALERT);
             result.removeItem(ITEM_ADVANCED_SEARCH);
-            result.removeItem(ITEM_CATEGORIES);
             result.updateName(ITEM_OBF, new StringHolder(getString(R.string.open_food_drawer)));
         }
 


### PR DESCRIPTION
## Description

Reenable categories for Open Products Facts

## Related issues and discussion
Issue Number: #1753 (Reenable categories for Open Products Facts.)
 
 ## Screen-shots, if any
 
![screenshot_1534090755](https://user-images.githubusercontent.com/32436867/44004239-234a22d8-9e7d-11e8-9905-0478f981a88e.png)
![screenshot_1534090758](https://user-images.githubusercontent.com/32436867/44004240-237f0278-9e7d-11e8-9076-9d77b1e3e412.png)
![screenshot_1534090784](https://user-images.githubusercontent.com/32436867/44004241-23b46c9c-9e7d-11e8-9df3-7d084c10085b.png)



