### PR TITLE
Fixes #1874: Additives don't display in certain conditions

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductPresenter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductPresenter.java
@@ -47,9 +47,9 @@ public class IngredientsProductPresenter implements IIngredientsProductPresenter
                                     }))
                             .filter(additiveName -> additiveName.isNotNull())
                             .toList()
-                            .doOnSubscribe(d -> view.showAdditivesState(ProductInfoState.LOADING))
                             .subscribeOn(Schedulers.io())
                             .observeOn(AndroidSchedulers.mainThread())
+                            .doOnSubscribe(d -> view.showAdditivesState(ProductInfoState.LOADING))
                             .subscribe(additives -> {
                                 if (additives.isEmpty()) {
                                     view.showAdditivesState(ProductInfoState.EMPTY);


### PR DESCRIPTION
## Description
Caused by trying to modify the view in a background thread. Moved RxJava call to .doOnSubscribe(...) to be called on the main thread. For some reason, the exception only sometimes propagated to RxJava callbacks (maybe depends on device, version, dev mode?).

## Related issues and discussion
Fixes #1874
 
 ## Screen-shots
![image](https://user-images.githubusercontent.com/2354602/45462105-3b9bb580-b6bb-11e8-81aa-ffa3371436be.png)

