### PR TITLE
Fixes #1846 The allergen field behaves weirdly

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
@@ -79,7 +79,7 @@ import static org.jsoup.helper.StringUtil.isBlank;
 public class IngredientsProductFragment extends BaseFragment implements IIngredientsProductPresenter.View {
 
     public static final Pattern INGREDIENT_PATTERN = Pattern.compile("[\\p{L}\\p{Nd}(),.-]+");
-    public static final Pattern ALLERGEN_PATTERN = Pattern.compile("[\\p{L}\\p{Nd}]+");
+    public static final Pattern ALLERGEN_PATTERN = Pattern.compile("[\\p{L}\\p{Nd}]+[\\p{L}\\p{Nd}\\p{Z}\\p{P}&&[^,]]*");
     @BindView(R.id.textIngredientProduct)
     TextView ingredientsProduct;
     @BindView(R.id.textSubstanceProduct)
@@ -443,9 +443,9 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
         }
 
         List<String> list = new ArrayList<>();
-        Matcher m = ALLERGEN_PATTERN.matcher(mState.getProduct().getAllergens().replace(",", ""));
+        Matcher m = ALLERGEN_PATTERN.matcher(mState.getProduct().getAllergens());
         while (m.find()) {
-            final String tma = m.group();
+            final String tma = m.group().trim();
             boolean canAdd = true;
 
             for (String allergen : list) {


### PR DESCRIPTION
## Description

The weird behaviour of allergen field was caused by improper regex matching of allergen names, which caused issues with allergens with multi-part names and improper spacing. For example the matching result for "lécithine de soja, blé" was ["lécithine ", "de ", "soja", "blé" ].

I've modified the regex to take this into consideration and to use commas a delimiters.

## Related issues and discussion
Fixes #1846
 
 ## Screen-shots, if any
![image](https://user-images.githubusercontent.com/2354602/45276412-fa1ac880-b476-11e8-828c-6e8b63ff06ad.png)
