### PR TITLE
Fix #1889: MaterialDialogException in HistoryScanActivity.

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
@@ -448,7 +448,7 @@ public class HistoryScanActivity extends BaseActivity implements SwipeController
         if (Utils.isHardwareCameraInstalled(getBaseContext())) {
             if (ContextCompat.checkSelfPermission(getBaseContext(), Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED) {
                 if (ActivityCompat.shouldShowRequestPermissionRationale(HistoryScanActivity.this, Manifest.permission.CAMERA)) {
-                    new MaterialDialog.Builder(getBaseContext())
+                    new MaterialDialog.Builder(this)
                             .title(R.string.action_about)
                             .content(R.string.permission_camera)
                             .neutralText(R.string.txtOk)


### PR DESCRIPTION
## Description

**Steps To Reproduce:**
1.  Enable "Don't keep activities" in the Developer Options.
2.  Run the app go to the History section, then switch back to another app, stay there for 15-20 seconds, then open the app from the recent.
3.  It will crash.

We need to pass the Activity instance here, not the base context. So I replace getBaseContext() with "this".

## Related issues and discussion
#1889 MaterialDialogException in HistoryScanActivity.