### PR TITLE
Possible Fix for #1722: MaterialDialog$DialogException: at openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient$1.a (OpenFoodAPIClient.java:59)

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIClient.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIClient.java
@@ -132,16 +132,17 @@ public class OpenFoodAPIClient {
                             .positiveText(R.string.txtYes)
                             .negativeText(R.string.txtNo)
                             .onPositive((dialog, which) -> {
-                                Intent intent = new Intent(activity, AddProductActivity.class);
-                                State st = new State();
-                                Product pd = new Product();
-                                pd.setCode(barcode);
-                                st.setProduct(pd);
-                                intent.putExtra("state", st);
-                                activity.startActivity(intent);
-                                activity.finish();
+                                if (!activity.isFinishing()) {
+                                    Intent intent = new Intent(activity, AddProductActivity.class);
+                                    State st = new State();
+                                    Product pd = new Product();
+                                    pd.setCode(barcode);
+                                    st.setProduct(pd);
+                                    intent.putExtra("state", st);
+                                    activity.startActivity(intent);
+                                    activity.finish();
+                                }
                             })
-                            .onNegative((dialog, which) -> activity.onBackPressed())
                             .show();
                 } else {
                     new HistoryTask().doInBackground(s.getProduct());
@@ -155,22 +156,28 @@ public class OpenFoodAPIClient {
 
             @Override
             public void onFailure(@NonNull Call<State> call, @NonNull Throwable t) {
+
+                if (activity == null || activity.isFinishing()) {
+                    return;
+                }
+
                 new MaterialDialog.Builder(activity)
                         .title(R.string.txtDialogsTitle)
                         .content(R.string.txtDialogsContent)
                         .positiveText(R.string.txtYes)
                         .negativeText(R.string.txtNo)
                         .onPositive((dialog, which) -> {
-                            Intent intent = new Intent(activity, AddProductActivity.class);
-                            State st = new State();
-                            Product pd = new Product();
-                            pd.setCode(barcode);
-                            st.setProduct(pd);
-                            intent.putExtra("state", st);
-                            activity.startActivity(intent);
-                            activity.finish();
+                            if (!activity.isFinishing()) {
+                                Intent intent = new Intent(activity, AddProductActivity.class);
+                                State st = new State();
+                                Product pd = new Product();
+                                pd.setCode(barcode);
+                                st.setProduct(pd);
+                                intent.putExtra("state", st);
+                                activity.startActivity(intent);
+                                activity.finish();
+                            }
                         })
-                        .onNegative((dialog, which) -> activity.onBackPressed())
                         .show();
             }
         });


### PR DESCRIPTION
## Description
DialogException is caused by using MaterialDialog with an "invalid activity" (i.e. null, destroyed, finishing). Added some checks to hopefully prevent this. 

Also, there are some errors with the callback ` .onNegative((dialog, which) -> activity.onBackPressed())`, which occurs when there are many subsequent calls to `OpenFoodApiClient.getProduct()` that show a MaterialDialog. 

## Related issues and discussion
#1722
 
