### PR TITLE
Always a network error is displayed in case of any errors in editing a product

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/AddProductActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/AddProductActivity.java
@@ -930,17 +930,37 @@ public class AddProductActivity extends AppCompatActivity {
                     @Override
                     public void onError(Throwable e) {
                         dialog.dismiss();
-                        if (!edit_product) {
-                            saveProductOffline();
-                        } else {
-                            MaterialDialog.Builder builder = new MaterialDialog.Builder(AddProductActivity.this)
-                                    .title(R.string.device_offline_dialog_title)
-                                    .positiveText(R.string.txt_try_again)
-                                    .negativeText(R.string.dialog_cancel)
-                                    .onPositive((dialog, which) -> checkFrontImageUploadStatus())
-                                    .onNegative((dialog, which) -> dialog.dismiss());
-                            dialog = builder.build();
-                            dialog.show();
+                        Log.e(AddProductActivity.class.getSimpleName(), e.getMessage());
+                        // A network error happened
+                        if (e instanceof IOException) {
+                            if (!edit_product) {
+                                saveProductOffline();
+                            } else {
+                                MaterialDialog.Builder builder = new MaterialDialog.Builder(AddProductActivity.this)
+                                        .title(R.string.device_offline_dialog_title)
+                                        .positiveText(R.string.txt_try_again)
+                                        .negativeText(R.string.dialog_cancel)
+                                        .onPositive((dialog, which) -> checkFrontImageUploadStatus())
+                                        .onNegative((dialog, which) -> dialog.dismiss());
+                                dialog = builder.build();
+                                dialog.show();
+                            }
+                        }
+                        // Not a network error
+                        else {
+                            if (!edit_product) {
+                                Toast.makeText(AddProductActivity.this, e.getMessage(), Toast.LENGTH_SHORT).show();
+                                saveProductOffline();
+                            } else {
+                                MaterialDialog.Builder builder = new MaterialDialog.Builder(AddProductActivity.this)
+                                        .title(R.string.error_adding_product)
+                                        .positiveText(R.string.txt_try_again)
+                                        .negativeText(R.string.dialog_cancel)
+                                        .onPositive((dialog, which) -> checkFrontImageUploadStatus())
+                                        .onNegative((dialog, which) -> dialog.dismiss());
+                                dialog = builder.build();
+                                dialog.show();
+                            }
                         }
                     }
                 });


### PR DESCRIPTION
## Description
Whenever an error occurred during editing a product a network error message is always displayed in the dialog box. I changed this behaviour and check if the error was a network error or some other error (maybe server down etc.) and display a meaningful message to the user accordingly. After OFF was shown on TV few days back, our servers went down and during that time many users faced "Network Errors" in the android app however their connection was alright and it was an issue due to the server, therefore displaying appropriate error message to the user is important. 
 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines.
