### PR TITLE
Closes #1954 Fix crash on navigating back from search by barcode

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
@@ -54,7 +54,6 @@ public class HomeFragment extends NavigationBaseFragment {
     TextView textHome;
 
     private OpenFoodAPIService apiClient;
-    private SharedPreferences.Editor editor;
     private SharedPreferences sp;
 
     @Override
@@ -167,6 +166,7 @@ public class HomeFragment extends NavigationBaseFragment {
 
                     @Override
                     public void onSuccess(Search search) {
+                        SharedPreferences.Editor editor;
                         int totalProductCount = Integer.parseInt(search.getCount());
                         textHome.setText(String.format(txtHomeOnline, totalProductCount));
                         editor = sp.edit();

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIService.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIService.java
@@ -336,7 +336,7 @@ public interface OpenFoodAPIService {
     @GET("state/to-be-completed/{page}.json")
     Call<Search> getIncompleteProducts(@Path("page") int page);
 
-    @GET("/1.json")
-    Call<Search> getTotalProductCount();
+    @GET("/1.json?fields=null")
+    Single<Search> getTotalProductCount();
 }
 


### PR DESCRIPTION
## Description
- Used `OFFApplication.getInstance()` to get the string resource to prevent crash.
- Removed lint warnings from the `HomeFragment.java`.
- Changed the endpoint of getting the total products count from `/1.json` to `/1.json?fields=null` and thus reducing the size of the json from **354.5 kB (3,54,485 bytes)** to **124 bytes**.
- Also cache the total products count and use it in the absence of internet connection.

## Related issues and discussion
Fixes #1954 
Probably Fixes #1943
 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines.
