### PR TITLE
Closes #1907 Fix network error on clicking an empty category

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIClient.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIClient.java
@@ -808,12 +808,7 @@ public class OpenFoodAPIClient {
                 }
 
                 if (response.isSuccessful()) {
-
-                    if (Integer.valueOf(response.body().getCount()) == 0) {
-                        onCategoryCallback.onCategoryResponse(false, null);
-                    } else {
-                        onCategoryCallback.onCategoryResponse(true, response.body());
-                    }
+                    onCategoryCallback.onCategoryResponse(true, response.body());
                 }
 
 

--- a/app/src/main/res/layout/activity_brand.xml
+++ b/app/src/main/res/layout/activity_brand.xml
@@ -32,8 +32,7 @@
         <android.support.v4.widget.SwipeRefreshLayout
             android:id="@+id/swipe_refresh"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_below="@id/textCountProduct">
+            android:layout_height="match_parent">
 
             <android.support.v7.widget.RecyclerView
                 android:id="@+id/products_recycler_view"
@@ -106,8 +105,9 @@
 
     <LinearLayout
         android:id="@+id/noResultsLayout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_margin="@dimen/activity_horizontal_margin"
         android:gravity="center"
         android:orientation="vertical"
         android:visibility="invisible"
@@ -120,6 +120,8 @@
             android:id="@+id/textNoResults"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:paddingEnd="@dimen/padding_too_short"
+            android:paddingStart="@dimen/padding_too_short"
             android:text="@string/txt_no_matching_products"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:textColor="@color/grey_500"
@@ -130,6 +132,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/materialize_typography_subheading"
+            android:paddingEnd="@dimen/padding_too_short"
+            android:paddingStart="@dimen/padding_too_short"
             android:text="@string/txt_broaden_search"
             android:textAppearance="?android:attr/textAppearanceMedium"
             android:textColor="@color/grey_500"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -485,6 +485,7 @@
     <string name="number_of_products">Number of products: </string>
     <string name="txt_no_results">No results found</string>
     <string name="txt_extend_search">Try broadening your search or add the product</string>
+    <string name="txt_no_matching__category_products">Oh no, we don’t have any product in this category, can you add one?</string>
     <string name="txt_no_matching_products">We haven\'t found any matching products.\nYou can try :</string>
     <string name="txt_broaden_search">- broadening your search \n- scan and add it to Open Food Facts</string>
     <string name="txt_cant_load_search_results">Can\'t load search results</string>


### PR DESCRIPTION
## Description
- Checked the count of the obtained results. If it is zero then display "no products found" layout instead of "no network layout".
- Also fixed a NPE which occurred when the category name was not found in the db, it resulted in NPE when trying to search for the tag belonging to that null category.

## Related issues and discussion
Fixes #1907 
 
 ## Screen-shots, if any
<kbd>![screenshot_20180921-004420](https://user-images.githubusercontent.com/10832531/45842108-5ca67b00-bd39-11e8-876a-3c0bc39ab1c0.png)</kbd>

 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines.
