### PR TITLE
Closes #1854 : Fix product name not displayed in the quick view

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
@@ -314,10 +314,13 @@ public class ContinuousScanActivity extends android.support.v7.app.AppCompatActi
     private void showOfflineSavedDetails(OfflineSavedProduct offlineSavedProduct) {
         showAllViews();
         HashMap<String, String> productDetails = offlineSavedProduct.getProductDetailsMap();
-        if (productDetails.get("product_name") == null || productDetails.get("product_name").equals("")) {
-            name.setText(R.string.productNameNull);
+        String lc = productDetails.get("lang") != null ? productDetails.get("lang") : "en";
+        if (productDetails.get("product_name_" + lc) != null) {
+            name.setText(productDetails.get("product_name_" + lc));
+        } else if (productDetails.get("product_name_en") != null) {
+            name.setText(productDetails.get("product_name_en"));
         } else {
-            name.setText(productDetails.get("product_name"));
+            name.setText(R.string.productNameNull);
         }
         if (productDetails.get("add_brands") == null || productDetails.get("add_brands").equals("")) {
             brand.setText(R.string.productBrandNull);


### PR DESCRIPTION
## Description
- Earlier the product name was saved in the HashMap with key `product_name` but now the key is appended with the language code therefore the key is not fixed now and depends with the product's language. The key can be `product_name_fr` or `product_name_en` depending upon the product's language.
- Since there was no value corresponding to the key `product_name` therefore "Name Unknown" was displayed every time. I have changed the key accordingly by appending the product's language code after the key thus getting the correct value of the product name.

## Related issues and discussion
Fixes #1854 
 
 ## Screen-shots, if any
<kbd>![screenshot_20180824-155624](https://user-images.githubusercontent.com/10832531/44580876-46001900-a7b9-11e8-9b81-81dc74b66999.png)</kbd> <kbd>![screenshot_20180824-155640](https://user-images.githubusercontent.com/10832531/44580899-64661480-a7b9-11e8-9d2d-0f4ad5fbbeda.png) </kbd>

The product name is now displayed in the quick view.
 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines.
