### PR TITLE
Closes #1924 : NullPointerException at AddProductOverviewFragment.

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
@@ -848,7 +848,7 @@ public class AddProductOverviewFragment extends BaseFragment {
 
     public boolean areRequiredFieldsEmpty() {
         if (mImageUrl == null || mImageUrl.equals("")) {
-            Toast.makeText(activity, R.string.add_at_least_one_picture, Toast.LENGTH_SHORT).show();
+            Toast.makeText(activity.getApplicationContext(), R.string.add_at_least_one_picture, Toast.LENGTH_SHORT).show();
             scrollView.fullScroll(View.FOCUS_UP);
             return true;
         } else {


### PR DESCRIPTION
## Description
While making toast the activity context is used which was creating the NullPointerException. As the activity is pushed to the background, the system may have killed the activity to reclaim memory for other foreground or visible process. And when the user navigates back to the activity (making it visible on the screen again), its onCreate(Bundle) method will be called with the savedInstanceState it had previously supplied in onSaveInstanceState(Bundle) so that it can restart itself in the same state as the user last left it, which I think may result in activityContext to be null. And as the AppProductActivity is a long living process activityContext may result in memory leak. So I replaced the activityContext with the applicationContext(). 

## Related issues and discussion
#1924 NullPointerException at AddProductOverviewFragment.