### PR TITLE
Closes 1844: We are also not displaying the nutrient modifiers in the product view (< > ~)

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/HeaderNutrimentItem.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/HeaderNutrimentItem.java
@@ -1,5 +1,7 @@
 package openfoodfacts.github.scrachx.openfood.models;
 
+import android.support.annotation.NonNull;
+
 import static openfoodfacts.github.scrachx.openfood.utils.Utils.bold;
 
 /**
@@ -13,8 +15,10 @@ public class HeaderNutrimentItem extends NutrimentItem {
      * @param servingValue
      * @param unit
      */
-    public HeaderNutrimentItem(CharSequence title, CharSequence value, CharSequence servingValue, CharSequence unit) {
-        super(bold(title), bold(value), bold(servingValue), bold(unit));
+    public HeaderNutrimentItem(@NonNull CharSequence title, @NonNull CharSequence value,
+                               @NonNull CharSequence servingValue, @NonNull CharSequence unit,
+                               @NonNull CharSequence modifier) {
+        super(bold(title), bold(value), bold(servingValue), bold(unit), bold(modifier));
     }
 
 
@@ -22,7 +26,7 @@ public class HeaderNutrimentItem extends NutrimentItem {
      * Header with only bold title
      * @param title
      */
-    public HeaderNutrimentItem(CharSequence title) {
-        super(bold(title), "", "", "");
+    public HeaderNutrimentItem(@NonNull CharSequence title) {
+        super(bold(title), "", "", "", "");
     }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/NutrimentItem.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/NutrimentItem.java
@@ -8,26 +8,35 @@ public class NutrimentItem {
     private final CharSequence value;
     private final CharSequence servingValue;
     private final CharSequence unit;
+    private final CharSequence modifier;
 
-    public NutrimentItem(CharSequence title, CharSequence value, CharSequence servingValue, CharSequence unit){
+    /**
+     * @see #NutrimentItem(String, String, String, String, String)
+     */
+    public NutrimentItem(CharSequence title, CharSequence value, CharSequence servingValue,
+                         CharSequence unit, CharSequence modifier) {
         this.title = title;
         this.value = value;
         this.servingValue = servingValue;
         this.unit = unit;
+        this.modifier = modifier;
     }
 
     /**
      * Use a round value for value and servingValue parameters
-     * @param title
-     * @param value
-     * @param servingValue
-     * @param unit
+     * @param title name of nutriment
+     * @param value value of nutriment per 100g
+     * @param servingValue value of nutriment per serving
+     * @param unit unit of nutriment
+     * @param modifier one of the following: "<", ">", or "~"
      */
-    public NutrimentItem( String title, String value, String servingValue, String unit){
+    public NutrimentItem( String title, String value, String servingValue, String unit,
+                          String modifier){
         this.title = title;
         this.value = getRoundNumber(value);
         this.servingValue = getRoundNumber(servingValue);
         this.unit = unit;
+        this.modifier = modifier;
     }
 
     public CharSequence getTitle() {
@@ -36,6 +45,15 @@ public class NutrimentItem {
 
     public CharSequence getValue() {
         return value;
+    }
+
+    /**
+     * Get the modifier for this nutriment.
+     *
+     * @return one of the following: "<", ">", "~", ""
+     */
+    public CharSequence getModifier() {
+        return modifier == null ? "" : modifier;
     }
 
     public CharSequence getUnit() {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/Nutriments.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/Nutriments.java
@@ -1,5 +1,6 @@
 package openfoodfacts.github.scrachx.openfood.models;
 
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
@@ -234,6 +235,7 @@ public class Nutriments implements Serializable {
         return null;
     }
 
+    @Nullable
     public String getModifier(String nutrimentName) {
         if (additionalProperties.get(nutrimentName + "_modifier") != null) {
             return additionalProperties.get(nutrimentName + "_modifier").toString();

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/CalculateAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/CalculateAdapter.java
@@ -51,10 +51,12 @@ public class CalculateAdapter extends RecyclerView.Adapter {
         NutrimentViewHolder nutrimentViewHolder = (NutrimentViewHolder) holder;
 
         nutrimentViewHolder.vNutrimentName.setText(item.getTitle());
+        nutrimentViewHolder.vNutrimentValue.append(item.getModifier());
         nutrimentViewHolder.vNutrimentValue.append(item.getValue());
         nutrimentViewHolder.vNutrimentValue.append(" ");
         nutrimentViewHolder.vNutrimentValue.append(item.getUnit());
 
+        nutrimentViewHolder.vNutrimentServingValue.append(item.getModifier());
         nutrimentViewHolder.vNutrimentServingValue.append(item.getServingValue());
         nutrimentViewHolder.vNutrimentServingValue.append(" ");
         nutrimentViewHolder.vNutrimentServingValue.append(item.getUnit());

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/NutrimentsRecyclerViewAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/NutrimentsRecyclerViewAdapter.java
@@ -47,10 +47,12 @@ public class NutrimentsRecyclerViewAdapter extends RecyclerView.Adapter {
         NutrimentViewHolder nutrimentViewHolder = (NutrimentViewHolder) holder;
 
         nutrimentViewHolder.vNutrimentName.setText(item.getTitle());
+        nutrimentViewHolder.vNutrimentValue.append(item.getModifier());
         nutrimentViewHolder.vNutrimentValue.append(item.getValue());
         nutrimentViewHolder.vNutrimentValue.append(" ");
         nutrimentViewHolder.vNutrimentValue.append(item.getUnit());
 
+        nutrimentViewHolder.vNutrimentServingValue.append(item.getModifier());
         nutrimentViewHolder.vNutrimentServingValue.append(item.getServingValue());
         nutrimentViewHolder.vNutrimentServingValue.append(" ");
         nutrimentViewHolder.vNutrimentServingValue.append(item.getUnit());

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/CalculateDetails.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/CalculateDetails.java
@@ -2,25 +2,14 @@ package openfoodfacts.github.scrachx.openfood.views.product;
 
 import android.content.Intent;
 import android.content.pm.ActivityInfo;
-import android.net.Uri;
 import android.os.Bundle;
-import android.support.customtabs.CustomTabsIntent;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
-import android.text.TextUtils;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.view.View;
-import android.widget.AdapterView;
-import android.widget.Button;
-import android.widget.EditText;
-import android.widget.Spinner;
 import android.widget.TextView;
-import android.widget.Toast;
-
-import com.afollestad.materialdialogs.MaterialDialog;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,10 +25,6 @@ import openfoodfacts.github.scrachx.openfood.models.Product;
 import openfoodfacts.github.scrachx.openfood.utils.Utils;
 import openfoodfacts.github.scrachx.openfood.views.BaseActivity;
 import openfoodfacts.github.scrachx.openfood.views.adapters.CalculateAdapter;
-import openfoodfacts.github.scrachx.openfood.views.adapters.NutrimentsRecyclerViewAdapter;
-import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabActivityHelper;
-import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabsHelper;
-import openfoodfacts.github.scrachx.openfood.views.customtabs.WebViewFallback;
 
 import static android.support.v7.widget.DividerItemDecoration.VERTICAL;
 import static openfoodfacts.github.scrachx.openfood.models.Nutriments.CARBOHYDRATES;
@@ -98,18 +83,28 @@ public class CalculateDetails extends BaseActivity {
         nutrimentsRecyclerView.addItemDecoration(dividerItemDecoration);
 
         // Header hack
-        nutrimentItems.add(new NutrimentItem(null, null, null, null));
+        nutrimentItems.add(new NutrimentItem(null, null, null,
+                                             null, null));
 
         // Energy
         Nutriments.Nutriment energy = nutriments.get(ENERGY);
         if (energy != null) {
-            nutrimentItems.add(new NutrimentItem(getString(R.string.nutrition_energy_short_name), calculateCalories(value, spinnervalue), Utils.getEnergy(energy.getForServing()), "kcal"));
+            nutrimentItems.add(new NutrimentItem(getString(R.string.nutrition_energy_short_name),
+                                                 calculateCalories(value, spinnervalue),
+                                                 Utils.getEnergy(energy.getForServing()),
+                                                 "kcal",
+                                                 nutriments.getModifier(ENERGY)));
         }
 
         // Fat
         Nutriments.Nutriment fat = nutriments.get(FAT);
         if (fat != null) {
-            nutrimentItems.add(new HeaderNutrimentItem(getString(R.string.nutrition_fat), fat.getforanyvalue(value, spinnervalue), fat.getForServing(), fat.getUnit()));
+            String modifier = nutriments.getModifier(FAT);
+            nutrimentItems.add(new HeaderNutrimentItem(getString(R.string.nutrition_fat),
+                                                       fat.getforanyvalue(value, spinnervalue),
+                                                       fat.getForServing(),
+                                                       fat.getUnit(),
+                                                       modifier == null ? "" : modifier));
 
             nutrimentItems.addAll(getNutrimentItems(nutriments, FAT_MAP));
         }
@@ -117,10 +112,13 @@ public class CalculateDetails extends BaseActivity {
         // Carbohydrates
         Nutriments.Nutriment carbohydrates = nutriments.get(CARBOHYDRATES);
         if (carbohydrates != null) {
+            String modifier = nutriments.getModifier(CARBOHYDRATES);
             nutrimentItems.add(new HeaderNutrimentItem(getString(R.string.nutrition_carbohydrate),
-                    carbohydrates.getforanyvalue(value, spinnervalue),
-                    carbohydrates.getForServing(),
-                    carbohydrates.getUnit()));
+                                                       carbohydrates.getforanyvalue(value,
+                                                                                    spinnervalue),
+                                                       carbohydrates.getForServing(),
+                                                       carbohydrates.getUnit(),
+                                                       modifier == null ? "" : modifier));
 
             nutrimentItems.addAll(getNutrimentItems(nutriments, CARBO_MAP));
         }
@@ -131,10 +129,13 @@ public class CalculateDetails extends BaseActivity {
         // Proteins
         Nutriments.Nutriment proteins = nutriments.get(PROTEINS);
         if (proteins != null) {
-            nutrimentItems.add(new HeaderNutrimentItem(getString(R.string.nutrition_proteins),
-                    proteins.getforanyvalue(value, spinnervalue),
-                    proteins.getForServing(),
-                    proteins.getUnit()));
+            String modifier = nutriments.getModifier(PROTEINS);
+            nutrimentItems.add(
+                    new HeaderNutrimentItem(getString(R.string.nutrition_proteins),
+                                            proteins.getforanyvalue(value, spinnervalue),
+                                            proteins.getForServing(),
+                                            proteins.getUnit(),
+                                            modifier == null ? "" : modifier));
 
             nutrimentItems.addAll(getNutrimentItems(nutriments, PROT_MAP));
         }
@@ -171,7 +172,10 @@ public class CalculateDetails extends BaseActivity {
             Nutriments.Nutriment nutriment = nutriments.get(entry.getKey());
             if (nutriment != null) {
                 items.add(new NutrimentItem(getString(entry.getValue()),
-                        nutriment.getforanyvalue(value, spinnervalue), nutriment.getForServing(), nutriment.getUnit()));
+                                            nutriment.getforanyvalue(value, spinnervalue),
+                                            nutriment.getForServing(),
+                                            nutriment.getUnit(),
+                                            nutriments.getModifier(entry.getKey())));
             }
         }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/CalculateDetails.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/CalculateDetails.java
@@ -114,8 +114,7 @@ public class CalculateDetails extends BaseActivity {
         if (carbohydrates != null) {
             String modifier = nutriments.getModifier(CARBOHYDRATES);
             nutrimentItems.add(new HeaderNutrimentItem(getString(R.string.nutrition_carbohydrate),
-                                                       carbohydrates.getforanyvalue(value,
-                                                                                    spinnervalue),
+                                                       carbohydrates.getforanyvalue(value, spinnervalue),
                                                        carbohydrates.getForServing(),
                                                        carbohydrates.getUnit(),
                                                        modifier == null ? "" : modifier));

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition/NutritionProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition/NutritionProductFragment.java
@@ -100,28 +100,46 @@ public class NutritionProductFragment extends BaseFragment implements CustomTabA
             Nutriments.Nutriment fatNutriment = nutriments.get(Nutriments.FAT);
             if (fat != null && fatNutriment != null) {
                 String fatNutrimentLevel = fat.getLocalize(context);
-                levelItem.add(new NutrientLevelItem(getString(R.string.txtFat), getRoundNumber(fatNutriment.getFor100g()) + " " + fatNutriment.getUnit(), fatNutrimentLevel, fat.getImageLevel()));
+                String modifier = nutriments.getModifier(Nutriments.FAT);
+                levelItem.add(new NutrientLevelItem(getString(R.string.txtFat),
+                                                    (modifier == null ? "" : modifier)
+                                                            + getRoundNumber(fatNutriment.getFor100g())
+                                                            + " " + fatNutriment.getUnit(),
+                                                    fatNutrimentLevel,
+                                                    fat.getImageLevel()));
             }
 
             Nutriments.Nutriment saturatedFatNutriment = nutriments.get(Nutriments.SATURATED_FAT);
             if (saturatedFat != null && saturatedFatNutriment != null) {
                 String saturatedFatLocalize = saturatedFat.getLocalize(context);
                 String saturatedFatValue = getRoundNumber(saturatedFatNutriment.getFor100g()) + " " + saturatedFatNutriment.getUnit();
-                levelItem.add(new NutrientLevelItem(getString(R.string.txtSaturatedFat), saturatedFatValue, saturatedFatLocalize, saturatedFat.getImageLevel()));
+                String modifier = nutriments.getModifier(Nutriments.SATURATED_FAT);
+                levelItem.add(new NutrientLevelItem(getString(R.string.txtSaturatedFat),
+                                                    (modifier == null ? "" : modifier) + saturatedFatValue,
+                                                    saturatedFatLocalize,
+                                                    saturatedFat.getImageLevel()));
             }
 
             Nutriments.Nutriment sugarsNutriment = nutriments.get(Nutriments.SUGARS);
             if (sugars != null && sugarsNutriment  != null) {
                 String sugarsLocalize = sugars.getLocalize(context);
                 String sugarsValue = getRoundNumber(sugarsNutriment.getFor100g()) + " " + sugarsNutriment.getUnit();
-                levelItem.add(new NutrientLevelItem(getString(R.string.txtSugars), sugarsValue, sugarsLocalize, sugars.getImageLevel()));
+                String modifier = nutriments.getModifier(Nutriments.SUGARS);
+                levelItem.add(new NutrientLevelItem(getString(R.string.txtSugars),
+                                                    (modifier == null ? "" : modifier) + sugarsValue,
+                                                    sugarsLocalize,
+                                                    sugars.getImageLevel()));
             }
 
             Nutriments.Nutriment saltNutriment = nutriments.get(Nutriments.SALT);
             if (salt != null && saltNutriment != null) {
                 String saltLocalize = salt.getLocalize(context);
                 String saltValue = getRoundNumber(saltNutriment.getFor100g()) + " " + saltNutriment.getUnit();
-                levelItem.add(new NutrientLevelItem(getString(R.string.txtSalt), saltValue, saltLocalize, salt.getImageLevel()));
+                String modifier = nutriments.getModifier(Nutriments.SALT);
+                levelItem.add(new NutrientLevelItem(getString(R.string.txtSalt),
+                                                    (modifier == null ? "" : modifier) + saltValue,
+                                                    saltLocalize,
+                                                    salt.getImageLevel()));
             }
 
             img.setImageDrawable(ContextCompat.getDrawable(context, Utils.getImageGrade(product.getNutritionGradeFr())));

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition_details/NutritionInfoProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition_details/NutritionInfoProductFragment.java
@@ -184,8 +184,7 @@ public class NutritionInfoProductFragment extends BaseFragment {
             nutrimentItems.add(
                     new NutrimentItem(getString(R.string.nutrition_energy_short_name),
                                       Utils.getEnergy(energy.getFor100g()),
-                                      Utils.getEnergy(energy
-                                                              .getForServing()),
+                                      Utils.getEnergy(energy.getForServing()),
                                       "kcal",
                                       nutriments.getModifier(ENERGY)));
         }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition_details/NutritionInfoProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition_details/NutritionInfoProductFragment.java
@@ -176,19 +176,29 @@ public class NutritionInfoProductFragment extends BaseFragment {
         nutrimentsRecyclerView.addItemDecoration(dividerItemDecoration);
 
         // Header hack
-        nutrimentItems.add(new NutrimentItem(null, null, null, null));
+        nutrimentItems.add(new NutrimentItem(null, null, null, null, null));
 
         // Energy
         Nutriment energy = nutriments.get(ENERGY);
         if (energy != null) {
-            nutrimentItems.add(new NutrimentItem(getString(R.string.nutrition_energy_short_name), Utils.getEnergy(energy.getFor100g()), Utils.getEnergy(energy
-                    .getForServing()), "kcal"));
+            nutrimentItems.add(
+                    new NutrimentItem(getString(R.string.nutrition_energy_short_name),
+                                      Utils.getEnergy(energy.getFor100g()),
+                                      Utils.getEnergy(energy
+                                                              .getForServing()),
+                                      "kcal",
+                                      nutriments.getModifier(ENERGY)));
         }
 
         // Fat        
         Nutriment fat = nutriments.get(FAT);
         if (fat != null) {
-            nutrimentItems.add(new HeaderNutrimentItem(getString(R.string.nutrition_fat), fat.getFor100g(), fat.getForServing(), fat.getUnit()));
+            String modifier = nutriments.getModifier(FAT);
+            nutrimentItems.add(new HeaderNutrimentItem(getString(R.string.nutrition_fat),
+                                                       fat.getFor100g(),
+                                                       fat.getForServing(),
+                                                       fat.getUnit(),
+                                                       modifier == null ? "" : modifier));
 
             nutrimentItems.addAll(getNutrimentItems(nutriments, FAT_MAP));
         }
@@ -196,10 +206,12 @@ public class NutritionInfoProductFragment extends BaseFragment {
         // Carbohydrates
         Nutriment carbohydrates = nutriments.get(CARBOHYDRATES);
         if (carbohydrates != null) {
+            String modifier = nutriments.getModifier(CARBOHYDRATES);
             nutrimentItems.add(new HeaderNutrimentItem(getString(R.string.nutrition_carbohydrate),
-                    carbohydrates.getFor100g(),
-                    carbohydrates.getForServing(),
-                    carbohydrates.getUnit()));
+                                                       carbohydrates.getFor100g(),
+                                                       carbohydrates.getForServing(),
+                                                       carbohydrates.getUnit(),
+                                                       modifier == null ? "" : modifier));
 
             nutrimentItems.addAll(getNutrimentItems(nutriments, CARBO_MAP));
         }
@@ -210,10 +222,12 @@ public class NutritionInfoProductFragment extends BaseFragment {
         // Proteins
         Nutriment proteins = nutriments.get(PROTEINS);
         if (proteins != null) {
+            String modifier = nutriments.getModifier(PROTEINS);
             nutrimentItems.add(new HeaderNutrimentItem(getString(R.string.nutrition_proteins),
-                    proteins.getFor100g(),
-                    proteins.getForServing(),
-                    proteins.getUnit()));
+                                                       proteins.getFor100g(),
+                                                       proteins.getForServing(),
+                                                       proteins.getUnit(),
+                                                       modifier == null ? "" : modifier));
 
             nutrimentItems.addAll(getNutrimentItems(nutriments, PROT_MAP));
         }
@@ -249,7 +263,10 @@ public class NutritionInfoProductFragment extends BaseFragment {
             Nutriment nutriment = nutriments.get(entry.getKey());
             if (nutriment != null) {
                 items.add(new NutrimentItem(getString(entry.getValue()),
-                        nutriment.getFor100g(), nutriment.getForServing(), nutriment.getUnit()));
+                                            nutriment.getFor100g(),
+                                            nutriment.getForServing(),
+                                            nutriment.getUnit(),
+                                            nutriments.getModifier(entry.getKey())));
             }
         }
 


### PR DESCRIPTION
## Description
Added support for displaying modifiers (<, >, ~) for applicable nutrients in the product view (in the Nutrition Tab, Nutrition Facts tab, and the Calculated Nutrition Facts view).

## Related issues and discussion
#1844
 
 ## Screen-shots, if any
![image](https://user-images.githubusercontent.com/2354602/45608169-23eb6680-ba06-11e8-84f4-dee01c567c55.png)![image](https://user-images.githubusercontent.com/2354602/45608177-3bc2ea80-ba06-11e8-9de5-52e970268847.png)![image](https://user-images.githubusercontent.com/2354602/45608182-454c5280-ba06-11e8-9362-6e5e76c6b58c.png)
