### PR TITLE
Fixes #1864 Encoding error on the Product URL field search function

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
@@ -792,8 +792,9 @@ public class AddProductOverviewFragment extends BaseFragment {
     @OnClick(R.id.hint_link)
     void searchProductLink() {
         String url = "https://www.google.com/search?q=" + code;
-        if (!brand.getText().toString().isEmpty()) {
-            url = url + " " + brand.getText().toString();
+        if (!brand.getChipAndTokenValues().isEmpty()) {
+            List<String> brandNames = brand.getChipAndTokenValues();
+            url = url + " " + StringUtils.join(brandNames, ' ');
         }
         if (!name.getText().toString().isEmpty()) {
             url = url + " " + name.getText().toString();


### PR DESCRIPTION
## Description

The problem was caused by calling getText().toString() on a NachoTextView with chipified text, which would result in special characters that messed up the query. The proper way to get the chipified text is to call NachoTextView.getChipValues().

## Related issues and discussion
Fixes #1864