### PR TITLE
Fixes for Share to Open Food Facts

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -535,6 +535,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
             apiClient.syncOldHistory();
         }
 
+        handleIntent(getIntent());
     }
 
     private void scan() {
@@ -767,6 +768,10 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
 
     @Override
     protected void onNewIntent(Intent intent) {
+        handleIntent(intent);
+    }
+
+    private void handleIntent(Intent intent) {
         String type = intent.getType();
         if (Intent.ACTION_SEARCH.equals(intent.getAction())) {
             Log.e("INTENT", "start activity");

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -28,6 +28,8 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.SearchView;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
@@ -36,7 +38,6 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.EditText;
-import android.widget.ImageView;
 import android.widget.Toast;
 
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -93,6 +94,7 @@ import openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener;
 import openfoodfacts.github.scrachx.openfood.utils.SearchType;
 import openfoodfacts.github.scrachx.openfood.utils.ShakeDetector;
 import openfoodfacts.github.scrachx.openfood.utils.Utils;
+import openfoodfacts.github.scrachx.openfood.views.adapters.PhotosAdapter;
 import openfoodfacts.github.scrachx.openfood.views.category.activity.CategoryActivity;
 import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabActivityHelper;
 import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabsHelper;
@@ -955,12 +957,14 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         alertDialogBuilder.setView(dialogView);
 
         final EditText barcode_edittext = dialogView.findViewById(R.id.barcode);
-        final ImageView product_image = dialogView.findViewById(R.id.product_image);
+        final RecyclerView product_images = dialogView.findViewById(R.id.product_image);
+        LinearLayoutManager layoutManager
+                = new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false);
+        product_images.setLayoutManager(layoutManager);
+        product_images.setAdapter(new PhotosAdapter( uri));
 
-        product_image.setImageURI(uri.get(0));
         if (hasEditText) {
             barcode_edittext.setVisibility(View.VISIBLE);
-            product_image.setVisibility(View.VISIBLE);
             alertDialogBuilder.setTitle(getString(R.string.no_barcode));
             alertDialogBuilder.setMessage(getString(R.string.enter_barcode));
         } else {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/PhotosAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/PhotosAdapter.java
@@ -3,6 +3,7 @@ package openfoodfacts.github.scrachx.openfood.views.adapters;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/PhotosAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/PhotosAdapter.java
@@ -1,0 +1,60 @@
+package openfoodfacts.github.scrachx.openfood.views.adapters;
+
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+
+import com.squareup.picasso.Picasso;
+
+import java.util.List;
+
+import openfoodfacts.github.scrachx.openfood.R;
+
+public class PhotosAdapter extends RecyclerView.Adapter<PhotosAdapter.ViewHolder> {
+
+    private List<Uri> mPhotos;
+
+    public PhotosAdapter(List<Uri> mPhotos) {
+        this.mPhotos = mPhotos;
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        ImageView photo =
+                (ImageView) LayoutInflater.from(parent.getContext())
+                                          .inflate(R.layout.dialog_photo_item, parent, false);
+        return new PhotosAdapter.ViewHolder(photo);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        ImageView imageView = holder.getImageView();
+
+        Picasso.with(imageView.getContext())
+               .load(mPhotos.get(position))
+               .placeholder(R.drawable.placeholder_thumb)
+               .error(R.drawable.error_image)
+               .into(imageView);
+    }
+
+    @Override
+    public int getItemCount() {
+        return mPhotos.size();
+    }
+
+    static class ViewHolder extends RecyclerView.ViewHolder {
+
+        public ViewHolder(View itemView) {
+            super(itemView);
+        }
+
+        ImageView getImageView() {
+            return (ImageView) itemView;
+        }
+    }
+}

--- a/app/src/main/res/layout/alert_barcode.xml
+++ b/app/src/main/res/layout/alert_barcode.xml
@@ -1,28 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical" android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
 
-    <ImageView
+    <android.support.v7.widget.RecyclerView
         android:id="@+id/product_image"
         android:layout_width="@dimen/product_width"
         android:layout_height="@dimen/product_height"
         android:layout_gravity="center_horizontal"
-        android:layout_margin="@dimen/spacing_small"
-        android:visibility="gone"
-        />
+        android:scrollbars="horizontal"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:layout_marginBottom="@dimen/spacing_small"/>
+
     <EditText
         android:id="@+id/barcode"
         android:layout_width="fill_parent"
         android:layout_height="50dp"
-        android:padding="10dp"
-        android:visibility="gone"
         android:layout_gravity="center_horizontal"
-        android:textSize="@dimen/font_normal"
         android:inputType="number"
-        />
-
-
+        android:padding="10dp"
+        android:textSize="@dimen/font_normal"
+        android:visibility="gone" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_photo_item.xml
+++ b/app/src/main/res/layout/dialog_photo_item.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ImageView
+<com.github.chrisbanes.photoview.PhotoView
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="@dimen/photo_width"
     android:layout_height="@dimen/photo_height"
     android:layout_margin="@dimen/spacing_small">
-</ImageView>
+</com.github.chrisbanes.photoview.PhotoView>

--- a/app/src/main/res/layout/dialog_photo_item.xml
+++ b/app/src/main/res/layout/dialog_photo_item.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="@dimen/photo_width"
+    android:layout_height="@dimen/photo_height"
+    android:layout_margin="@dimen/spacing_small">
+</ImageView>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -60,4 +60,6 @@
     <!--- AlertDialog ProductImage -->
     <dimen name="product_height">200dp</dimen>
     <dimen name="product_width">250dp</dimen>
+    <dimen name="photo_height">180dp</dimen>
+    <dimen name="photo_width">180dp</dimen>
 </resources>


### PR DESCRIPTION
## Description
Added horizontal scrolling recycler view for viewing images shared to off. Photos are shown for both detected and undetected barcode. Fixed bug where sharing to open food facts would fail silently on cold launch of app (maybe fixes #1518 / #1599?)

## Related issues and discussion
#1625 
#1599
#1518
#1520 
 
 ## Screen-shots, if any
![image](https://user-images.githubusercontent.com/2354602/45424728-3fdcba00-b64c-11e8-860d-2259b0ce72fe.png)


