### PR TITLE
Show additive overexposure table even if wikidata is missing

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/AdditiveName.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/AdditiveName.java
@@ -200,4 +200,9 @@ public class AdditiveName {
         this.exposureMeanGreaterThanAdi = exposureMeanGreaterThanAdi;
         this.exposureMeanGreaterThanNoael = exposureMeanGreaterThanNoael;
     }
+
+    @Keep
+    public boolean hasOverexposureData() {
+        return overexposureRisk != null && !"no".equalsIgnoreCase(overexposureRisk);
+    }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ProductActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ProductActivity.java
@@ -478,11 +478,10 @@ doesn't have calories information in nutrition facts.
 	}
 
 	private void showBottomSheet(JSONObject result, Long id, String name,
-			String wikidataId, String searchType, String fragmentTag) {
+								 String wikidataId, String searchType, String fragmentTag) {
 		try {
-			String jsonObjectStr = result.getJSONObject("entities")
-					.getJSONObject(wikidataId)
-					.toString();
+			String jsonObjectStr = (result != null) ? result.getJSONObject("entities")
+					.getJSONObject(wikidataId).toString() : null;
 			ProductAttributeDetailsFragment fragment =
 					ProductAttributeDetailsFragment.newInstance(jsonObjectStr, id, searchType, name);
 			fragment.show(getSupportFragmentManager(), fragmentTag);

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ProductAttributeDetailsFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ProductAttributeDetailsFragment.java
@@ -15,6 +15,7 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 import android.widget.Toast;
+
 import openfoodfacts.github.scrachx.openfood.R;
 import openfoodfacts.github.scrachx.openfood.models.*;
 import openfoodfacts.github.scrachx.openfood.utils.SearchType;
@@ -23,6 +24,7 @@ import openfoodfacts.github.scrachx.openfood.views.ProductBrowsingListActivity;
 import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabActivityHelper;
 import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabsHelper;
 import openfoodfacts.github.scrachx.openfood.views.customtabs.WebViewFallback;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -35,13 +37,8 @@ public class ProductAttributeDetailsFragment extends BottomSheetDialogFragment i
 	private static final String ARG_SEARCH_TYPE = "search_type";
 	private static final String ARG_TITLE = "title";
 
-	private TextView bottomSheetDesciption;
-	private TextView bottomSheetTitle;
 	private AppCompatImageView bottomSheetTitleIcon;
-	private Button buttonToBrowseProducts;
-	private Button wikipediaButton;
 
-	private View exposureEvalTable;
 	private AppCompatImageView mpInfantsImage;
 	private AppCompatImageView mpToddlersImage;
 	private AppCompatImageView mpChildrenImage;
@@ -55,18 +52,17 @@ public class ProductAttributeDetailsFragment extends BottomSheetDialogFragment i
 	private AppCompatImageView spAdultsImage;
 	private AppCompatImageView spElderlyImage;
 
-	private CustomTabActivityHelper customTabActivityHelper;
 	private CustomTabsIntent customTabsIntent;
 
-	public static ProductAttributeDetailsFragment newInstance( String jsonObjectStr, long id, String searchType, String title )
-	{
+	public static ProductAttributeDetailsFragment newInstance(String jsonObjectStr, long id, String searchType, String title) {
 		ProductAttributeDetailsFragment fragment = new ProductAttributeDetailsFragment();
 		Bundle args = new Bundle();
-		args.putString( ARG_OBJECT, jsonObjectStr );
-		args.putLong( ARG_ID, id );
-		args.putString( ARG_SEARCH_TYPE, searchType );
-		args.putString( ARG_TITLE, title );
-		fragment.setArguments( args );
+		args.putString(ARG_OBJECT, jsonObjectStr);
+		args.putLong(ARG_ID, id);
+		args.putString(ARG_SEARCH_TYPE, searchType);
+		args.putString(ARG_TITLE, title);
+
+		fragment.setArguments(args);
 
 		return fragment;
 	}
@@ -77,38 +73,57 @@ public class ProductAttributeDetailsFragment extends BottomSheetDialogFragment i
 							  @Nullable ViewGroup container,
 							  @Nullable Bundle savedInstanceState )
 	{
-		customTabActivityHelper = new CustomTabActivityHelper();
+		CustomTabActivityHelper customTabActivityHelper = new CustomTabActivityHelper();
 		customTabActivityHelper.setConnectionCallback( this );
 		customTabsIntent = CustomTabsHelper.getCustomTabsIntent( getContext().getApplicationContext(), customTabActivityHelper.getSession() );
 
 		View view = inflater.inflate( R.layout.fragment_product_attribute_details, container,
 				false );
 
-		bottomSheetDesciption = view.findViewById( R.id.description );
-		bottomSheetTitle = view.findViewById( R.id.titleBottomSheet );
+		TextView bottomSheetDescription = view.findViewById(R.id.description);
+		TextView bottomSheetTitle = view.findViewById(R.id.titleBottomSheet);
 		bottomSheetTitleIcon = view.findViewById( R.id.titleBottomSheetIcon );
-		buttonToBrowseProducts = view.findViewById( R.id.buttonToBrowseProducts );
-		wikipediaButton = view.findViewById( R.id.wikipediaButton );
+		Button buttonToBrowseProducts = view.findViewById(R.id.buttonToBrowseProducts);
+		Button wikipediaButton = view.findViewById(R.id.wikipediaButton);
 
 		try
 		{
-			JSONObject result = new JSONObject( getArguments().getString( ARG_OBJECT ) );
-			JSONObject description = result.getJSONObject( "descriptions" );
-			JSONObject siteLinks = result.getJSONObject( "sitelinks" );
-			String descriptionString = getDescription( description );
-			String wikiLink = getWikiLink( siteLinks );
+			final String descriptionString;
+			final String wikiLink;
+			String str = getArguments().getString(ARG_OBJECT);
+			if (str != null) {
+				JSONObject result = new JSONObject(str);
+				JSONObject description = result.getJSONObject("descriptions");
+				JSONObject siteLinks = result.getJSONObject("sitelinks");
 
-			String title = getArguments().getString( ARG_TITLE );
-			bottomSheetTitle.setText( title );
-			String searchType = getArguments().getString( ARG_SEARCH_TYPE );
-			bottomSheetDesciption.setText( descriptionString );
-			buttonToBrowseProducts.setOnClickListener( v -> {
-				Intent intent = new Intent( getContext(), ProductBrowsingListActivity.class );
-				intent.putExtra( "search_type", searchType );
-				intent.putExtra( "search_query", title );
-				startActivity( intent );
-			} );
-			wikipediaButton.setOnClickListener( v -> openInCustomTab( wikiLink ) );
+				descriptionString = getDescription(description);
+				wikiLink = getWikiLink(siteLinks);
+			} else {
+				descriptionString = null;
+				wikiLink = null;
+			}
+
+			String title = getArguments().getString(ARG_TITLE);
+			bottomSheetTitle.setText(title);
+			String searchType = getArguments().getString(ARG_SEARCH_TYPE);
+			if (descriptionString != null) {
+				bottomSheetDescription.setText(descriptionString);
+				bottomSheetDescription.setVisibility(View.VISIBLE);
+			} else {
+				bottomSheetDescription.setVisibility(View.GONE);
+			}
+			buttonToBrowseProducts.setOnClickListener(v -> {
+				Intent intent = new Intent(getContext(), ProductBrowsingListActivity.class);
+				intent.putExtra("search_type", searchType);
+				intent.putExtra("search_query", title);
+				startActivity(intent);
+			});
+			if (wikiLink != null) {
+				wikipediaButton.setOnClickListener(v -> openInCustomTab(wikiLink));
+				wikipediaButton.setVisibility(View.VISIBLE);
+			} else {
+				wikipediaButton.setVisibility(View.GONE);
+			}
 
 			long id = getArguments().getLong( ARG_ID );
 			switch( searchType )
@@ -161,7 +176,7 @@ public class ProductAttributeDetailsFragment extends BottomSheetDialogFragment i
 
 	private void updateContent( View view, AdditiveName additive )
 	{
-		exposureEvalTable = view.findViewById( R.id.exposureEvalTable );
+		View exposureEvalTable = view.findViewById(R.id.exposureEvalTable);
 		mpInfantsImage = view.findViewById( R.id.mpInfants );
 		mpToddlersImage = view.findViewById( R.id.mpToddlers );
 		mpChildrenImage = view.findViewById( R.id.mpChildren );
@@ -178,7 +193,7 @@ public class ProductAttributeDetailsFragment extends BottomSheetDialogFragment i
 		TextView efsaWarning = view.findViewById( R.id.efsaWarning );
 
 		String overexposureRisk = additive.getOverexposureRisk();
-		if( overexposureRisk != null && !"no".equals( overexposureRisk ) )
+		if( additive.hasOverexposureData() )
 		{
 			boolean isHighRisk = "high".equalsIgnoreCase( overexposureRisk );
 			if( isHighRisk )
@@ -359,11 +374,14 @@ public class ProductAttributeDetailsFragment extends BottomSheetDialogFragment i
 	private void openInCustomTab( String url )
 	{
 		// Url might be empty string if there is no wiki link in english or the user's language
-		if (!url.equals("")) {
-			Uri wikipediaUri = Uri.parse(url);
-			CustomTabActivityHelper.openCustomTab(getActivity(), customTabsIntent, wikipediaUri, new WebViewFallback());
-		} else {
-			Toast.makeText(getContext(), R.string.wikidata_unavailable, Toast.LENGTH_SHORT).show();
+		if( !url.equals( "" ) )
+		{
+			Uri wikipediaUri = Uri.parse( url );
+			CustomTabActivityHelper.openCustomTab( getActivity(), customTabsIntent, wikipediaUri, new WebViewFallback() );
+		}
+		else
+		{
+			Toast.makeText( getContext(), R.string.wikidata_unavailable, Toast.LENGTH_SHORT ).show();
 		}
 	}
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
@@ -336,7 +336,9 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
                             }
                         } else {
                             if (additive.hasOverexposureData()) {
-                                productActivity.showBottomScreen(null, additive);
+                                if (productActivity != null && !productActivity.isFinishing()) {
+                                    productActivity.showBottomScreen(null, additive);
+                                }
                             } else {
                                 ProductBrowsingListActivity.startActivity(getContext(), additive.getName(), SearchType.ADDITIVE);
                             }
@@ -345,7 +347,9 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
                 } else {
                     ProductActivity productActivity = (ProductActivity) getActivity();
                     if (additive.hasOverexposureData()) {
-                        productActivity.showBottomScreen(null, additive);
+                        if (productActivity != null && !productActivity.isFinishing()) {
+                            productActivity.showBottomScreen(null, additive);
+                        }
                     } else {
                         ProductBrowsingListActivity.startActivity(getContext(), additive.getName(), SearchType.ADDITIVE);
                     }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
@@ -75,675 +75,573 @@ import static openfoodfacts.github.scrachx.openfood.utils.Utils.*;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.jsoup.helper.StringUtil.isBlank;
 
-public class IngredientsProductFragment extends BaseFragment implements IIngredientsProductPresenter.View
-{
+public class IngredientsProductFragment extends BaseFragment implements IIngredientsProductPresenter.View {
 
-	public static final Pattern INGREDIENT_PATTERN = Pattern.compile( "[\\p{L}\\p{Nd}(),.-]+" );
-	public static final Pattern ALLERGEN_PATTERN = Pattern.compile( "[\\p{L}\\p{Nd}]+[\\p{L}\\p{Nd}\\p{Z}\\p{P}&&[^,]]*" );
-	@BindView( R.id.textIngredientProduct )
-	TextView ingredientsProduct;
-	@BindView( R.id.textSubstanceProduct )
-	TextView substanceProduct;
-	@BindView( R.id.textTraceProduct )
-	TextView traceProduct;
-	@BindView( R.id.textAdditiveProduct )
-	TextView additiveProduct;
-	@BindView( R.id.textPalmOilProduct )
-	TextView palmOilProduct;
-	@BindView( R.id.textMayBeFromPalmOilProduct )
-	TextView mayBeFromPalmOilProduct;
-	@BindView( R.id.imageViewIngredients )
-	ImageView mImageIngredients;
-	@BindView( R.id.addPhotoLabel )
-	TextView addPhotoLabel;
-	@BindView( R.id.vitaminsTagsText )
-	TextView vitaminTagsTextView;
-	@BindView( R.id.mineralTagsText )
-	TextView mineralTagsTextView;
-	@BindView( R.id.aminoAcidTagsText )
-	TextView aminoAcidTagsTextView;
-	@BindView( R.id.otherNutritionTags )
-	TextView otherNutritionTagTextView;
-	@BindView( R.id.cvTextIngredientProduct )
-	CardView textIngredientProductCardView;
-	@BindView( R.id.cvTextSubstanceProduct )
-	CardView textSubstanceProductCardView;
-	@BindView( R.id.cvTextTraceProduct )
-	CardView textTraceProductCardView;
-	@BindView( R.id.cvTextAdditiveProduct )
-	CardView textAdditiveProductCardView;
-	@BindView( R.id.cvTextPalmOilProduct )
-	CardView textPalmOilProductCardView;
-	@BindView( R.id.cvVitaminsTagsText )
-	CardView vitaminsTagsTextCardView;
-	@BindView( R.id.cvAminoAcidTagsText )
-	CardView aminoAcidTagsTextCardView;
-	@BindView( R.id.cvMineralTagsText )
-	CardView mineralTagsTextCardView;
-	@BindView( R.id.cvOtherNutritionTags )
-	CardView otherNutritionTagsCardView;
+    public static final Pattern INGREDIENT_PATTERN = Pattern.compile("[\\p{L}\\p{Nd}(),.-]+");
+    public static final Pattern ALLERGEN_PATTERN = Pattern.compile("[\\p{L}\\p{Nd}]+[\\p{L}\\p{Nd}\\p{Z}\\p{P}&&[^,]]*");
+    @BindView(R.id.textIngredientProduct)
+    TextView ingredientsProduct;
+    @BindView(R.id.textSubstanceProduct)
+    TextView substanceProduct;
+    @BindView(R.id.textTraceProduct)
+    TextView traceProduct;
+    @BindView(R.id.textAdditiveProduct)
+    TextView additiveProduct;
+    @BindView(R.id.textPalmOilProduct)
+    TextView palmOilProduct;
+    @BindView(R.id.textMayBeFromPalmOilProduct)
+    TextView mayBeFromPalmOilProduct;
+    @BindView(R.id.imageViewIngredients)
+    ImageView mImageIngredients;
+    @BindView(R.id.addPhotoLabel)
+    TextView addPhotoLabel;
+    @BindView(R.id.vitaminsTagsText)
+    TextView vitaminTagsTextView;
+    @BindView(R.id.mineralTagsText)
+    TextView mineralTagsTextView;
+    @BindView(R.id.aminoAcidTagsText)
+    TextView aminoAcidTagsTextView;
+    @BindView(R.id.otherNutritionTags)
+    TextView otherNutritionTagTextView;
+    @BindView(R.id.cvTextIngredientProduct)
+    CardView textIngredientProductCardView;
+    @BindView(R.id.cvTextSubstanceProduct)
+    CardView textSubstanceProductCardView;
+    @BindView(R.id.cvTextTraceProduct)
+    CardView textTraceProductCardView;
+    @BindView(R.id.cvTextAdditiveProduct)
+    CardView textAdditiveProductCardView;
+    @BindView(R.id.cvTextPalmOilProduct)
+    CardView textPalmOilProductCardView;
+    @BindView(R.id.cvVitaminsTagsText)
+    CardView vitaminsTagsTextCardView;
+    @BindView(R.id.cvAminoAcidTagsText)
+    CardView aminoAcidTagsTextCardView;
+    @BindView(R.id.cvMineralTagsText)
+    CardView mineralTagsTextCardView;
+    @BindView(R.id.cvOtherNutritionTags)
+    CardView otherNutritionTagsCardView;
 
-	private Product product;
-	private OpenFoodAPIClient api;
-	private String mUrlImage;
-	private State mState;
-	private String barcode;
-	private AdditiveDao mAdditiveDao;
-	private IProductRepository productRepository;
-	private IngredientsProductFragment mFragment;
-	private SendProduct mSendProduct;
-	private WikidataApiClient apiClientForWikiData;
-	private CustomTabActivityHelper customTabActivityHelper;
-	private CustomTabsIntent customTabsIntent;
-	private IIngredientsProductPresenter.Actions presenter;
-	//boolean to determine if image should be loaded or not
-	private boolean isLowBatteryMode = false;
+    private Product product;
+    private OpenFoodAPIClient api;
+    private String mUrlImage;
+    private State mState;
+    private String barcode;
+    private AdditiveDao mAdditiveDao;
+    private IProductRepository productRepository;
+    private IngredientsProductFragment mFragment;
+    private SendProduct mSendProduct;
+    private WikidataApiClient apiClientForWikiData;
+    private CustomTabActivityHelper customTabActivityHelper;
+    private CustomTabsIntent customTabsIntent;
+    private IIngredientsProductPresenter.Actions presenter;
+    //boolean to determine if image should be loaded or not
+    private boolean isLowBatteryMode = false;
 
-	@Override
-	public void onAttach( Context context )
-	{
-		super.onAttach( context );
-		productRepository = ProductRepository.getInstance();
-		customTabActivityHelper = new CustomTabActivityHelper();
-		customTabsIntent = CustomTabsHelper.getCustomTabsIntent( getContext(), customTabActivityHelper.getSession() );
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        productRepository = ProductRepository.getInstance();
+        customTabActivityHelper = new CustomTabActivityHelper();
+        customTabsIntent = CustomTabsHelper.getCustomTabsIntent(getContext(), customTabActivityHelper.getSession());
 
-		Intent intent = getActivity().getIntent();
-		mState = (State) intent.getExtras().getSerializable( "state" );
-		product = mState.getProduct();
+        Intent intent = getActivity().getIntent();
+        mState = (State) intent.getExtras().getSerializable("state");
+        product = mState.getProduct();
 
-		presenter = new IngredientsProductPresenter( product, this );
-	}
+        presenter = new IngredientsProductPresenter(product, this);
+    }
 
-	@Override
-	public View onCreateView( LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState )
-	{
-		api = new OpenFoodAPIClient( getActivity() );
-		apiClientForWikiData = new WikidataApiClient();
-		mFragment = this;
-		return createView( inflater, container, R.layout.fragment_ingredients_product );
-	}
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        api = new OpenFoodAPIClient(getActivity());
+        apiClientForWikiData = new WikidataApiClient();
+        mFragment = this;
+        return createView(inflater, container, R.layout.fragment_ingredients_product);
+    }
 
-	@Override
-	public void onViewCreated( View view, @Nullable Bundle savedInstanceState )
-	{
-		super.onViewCreated( view, savedInstanceState );
-		Intent intent = getActivity().getIntent();
-		mState = (State) intent.getExtras().getSerializable( "state" );
-		refreshView( mState );
-	}
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        Intent intent = getActivity().getIntent();
+        mState = (State) intent.getExtras().getSerializable("state");
+        refreshView(mState);
+    }
 
-	@Override
-	public void refreshView( State state )
-	{
-		super.refreshView( state );
-		mState = state;
+    @Override
+    public void refreshView(State state) {
+        super.refreshView(state);
+        mState = state;
 
-		if( getArguments() != null )
-		{
-			mSendProduct = (SendProduct) getArguments().getSerializable( "sendProduct" );
-		}
+        if (getArguments() != null) {
+            mSendProduct = (SendProduct) getArguments().getSerializable("sendProduct");
+        }
 
-		mAdditiveDao = Utils.getAppDaoSession( getActivity() ).getAdditiveDao();
+        mAdditiveDao = Utils.getAppDaoSession(getActivity()).getAdditiveDao();
 
-		// If Battery Level is low and the user has checked the Disable Image in Preferences , then set isLowBatteryMode to true
-		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences( getContext() );
-		Utils.DISABLE_IMAGE_LOAD = preferences.getBoolean( "disableImageLoad", false );
-		if( Utils.DISABLE_IMAGE_LOAD && Utils.getBatteryLevel( getContext() ) )
-		{
-			isLowBatteryMode = true;
-		}
+        // If Battery Level is low and the user has checked the Disable Image in Preferences , then set isLowBatteryMode to true
+        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getContext());
+        Utils.DISABLE_IMAGE_LOAD = preferences.getBoolean("disableImageLoad", false);
+        if (Utils.DISABLE_IMAGE_LOAD && Utils.getBatteryLevel(getContext())) {
+            isLowBatteryMode = true;
+        }
 
-		final Product product = mState.getProduct();
-		barcode = product.getCode();
-		List<String> vitaminTagsList = product.getVitaminTags();
-		List<String> aminoAcidTagsList = product.getAminoAcidTags();
-		List<String> mineralTags = product.getMineralTags();
-		List<String> otherNutritionTags = product.getOtherNutritionTags();
-		String prefix = " ";
+        final Product product = mState.getProduct();
+        barcode = product.getCode();
+        List<String> vitaminTagsList = product.getVitaminTags();
+        List<String> aminoAcidTagsList = product.getAminoAcidTags();
+        List<String> mineralTags = product.getMineralTags();
+        List<String> otherNutritionTags = product.getOtherNutritionTags();
+        String prefix = " ";
 
-		if( !vitaminTagsList.isEmpty() )
-		{
-			StringBuilder vitaminStringBuilder = new StringBuilder();
-			vitaminsTagsTextCardView.setVisibility( View.VISIBLE );
-			vitaminTagsTextView.setText( bold( getString( R.string.vitamin_tags_text ) ) );
-			for( String vitamins : vitaminTagsList )
-			{
-				vitaminStringBuilder.append( prefix );
-				prefix = ", ";
-				vitaminStringBuilder.append( trimLanguagePartFromString( vitamins ) );
-			}
-			vitaminTagsTextView.append( vitaminStringBuilder.toString() );
-		}
+        if (!vitaminTagsList.isEmpty()) {
+            StringBuilder vitaminStringBuilder = new StringBuilder();
+            vitaminsTagsTextCardView.setVisibility(View.VISIBLE);
+            vitaminTagsTextView.setText(bold(getString(R.string.vitamin_tags_text)));
+            for (String vitamins : vitaminTagsList) {
+                vitaminStringBuilder.append(prefix);
+                prefix = ", ";
+                vitaminStringBuilder.append(trimLanguagePartFromString(vitamins));
+            }
+            vitaminTagsTextView.append(vitaminStringBuilder.toString());
+        }
 
-		if( !aminoAcidTagsList.isEmpty() )
-		{
-			String aminoPrefix = " ";
-			StringBuilder aminoAcidStringBuilder = new StringBuilder();
-			aminoAcidTagsTextCardView.setVisibility( View.VISIBLE );
-			aminoAcidTagsTextView.setText( bold( getString( R.string.amino_acid_tags_text ) ) );
-			for( String aminoAcid : aminoAcidTagsList )
-			{
-				aminoAcidStringBuilder.append( aminoPrefix );
-				aminoPrefix = ", ";
-				aminoAcidStringBuilder.append( trimLanguagePartFromString( aminoAcid ) );
-			}
-			aminoAcidTagsTextView.append( aminoAcidStringBuilder.toString() );
-		}
+        if (!aminoAcidTagsList.isEmpty()) {
+            String aminoPrefix = " ";
+            StringBuilder aminoAcidStringBuilder = new StringBuilder();
+            aminoAcidTagsTextCardView.setVisibility(View.VISIBLE);
+            aminoAcidTagsTextView.setText(bold(getString(R.string.amino_acid_tags_text)));
+            for (String aminoAcid : aminoAcidTagsList) {
+                aminoAcidStringBuilder.append(aminoPrefix);
+                aminoPrefix = ", ";
+                aminoAcidStringBuilder.append(trimLanguagePartFromString(aminoAcid));
+            }
+            aminoAcidTagsTextView.append(aminoAcidStringBuilder.toString());
+        }
 
-		if( !mineralTags.isEmpty() )
-		{
-			String mineralPrefix = " ";
-			StringBuilder mineralsStringBuilder = new StringBuilder();
-			mineralTagsTextCardView.setVisibility( View.VISIBLE );
-			mineralTagsTextView.setText( bold( getString( R.string.mineral_tags_text ) ) );
-			for( String mineral : mineralTags )
-			{
-				mineralsStringBuilder.append( mineralPrefix );
-				mineralPrefix = ", ";
-				mineralsStringBuilder.append( trimLanguagePartFromString( mineral ) );
-			}
-			mineralTagsTextView.append( mineralsStringBuilder );
-		}
+        if (!mineralTags.isEmpty()) {
+            String mineralPrefix = " ";
+            StringBuilder mineralsStringBuilder = new StringBuilder();
+            mineralTagsTextCardView.setVisibility(View.VISIBLE);
+            mineralTagsTextView.setText(bold(getString(R.string.mineral_tags_text)));
+            for (String mineral : mineralTags) {
+                mineralsStringBuilder.append(mineralPrefix);
+                mineralPrefix = ", ";
+                mineralsStringBuilder.append(trimLanguagePartFromString(mineral));
+            }
+            mineralTagsTextView.append(mineralsStringBuilder);
+        }
 
-		if( !otherNutritionTags.isEmpty() )
-		{
-			String otherNutritionPrefix = " ";
-			StringBuilder otherNutritionStringBuilder = new StringBuilder();
-			otherNutritionTagTextView.setVisibility( View.VISIBLE );
-			otherNutritionTagTextView.setText( bold( getString( R.string.other_tags_text ) ) );
-			for( String otherSubstance : otherNutritionTags )
-			{
-				otherNutritionStringBuilder.append( otherNutritionPrefix );
-				otherNutritionPrefix = ", ";
-				otherNutritionStringBuilder.append( trimLanguagePartFromString( otherSubstance ) );
-			}
-			otherNutritionTagTextView.append( otherNutritionStringBuilder.toString() );
-		}
+        if (!otherNutritionTags.isEmpty()) {
+            String otherNutritionPrefix = " ";
+            StringBuilder otherNutritionStringBuilder = new StringBuilder();
+            otherNutritionTagTextView.setVisibility(View.VISIBLE);
+            otherNutritionTagTextView.setText(bold(getString(R.string.other_tags_text)));
+            for (String otherSubstance : otherNutritionTags) {
+                otherNutritionStringBuilder.append(otherNutritionPrefix);
+                otherNutritionPrefix = ", ";
+                otherNutritionStringBuilder.append(trimLanguagePartFromString(otherSubstance));
+            }
+            otherNutritionTagTextView.append(otherNutritionStringBuilder.toString());
+        }
 
-		additiveProduct.setText( bold( getString( R.string.txtAdditives ) ) );
-		presenter.loadAdditives();
+        additiveProduct.setText(bold(getString(R.string.txtAdditives)));
+        presenter.loadAdditives();
 
-		if( isNotBlank( product.getImageIngredientsUrl() ) )
-		{
-			addPhotoLabel.setVisibility( View.GONE );
+        if (isNotBlank(product.getImageIngredientsUrl())) {
+            addPhotoLabel.setVisibility(View.GONE);
 
-			// Load Image if isLowBatteryMode is false
-			if( !isLowBatteryMode )
-			{
-				Picasso.with( getContext() )
-						.load( product.getImageIngredientsUrl() )
-						.into( mImageIngredients );
-			}
-			else
-			{
-				mImageIngredients.setVisibility( View.GONE );
-			}
+            // Load Image if isLowBatteryMode is false
+            if (!isLowBatteryMode) {
+                Picasso.with(getContext())
+                        .load(product.getImageIngredientsUrl())
+                        .into(mImageIngredients);
+            } else {
+                mImageIngredients.setVisibility(View.GONE);
+            }
 
-			mUrlImage = product.getImageIngredientsUrl();
-		}
+            mUrlImage = product.getImageIngredientsUrl();
+        }
 
-		//useful when this fragment is used in offline saving
-		if( mSendProduct != null && isNotBlank( mSendProduct.getImgupload_ingredients() ) )
-		{
-			addPhotoLabel.setVisibility( View.GONE );
-			mUrlImage = mSendProduct.getImgupload_ingredients();
-			Picasso.with( getContext() ).load( "file://" + mUrlImage ).config( Bitmap.Config.RGB_565 ).into( mImageIngredients );
-		}
+        //useful when this fragment is used in offline saving
+        if (mSendProduct != null && isNotBlank(mSendProduct.getImgupload_ingredients())) {
+            addPhotoLabel.setVisibility(View.GONE);
+            mUrlImage = mSendProduct.getImgupload_ingredients();
+            Picasso.with(getContext()).load("file://" + mUrlImage).config(Bitmap.Config.RGB_565).into(mImageIngredients);
+        }
 
-		List<String> allergens = getAllergens();
+        List<String> allergens = getAllergens();
 
-		if( mState != null && product.getIngredientsText() != null )
-		{
-			textIngredientProductCardView.setVisibility( View.VISIBLE );
-			SpannableStringBuilder txtIngredients = new SpannableStringBuilder( product.getIngredientsText().replace( "_", "" ) );
-			txtIngredients = setSpanBoldBetweenTokens( txtIngredients, allergens );
-			int ingredientsListAt = Math.max( 0, txtIngredients.toString().indexOf( ":" ) );
-			if( !txtIngredients.toString().substring( ingredientsListAt ).trim().isEmpty() )
-			{
-				ingredientsProduct.setText( txtIngredients );
-			}
-		}
-		presenter.loadAllergens();
+        if (mState != null && product.getIngredientsText() != null) {
+            textIngredientProductCardView.setVisibility(View.VISIBLE);
+            SpannableStringBuilder txtIngredients = new SpannableStringBuilder(product.getIngredientsText().replace("_", ""));
+            txtIngredients = setSpanBoldBetweenTokens(txtIngredients, allergens);
+            int ingredientsListAt = Math.max(0, txtIngredients.toString().indexOf(":"));
+            if (!txtIngredients.toString().substring(ingredientsListAt).trim().isEmpty()) {
+                ingredientsProduct.setText(txtIngredients);
+            }
+        }
+        presenter.loadAllergens();
 
-		if( !isBlank( product.getTraces() ) )
-		{
-			textTraceProductCardView.setVisibility( View.VISIBLE );
-			traceProduct.setMovementMethod( LinkMovementMethod.getInstance() );
-			traceProduct.setText( bold( getString( R.string.txtTraces ) ) );
-			traceProduct.append( " " );
+        if (!isBlank(product.getTraces())) {
+            textTraceProductCardView.setVisibility(View.VISIBLE);
+            traceProduct.setMovementMethod(LinkMovementMethod.getInstance());
+            traceProduct.setText(bold(getString(R.string.txtTraces)));
+            traceProduct.append(" ");
 
-			String trace;
-			String traces[] = product.getTraces().split( "," );
-			for( int i = 0; i < traces.length - 1; i++ )
-			{
-				trace = traces[i];
-				traceProduct.append( Utils.getClickableText( trace, trace, SearchType.TRACE, getActivity(), customTabsIntent ) );
-				traceProduct.append( ", " );
-			}
+            String trace;
+            String traces[] = product.getTraces().split(",");
+            for (int i = 0; i < traces.length - 1; i++) {
+                trace = traces[i];
+                traceProduct.append(Utils.getClickableText(trace, trace, SearchType.TRACE, getActivity(), customTabsIntent));
+                traceProduct.append(", ");
+            }
 
-			trace = traces[traces.length - 1];
-			traceProduct.append( Utils.getClickableText( trace, trace, SearchType.TRACE, getActivity(), customTabsIntent ) );
-		}
+            trace = traces[traces.length - 1];
+            traceProduct.append(Utils.getClickableText(trace, trace, SearchType.TRACE, getActivity(), customTabsIntent));
+        }
 
-		if( !( product.getIngredientsFromPalmOilN() == 0 && product.getIngredientsFromOrThatMayBeFromPalmOilN() == 0 ) )
-		{
-			textPalmOilProductCardView.setVisibility( View.VISIBLE );
-			mayBeFromPalmOilProduct.setVisibility( View.VISIBLE );
-			if( !product.getIngredientsFromPalmOilTags().isEmpty() )
-			{
-				palmOilProduct.setText( bold( getString( R.string.txtPalmOilProduct ) ) );
-				palmOilProduct.append( " " );
-				palmOilProduct.append( product.getIngredientsFromPalmOilTags().toString().replaceAll( "[\\[,\\]]", "" ) );
-			}
-			else
-			{
-				palmOilProduct.setVisibility( View.GONE );
-			}
-			if( !product.getIngredientsThatMayBeFromPalmOilTags().isEmpty() )
-			{
-				mayBeFromPalmOilProduct.setText( bold( getString( R.string.txtMayBeFromPalmOilProduct ) ) );
-				mayBeFromPalmOilProduct.append( " " );
-				mayBeFromPalmOilProduct.append( product.getIngredientsThatMayBeFromPalmOilTags().toString().replaceAll( "[\\[,\\]]", "" ) );
-			}
-			else
-			{
-				mayBeFromPalmOilProduct.setVisibility( View.GONE );
-			}
-		}
-	}
+        if (!(product.getIngredientsFromPalmOilN() == 0 && product.getIngredientsFromOrThatMayBeFromPalmOilN() == 0)) {
+            textPalmOilProductCardView.setVisibility(View.VISIBLE);
+            mayBeFromPalmOilProduct.setVisibility(View.VISIBLE);
+            if (!product.getIngredientsFromPalmOilTags().isEmpty()) {
+                palmOilProduct.setText(bold(getString(R.string.txtPalmOilProduct)));
+                palmOilProduct.append(" ");
+                palmOilProduct.append(product.getIngredientsFromPalmOilTags().toString().replaceAll("[\\[,\\]]", ""));
+            } else {
+                palmOilProduct.setVisibility(View.GONE);
+            }
+            if (!product.getIngredientsThatMayBeFromPalmOilTags().isEmpty()) {
+                mayBeFromPalmOilProduct.setText(bold(getString(R.string.txtMayBeFromPalmOilProduct)));
+                mayBeFromPalmOilProduct.append(" ");
+                mayBeFromPalmOilProduct.append(product.getIngredientsThatMayBeFromPalmOilTags().toString().replaceAll("[\\[,\\]]", ""));
+            } else {
+                mayBeFromPalmOilProduct.setVisibility(View.GONE);
+            }
+        }
+    }
 
-	private CharSequence getAdditiveTag(AdditiveName additive) {
-		SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
+    private CharSequence getAdditiveTag(AdditiveName additive) {
+        SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
 
-		ClickableSpan clickableSpan = new ClickableSpan() {
-			@Override
-			public void onClick(View view) {
-				if (additive.getIsWikiDataIdPresent()) {
-					apiClientForWikiData.doSomeThing(additive.getWikiDataId(), (value, result) -> {
-						ProductActivity productActivity = (ProductActivity) getActivity();
-						if (value) {
-							if (productActivity != null && !productActivity.isFinishing()) {
-								productActivity.showBottomScreen(result, additive);
-							}
-						} else {
-							if (additive.hasOverexposureData()) {
-								productActivity.showBottomScreen(null, additive);
-							} else {
-								ProductBrowsingListActivity.startActivity(getContext(), additive.getName(), SearchType.ADDITIVE);
-							}
-						}
-					});
-				} else {
-					ProductActivity productActivity = (ProductActivity) getActivity();
-					if (additive.hasOverexposureData()) {
-						productActivity.showBottomScreen(null, additive);
-					} else {
-						ProductBrowsingListActivity.startActivity(getContext(), additive.getName(), SearchType.ADDITIVE);
-					}
-				}
-			}
-		};
+        ClickableSpan clickableSpan = new ClickableSpan() {
+            @Override
+            public void onClick(View view) {
+                if (additive.getIsWikiDataIdPresent()) {
+                    apiClientForWikiData.doSomeThing(additive.getWikiDataId(), (value, result) -> {
+                        ProductActivity productActivity = (ProductActivity) getActivity();
+                        if (value) {
+                            if (productActivity != null && !productActivity.isFinishing()) {
+                                productActivity.showBottomScreen(result, additive);
+                            }
+                        } else {
+                            if (additive.hasOverexposureData()) {
+                                productActivity.showBottomScreen(null, additive);
+                            } else {
+                                ProductBrowsingListActivity.startActivity(getContext(), additive.getName(), SearchType.ADDITIVE);
+                            }
+                        }
+                    });
+                } else {
+                    ProductActivity productActivity = (ProductActivity) getActivity();
+                    if (additive.hasOverexposureData()) {
+                        productActivity.showBottomScreen(null, additive);
+                    } else {
+                        ProductBrowsingListActivity.startActivity(getContext(), additive.getName(), SearchType.ADDITIVE);
+                    }
+                }
+            }
+        };
 
-		spannableStringBuilder.append( additive.getName() );
-		spannableStringBuilder.setSpan( clickableSpan, 0, spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE );
+        spannableStringBuilder.append(additive.getName());
+        spannableStringBuilder.setSpan(clickableSpan, 0, spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
 
-		// if the additive has an overexposure risk ("high" or "moderate") then append the warning message to it
-		if( additive.hasOverexposureData() )
-		{
-			boolean isHighRisk = "high".equalsIgnoreCase( additive.getOverexposureRisk() );
-			Drawable riskIcon;
-			String riskWarningStr;
-			int riskWarningColor;
-			if( isHighRisk )
-			{
-				riskIcon = ContextCompat.getDrawable( getContext(), R.drawable.ic_additive_high_risk );
-				riskWarningStr = getString( R.string.overexposure_high );
-				riskWarningColor = getColor( getContext(), R.color.overexposure_high );
-			}
-			else
-			{
-				riskIcon = ContextCompat.getDrawable( getContext(), R.drawable.ic_additive_moderate_risk );
-				riskWarningStr = getString( R.string.overexposure_moderate );
-				riskWarningColor = getColor( getContext(), R.color.overexposure_moderate );
-			}
-			riskIcon.setBounds( 0, 0, riskIcon.getIntrinsicWidth(), riskIcon.getIntrinsicHeight() );
-			ImageSpan iconSpan = new ImageSpan( riskIcon, ImageSpan.ALIGN_BOTTOM );
+        // if the additive has an overexposure risk ("high" or "moderate") then append the warning message to it
+        if (additive.hasOverexposureData()) {
+            boolean isHighRisk = "high".equalsIgnoreCase(additive.getOverexposureRisk());
+            Drawable riskIcon;
+            String riskWarningStr;
+            int riskWarningColor;
+            if (isHighRisk) {
+                riskIcon = ContextCompat.getDrawable(getContext(), R.drawable.ic_additive_high_risk);
+                riskWarningStr = getString(R.string.overexposure_high);
+                riskWarningColor = getColor(getContext(), R.color.overexposure_high);
+            } else {
+                riskIcon = ContextCompat.getDrawable(getContext(), R.drawable.ic_additive_moderate_risk);
+                riskWarningStr = getString(R.string.overexposure_moderate);
+                riskWarningColor = getColor(getContext(), R.color.overexposure_moderate);
+            }
+            riskIcon.setBounds(0, 0, riskIcon.getIntrinsicWidth(), riskIcon.getIntrinsicHeight());
+            ImageSpan iconSpan = new ImageSpan(riskIcon, ImageSpan.ALIGN_BOTTOM);
 
-			spannableStringBuilder.append( " - " ); // this will be replaced with the risk icon
-			spannableStringBuilder.setSpan( iconSpan, spannableStringBuilder.length() - 2, spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE );
+            spannableStringBuilder.append(" - "); // this will be replaced with the risk icon
+            spannableStringBuilder.setSpan(iconSpan, spannableStringBuilder.length() - 2, spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
 
-			spannableStringBuilder.append( riskWarningStr );
-			spannableStringBuilder.setSpan( new ForegroundColorSpan( riskWarningColor ), spannableStringBuilder.length() - riskWarningStr.length(), spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE );
-		}
+            spannableStringBuilder.append(riskWarningStr);
+            spannableStringBuilder.setSpan(new ForegroundColorSpan(riskWarningColor), spannableStringBuilder.length() - riskWarningStr.length(), spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
 
-		return spannableStringBuilder;
-	}
+        return spannableStringBuilder;
+    }
 
-	private CharSequence getAllergensTag( AllergenName allergen )
-	{
-		SpannableStringBuilder ssb = new SpannableStringBuilder();
+    private CharSequence getAllergensTag(AllergenName allergen) {
+        SpannableStringBuilder ssb = new SpannableStringBuilder();
 
-		ClickableSpan clickableSpan = new ClickableSpan()
-		{
-			@Override
-			public void onClick( View view )
-			{
-				if( allergen.getIsWikiDataIdPresent() )
-				{
-					apiClientForWikiData.doSomeThing(
-							allergen.getWikiDataId(),
-							( value, result ) -> {
-								if( value )
-								{
-									ProductActivity productActivity = (ProductActivity) getActivity();
-									if( productActivity != null && !productActivity.isFinishing() )
-									{
-										productActivity.showBottomScreen( result, allergen );
-									}
-								}
-								else
-								{
-									ProductBrowsingListActivity.startActivity( getContext(), allergen.getName(), SearchType.ALLERGEN );
-								}
-							} );
-				}
-				else
-				{
-					ProductBrowsingListActivity.startActivity( getContext(), allergen.getName(), SearchType.ALLERGEN );
-				}
-			}
-		};
+        ClickableSpan clickableSpan = new ClickableSpan() {
+            @Override
+            public void onClick(View view) {
+                if (allergen.getIsWikiDataIdPresent()) {
+                    apiClientForWikiData.doSomeThing(
+                            allergen.getWikiDataId(),
+                            (value, result) -> {
+                                if (value) {
+                                    ProductActivity productActivity = (ProductActivity) getActivity();
+                                    if (productActivity != null && !productActivity.isFinishing()) {
+                                        productActivity.showBottomScreen(result, allergen);
+                                    }
+                                } else {
+                                    ProductBrowsingListActivity.startActivity(getContext(), allergen.getName(), SearchType.ALLERGEN);
+                                }
+                            });
+                } else {
+                    ProductBrowsingListActivity.startActivity(getContext(), allergen.getName(), SearchType.ALLERGEN);
+                }
+            }
+        };
 
-		ssb.append( allergen.getName() );
-		ssb.setSpan( clickableSpan, 0, ssb.length(), SPAN_EXCLUSIVE_EXCLUSIVE );
-		// If allergen is not in the taxonomy list then italicize it
-		if( !allergen.isNotNull() )
-		{
-			StyleSpan iss =
-					new StyleSpan( android.graphics.Typeface.ITALIC ); //Span to make text italic
-			ssb.setSpan( iss, 0, ssb.length(), SPAN_EXCLUSIVE_EXCLUSIVE );
-		}
-		return ssb;
-	}
+        ssb.append(allergen.getName());
+        ssb.setSpan(clickableSpan, 0, ssb.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
+        // If allergen is not in the taxonomy list then italicize it
+        if (!allergen.isNotNull()) {
+            StyleSpan iss =
+                    new StyleSpan(android.graphics.Typeface.ITALIC); //Span to make text italic
+            ssb.setSpan(iss, 0, ssb.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
+        return ssb;
+    }
 
-	/**
-	 * @return the string after trimming the language code from the tags
-	 * like it returns folic-acid for en:folic-acid
-	 */
-	private String trimLanguagePartFromString( String string )
-	{
-		return string.substring( 3 );
-	}
+    /**
+     * @return the string after trimming the language code from the tags
+     * like it returns folic-acid for en:folic-acid
+     */
+    private String trimLanguagePartFromString(String string) {
+        return string.substring(3);
+    }
 
-	private SpannableStringBuilder setSpanBoldBetweenTokens( CharSequence text, List<String> allergens )
-	{
-		final SpannableStringBuilder ssb = new SpannableStringBuilder( text );
-		Matcher m = INGREDIENT_PATTERN.matcher( ssb );
-		while( m.find() )
-		{
-			final String tm = m.group();
-			final String allergenValue = tm.replaceAll( "[(),.-]+", "" );
+    private SpannableStringBuilder setSpanBoldBetweenTokens(CharSequence text, List<String> allergens) {
+        final SpannableStringBuilder ssb = new SpannableStringBuilder(text);
+        Matcher m = INGREDIENT_PATTERN.matcher(ssb);
+        while (m.find()) {
+            final String tm = m.group();
+            final String allergenValue = tm.replaceAll("[(),.-]+", "");
 
-			for( String allergen : allergens )
-			{
-				if( allergen.equalsIgnoreCase( allergenValue ) )
-				{
-					int start = m.start();
-					int end = m.end();
+            for (String allergen : allergens) {
+                if (allergen.equalsIgnoreCase(allergenValue)) {
+                    int start = m.start();
+                    int end = m.end();
 
-					if( tm.contains( "(" ) )
-					{
-						start += 1;
-					}
-					else if( tm.contains( ")" ) )
-					{
-						end -= 1;
-					}
+                    if (tm.contains("(")) {
+                        start += 1;
+                    } else if (tm.contains(")")) {
+                        end -= 1;
+                    }
 
-					ssb.setSpan( new StyleSpan( Typeface.BOLD ), start, end, SPAN_EXCLUSIVE_EXCLUSIVE );
-				}
-			}
-		}
-		ssb.insert( 0, Utils.bold( getString( R.string.txtIngredients ) + ' ' ) );
-		return ssb;
-	}
+                    ssb.setSpan(new StyleSpan(Typeface.BOLD), start, end, SPAN_EXCLUSIVE_EXCLUSIVE);
+                }
+            }
+        }
+        ssb.insert(0, Utils.bold(getString(R.string.txtIngredients) + ' '));
+        return ssb;
+    }
 
-	private SpannableString buildAdditivesList( List<AdditiveName> additives )
-	{
-		return null;
-	}
+    private SpannableString buildAdditivesList(List<AdditiveName> additives) {
+        return null;
+    }
 
-	@Override
-	public void showAdditives( List<AdditiveName> additives )
-	{
-		additiveProduct.setText( bold( getString( R.string.txtAdditives ) ) );
-		additiveProduct.setMovementMethod( LinkMovementMethod.getInstance() );
-		additiveProduct.append( " " );
-		additiveProduct.append( "\n" );
-		additiveProduct.setClickable( true );
-		additiveProduct.setMovementMethod( LinkMovementMethod.getInstance() );
+    @Override
+    public void showAdditives(List<AdditiveName> additives) {
+        additiveProduct.setText(bold(getString(R.string.txtAdditives)));
+        additiveProduct.setMovementMethod(LinkMovementMethod.getInstance());
+        additiveProduct.append(" ");
+        additiveProduct.append("\n");
+        additiveProduct.setClickable(true);
+        additiveProduct.setMovementMethod(LinkMovementMethod.getInstance());
 
-		for( int i = 0; i < additives.size() - 1; i++ )
-		{
-			additiveProduct.append( getAdditiveTag( additives.get( i ) ) );
-			additiveProduct.append( "\n" );
-		}
+        for (int i = 0; i < additives.size() - 1; i++) {
+            additiveProduct.append(getAdditiveTag(additives.get(i)));
+            additiveProduct.append("\n");
+        }
 
-		additiveProduct.append( getAdditiveTag( ( additives.get( additives.size() - 1 ) ) ) );
-	}
+        additiveProduct.append(getAdditiveTag((additives.get(additives.size() - 1))));
+    }
 
-	@Override
-	public void showAdditivesState( String state )
-	{
-		switch( state )
-		{
-			case LOADING:
-			{
-				textAdditiveProductCardView.setVisibility( View.VISIBLE );
-				additiveProduct.append( getString( R.string.txtLoading ) );
-				break;
-			}
-			case EMPTY:
-			{
-				textAdditiveProductCardView.setVisibility( View.GONE );
-				break;
-			}
-		}
-	}
+    @Override
+    public void showAdditivesState(String state) {
+        switch (state) {
+            case LOADING: {
+                textAdditiveProductCardView.setVisibility(View.VISIBLE);
+                additiveProduct.append(getString(R.string.txtLoading));
+                break;
+            }
+            case EMPTY: {
+                textAdditiveProductCardView.setVisibility(View.GONE);
+                break;
+            }
+        }
+    }
 
-	@Override
-	public void showAllergens( List<AllergenName> allergens )
-	{
-		substanceProduct.setMovementMethod( LinkMovementMethod.getInstance() );
-		substanceProduct.setText( bold( getString( R.string.txtSubstances ) ) );
-		substanceProduct.append( " " );
+    @Override
+    public void showAllergens(List<AllergenName> allergens) {
+        substanceProduct.setMovementMethod(LinkMovementMethod.getInstance());
+        substanceProduct.setText(bold(getString(R.string.txtSubstances)));
+        substanceProduct.append(" ");
 
-		for( int i = 0, lastIdx = allergens.size() - 1; i <= lastIdx; i++ )
-		{
-			AllergenName allergen = allergens.get( i );
-			substanceProduct.append( getAllergensTag( allergen ) );
-			// Add comma if not the last item
-			if( i != lastIdx )
-			{
-				substanceProduct.append( ", " );
-			}
-		}
-	}
+        for (int i = 0, lastIdx = allergens.size() - 1; i <= lastIdx; i++) {
+            AllergenName allergen = allergens.get(i);
+            substanceProduct.append(getAllergensTag(allergen));
+            // Add comma if not the last item
+            if (i != lastIdx) {
+                substanceProduct.append(", ");
+            }
+        }
+    }
 
-	@Override
-	public void showAllergensState( String state )
-	{
-		switch( state )
-		{
-			case LOADING:
-			{
-				textSubstanceProductCardView.setVisibility( View.VISIBLE );
-				substanceProduct.append( getString( R.string.txtLoading ) );
-				break;
-			}
-			case EMPTY:
-			{
-				textSubstanceProductCardView.setVisibility( View.GONE );
-				break;
-			}
-		}
-	}
+    @Override
+    public void showAllergensState(String state) {
+        switch (state) {
+            case LOADING: {
+                textSubstanceProductCardView.setVisibility(View.VISIBLE);
+                substanceProduct.append(getString(R.string.txtLoading));
+                break;
+            }
+            case EMPTY: {
+                textSubstanceProductCardView.setVisibility(View.GONE);
+                break;
+            }
+        }
+    }
 
-	private List<String> getAllergens()
-	{
-		List<String> allergens = mState.getProduct().getAllergensTags();
-		if( mState.getProduct() == null || allergens == null || allergens.isEmpty() )
-		{
-			return Collections.emptyList();
-		}
-		else
-		{
-			return allergens;
-		}
-	}
+    private List<String> getAllergens() {
+        List<String> allergens = mState.getProduct().getAllergensTags();
+        if (mState.getProduct() == null || allergens == null || allergens.isEmpty()) {
+            return Collections.emptyList();
+        } else {
+            return allergens;
+        }
+    }
 
-	@OnClick( R.id.imageViewIngredients )
-	public void openFullScreen( View v )
-	{
-		if( mUrlImage != null )
-		{
-			Intent intent = new Intent( v.getContext(), FullScreenImage.class );
-			Bundle bundle = new Bundle();
-			bundle.putString( "imageurl", mUrlImage );
-			intent.putExtras( bundle );
-			if( Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP )
-			{
-				ActivityOptionsCompat options = ActivityOptionsCompat.
-						makeSceneTransitionAnimation( getActivity(), (View) mImageIngredients,
-								getActivity().getString( R.string.product_transition ) );
-				startActivity( intent, options.toBundle() );
-			}
-			else
-			{
-				startActivity( intent );
-			}
-		}
-		else
-		{
-			// take a picture
-			if( ContextCompat.checkSelfPermission( getActivity(), CAMERA ) != PERMISSION_GRANTED )
-			{
-				ActivityCompat.requestPermissions( getActivity(), new String[]{ CAMERA }, MY_PERMISSIONS_REQUEST_CAMERA );
-			}
-			else
-			{
-				EasyImage.openCamera( this, 0 );
+    @OnClick(R.id.imageViewIngredients)
+    public void openFullScreen(View v) {
+        if (mUrlImage != null) {
+            Intent intent = new Intent(v.getContext(), FullScreenImage.class);
+            Bundle bundle = new Bundle();
+            bundle.putString("imageurl", mUrlImage);
+            intent.putExtras(bundle);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                ActivityOptionsCompat options = ActivityOptionsCompat.
+                        makeSceneTransitionAnimation(getActivity(), (View) mImageIngredients,
+                                getActivity().getString(R.string.product_transition));
+                startActivity(intent, options.toBundle());
+            } else {
+                startActivity(intent);
+            }
+        } else {
+            // take a picture
+            if (ContextCompat.checkSelfPermission(getActivity(), CAMERA) != PERMISSION_GRANTED) {
+                ActivityCompat.requestPermissions(getActivity(), new String[]{CAMERA}, MY_PERMISSIONS_REQUEST_CAMERA);
+            } else {
+                EasyImage.openCamera(this, 0);
 //                EasyImage.openGallery(this);
-			}
-		}
-	}
+            }
+        }
+    }
 
-	private void onPhotoReturned( File photoFile )
-	{
-		ProductImage image = new ProductImage( barcode, INGREDIENTS, photoFile );
-		image.setFilePath( photoFile.getAbsolutePath() );
-		api.postImg( getContext(), image );
-		addPhotoLabel.setVisibility( View.GONE );
-		mUrlImage = photoFile.getAbsolutePath();
+    private void onPhotoReturned(File photoFile) {
+        ProductImage image = new ProductImage(barcode, INGREDIENTS, photoFile);
+        image.setFilePath(photoFile.getAbsolutePath());
+        api.postImg(getContext(), image);
+        addPhotoLabel.setVisibility(View.GONE);
+        mUrlImage = photoFile.getAbsolutePath();
 
-		Picasso.with( getContext() )
-				.load( photoFile )
-				.fit()
-				.into( mImageIngredients );
-	}
+        Picasso.with(getContext())
+                .load(photoFile)
+                .fit()
+                .into(mImageIngredients);
+    }
 
-	@Override
-	public void onActivityResult( int requestCode, int resultCode, Intent data )
-	{
-		super.onActivityResult( requestCode, resultCode, data );
-		if( requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE )
-		{
-			CropImage.ActivityResult result = CropImage.getActivityResult( data );
-			if( resultCode == RESULT_OK )
-			{
-				Uri resultUri = result.getUri();
-				onPhotoReturned( new File( resultUri.getPath() ) );
-			}
-			else if( resultCode == CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE )
-			{
-				Exception error = result.getError();
-			}
-		}
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
+            CropImage.ActivityResult result = CropImage.getActivityResult(data);
+            if (resultCode == RESULT_OK) {
+                Uri resultUri = result.getUri();
+                onPhotoReturned(new File(resultUri.getPath()));
+            } else if (resultCode == CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE) {
+                Exception error = result.getError();
+            }
+        }
 
-		EasyImage.handleActivityResult( requestCode, resultCode, data, getActivity(), new DefaultCallback()
-		{
-			@Override
-			public void onImagePickerError( Exception e, EasyImage.ImageSource source, int type )
-			{
-				//Some error handling
-			}
+        EasyImage.handleActivityResult(requestCode, resultCode, data, getActivity(), new DefaultCallback() {
+            @Override
+            public void onImagePickerError(Exception e, EasyImage.ImageSource source, int type) {
+                //Some error handling
+            }
 
-			@Override
-			public void onImagesPicked( List<File> imageFiles, EasyImage.ImageSource source, int type )
-			{
-				CropImage.activity( Uri.fromFile( imageFiles.get( 0 ) ) )
-						.setCropMenuCropButtonIcon( R.drawable.ic_check_white_24dp )
-						.setAllowFlipping( false )
-						.setOutputUri( Utils.getOutputPicUri( getContext() ) )
-						.start( getContext(), mFragment );
-			}
+            @Override
+            public void onImagesPicked(List<File> imageFiles, EasyImage.ImageSource source, int type) {
+                CropImage.activity(Uri.fromFile(imageFiles.get(0)))
+                        .setCropMenuCropButtonIcon(R.drawable.ic_check_white_24dp)
+                        .setAllowFlipping(false)
+                        .setOutputUri(Utils.getOutputPicUri(getContext()))
+                        .start(getContext(), mFragment);
+            }
 
-			@Override
-			public void onCanceled( EasyImage.ImageSource source, int type )
-			{
-				//Cancel handling, you might wanna remove taken photo if it was canceled
-				if( source == EasyImage.ImageSource.CAMERA )
-				{
-					File photoFile = EasyImage.lastlyTakenButCanceledPhoto( getContext() );
-					if( photoFile != null )
-					{
-						photoFile.delete();
-					}
-				}
-			}
-		} );
-	}
+            @Override
+            public void onCanceled(EasyImage.ImageSource source, int type) {
+                //Cancel handling, you might wanna remove taken photo if it was canceled
+                if (source == EasyImage.ImageSource.CAMERA) {
+                    File photoFile = EasyImage.lastlyTakenButCanceledPhoto(getContext());
+                    if (photoFile != null) {
+                        photoFile.delete();
+                    }
+                }
+            }
+        });
+    }
 
-	@Override
-	public void onRequestPermissionsResult( int requestCode, @NonNull String permissions[], @NonNull int[] grantResults )
-	{
-		switch( requestCode )
-		{
-			case MY_PERMISSIONS_REQUEST_CAMERA:
-			{
-				if( grantResults.length <= 0 || grantResults[0] != PERMISSION_GRANTED )
-				{
-					new MaterialDialog.Builder( getActivity() )
-							.title( R.string.permission_title )
-							.content( R.string.permission_denied )
-							.negativeText( R.string.txtNo )
-							.positiveText( R.string.txtYes )
-							.onPositive( ( dialog, which ) -> {
-								Intent intent = new Intent();
-								intent.setAction( Settings.ACTION_APPLICATION_DETAILS_SETTINGS );
-								Uri uri = Uri.fromParts( "package", getActivity().getPackageName(), null );
-								intent.setData( uri );
-								startActivity( intent );
-							} )
-							.show();
-				}
-				else
-				{
-					EasyImage.openCamera( this, 0 );
-				}
-			}
-		}
-	}
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] grantResults) {
+        switch (requestCode) {
+            case MY_PERMISSIONS_REQUEST_CAMERA: {
+                if (grantResults.length <= 0 || grantResults[0] != PERMISSION_GRANTED) {
+                    new MaterialDialog.Builder(getActivity())
+                            .title(R.string.permission_title)
+                            .content(R.string.permission_denied)
+                            .negativeText(R.string.txtNo)
+                            .positiveText(R.string.txtYes)
+                            .onPositive((dialog, which) -> {
+                                Intent intent = new Intent();
+                                intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                                Uri uri = Uri.fromParts("package", getActivity().getPackageName(), null);
+                                intent.setData(uri);
+                                startActivity(intent);
+                            })
+                            .show();
+                } else {
+                    EasyImage.openCamera(this, 0);
+                }
+            }
+        }
+    }
 
-	public String getIngredients()
-	{
-		return mUrlImage;
-	}
+    public String getIngredients() {
+        return mUrlImage;
+    }
 
-	@Override
-	public void onDestroyView()
-	{
-		presenter.dispose();
-		super.onDestroyView();
-	}
+    @Override
+    public void onDestroyView() {
+        presenter.dispose();
+        super.onDestroyView();
+    }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
@@ -30,11 +30,14 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
+
 import butterknife.BindView;
 import butterknife.OnClick;
+
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.squareup.picasso.Picasso;
 import com.theartofdev.edmodo.cropper.CropImage;
+
 import openfoodfacts.github.scrachx.openfood.R;
 import openfoodfacts.github.scrachx.openfood.fragments.BaseFragment;
 import openfoodfacts.github.scrachx.openfood.models.*;
@@ -49,7 +52,9 @@ import openfoodfacts.github.scrachx.openfood.views.ProductBrowsingListActivity;
 import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabActivityHelper;
 import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabsHelper;
 import openfoodfacts.github.scrachx.openfood.views.product.ProductActivity;
+
 import org.json.JSONObject;
+
 import pl.aprilapps.easyphotopicker.DefaultCallback;
 import pl.aprilapps.easyphotopicker.EasyImage;
 
@@ -70,569 +75,675 @@ import static openfoodfacts.github.scrachx.openfood.utils.Utils.*;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.jsoup.helper.StringUtil.isBlank;
 
-public class IngredientsProductFragment extends BaseFragment implements IIngredientsProductPresenter.View {
+public class IngredientsProductFragment extends BaseFragment implements IIngredientsProductPresenter.View
+{
 
-    public static final Pattern INGREDIENT_PATTERN = Pattern.compile("[\\p{L}\\p{Nd}(),.-]+");
-    public static final Pattern ALLERGEN_PATTERN = Pattern.compile("[\\p{L}\\p{Nd}]+[\\p{L}\\p{Nd}\\p{Z}\\p{P}&&[^,]]*");
-    @BindView(R.id.textIngredientProduct)
-    TextView ingredientsProduct;
-    @BindView(R.id.textSubstanceProduct)
-    TextView substanceProduct;
-    @BindView(R.id.textTraceProduct)
-    TextView traceProduct;
-    @BindView(R.id.textAdditiveProduct)
-    TextView additiveProduct;
-    @BindView(R.id.textPalmOilProduct)
-    TextView palmOilProduct;
-    @BindView(R.id.textMayBeFromPalmOilProduct)
-    TextView mayBeFromPalmOilProduct;
-    @BindView(R.id.imageViewIngredients)
-    ImageView mImageIngredients;
-    @BindView(R.id.addPhotoLabel)
-    TextView addPhotoLabel;
-    @BindView(R.id.vitaminsTagsText)
-    TextView vitaminTagsTextView;
-    @BindView(R.id.mineralTagsText)
-    TextView mineralTagsTextView;
-    @BindView(R.id.aminoAcidTagsText)
-    TextView aminoAcidTagsTextView;
-    @BindView(R.id.otherNutritionTags)
-    TextView otherNutritionTagTextView;
-    @BindView(R.id.cvTextIngredientProduct)
-    CardView textIngredientProductCardView;
-    @BindView(R.id.cvTextSubstanceProduct)
-    CardView textSubstanceProductCardView;
-    @BindView(R.id.cvTextTraceProduct)
-    CardView textTraceProductCardView;
-    @BindView(R.id.cvTextAdditiveProduct)
-    CardView textAdditiveProductCardView;
-    @BindView(R.id.cvTextPalmOilProduct)
-    CardView textPalmOilProductCardView;
-    @BindView(R.id.cvVitaminsTagsText)
-    CardView vitaminsTagsTextCardView;
-    @BindView(R.id.cvAminoAcidTagsText)
-    CardView aminoAcidTagsTextCardView;
-    @BindView(R.id.cvMineralTagsText)
-    CardView mineralTagsTextCardView;
-    @BindView(R.id.cvOtherNutritionTags)
-    CardView otherNutritionTagsCardView;
+	public static final Pattern INGREDIENT_PATTERN = Pattern.compile( "[\\p{L}\\p{Nd}(),.-]+" );
+	public static final Pattern ALLERGEN_PATTERN = Pattern.compile( "[\\p{L}\\p{Nd}]+[\\p{L}\\p{Nd}\\p{Z}\\p{P}&&[^,]]*" );
+	@BindView( R.id.textIngredientProduct )
+	TextView ingredientsProduct;
+	@BindView( R.id.textSubstanceProduct )
+	TextView substanceProduct;
+	@BindView( R.id.textTraceProduct )
+	TextView traceProduct;
+	@BindView( R.id.textAdditiveProduct )
+	TextView additiveProduct;
+	@BindView( R.id.textPalmOilProduct )
+	TextView palmOilProduct;
+	@BindView( R.id.textMayBeFromPalmOilProduct )
+	TextView mayBeFromPalmOilProduct;
+	@BindView( R.id.imageViewIngredients )
+	ImageView mImageIngredients;
+	@BindView( R.id.addPhotoLabel )
+	TextView addPhotoLabel;
+	@BindView( R.id.vitaminsTagsText )
+	TextView vitaminTagsTextView;
+	@BindView( R.id.mineralTagsText )
+	TextView mineralTagsTextView;
+	@BindView( R.id.aminoAcidTagsText )
+	TextView aminoAcidTagsTextView;
+	@BindView( R.id.otherNutritionTags )
+	TextView otherNutritionTagTextView;
+	@BindView( R.id.cvTextIngredientProduct )
+	CardView textIngredientProductCardView;
+	@BindView( R.id.cvTextSubstanceProduct )
+	CardView textSubstanceProductCardView;
+	@BindView( R.id.cvTextTraceProduct )
+	CardView textTraceProductCardView;
+	@BindView( R.id.cvTextAdditiveProduct )
+	CardView textAdditiveProductCardView;
+	@BindView( R.id.cvTextPalmOilProduct )
+	CardView textPalmOilProductCardView;
+	@BindView( R.id.cvVitaminsTagsText )
+	CardView vitaminsTagsTextCardView;
+	@BindView( R.id.cvAminoAcidTagsText )
+	CardView aminoAcidTagsTextCardView;
+	@BindView( R.id.cvMineralTagsText )
+	CardView mineralTagsTextCardView;
+	@BindView( R.id.cvOtherNutritionTags )
+	CardView otherNutritionTagsCardView;
 
-    private Product product;
-    private OpenFoodAPIClient api;
-    private String mUrlImage;
-    private State mState;
-    private String barcode;
-    private AdditiveDao mAdditiveDao;
-    private IProductRepository productRepository;
-    private IngredientsProductFragment mFragment;
-    private SendProduct mSendProduct;
-    private WikidataApiClient apiClientForWikiData;
-    private CustomTabActivityHelper customTabActivityHelper;
-    private CustomTabsIntent customTabsIntent;
-    private IIngredientsProductPresenter.Actions presenter;
-    //boolean to determine if image should be loaded or not
-    private boolean isLowBatteryMode = false;
+	private Product product;
+	private OpenFoodAPIClient api;
+	private String mUrlImage;
+	private State mState;
+	private String barcode;
+	private AdditiveDao mAdditiveDao;
+	private IProductRepository productRepository;
+	private IngredientsProductFragment mFragment;
+	private SendProduct mSendProduct;
+	private WikidataApiClient apiClientForWikiData;
+	private CustomTabActivityHelper customTabActivityHelper;
+	private CustomTabsIntent customTabsIntent;
+	private IIngredientsProductPresenter.Actions presenter;
+	//boolean to determine if image should be loaded or not
+	private boolean isLowBatteryMode = false;
 
-    @Override
-    public void onAttach(Context context) {
-        super.onAttach(context);
-        productRepository = ProductRepository.getInstance();
-        customTabActivityHelper = new CustomTabActivityHelper();
-        customTabsIntent = CustomTabsHelper.getCustomTabsIntent(getContext(), customTabActivityHelper.getSession());
+	@Override
+	public void onAttach( Context context )
+	{
+		super.onAttach( context );
+		productRepository = ProductRepository.getInstance();
+		customTabActivityHelper = new CustomTabActivityHelper();
+		customTabsIntent = CustomTabsHelper.getCustomTabsIntent( getContext(), customTabActivityHelper.getSession() );
 
-        Intent intent = getActivity().getIntent();
-        mState = (State) intent.getExtras().getSerializable("state");
-        product = mState.getProduct();
+		Intent intent = getActivity().getIntent();
+		mState = (State) intent.getExtras().getSerializable( "state" );
+		product = mState.getProduct();
 
-        presenter = new IngredientsProductPresenter(product, this);
-    }
+		presenter = new IngredientsProductPresenter( product, this );
+	}
 
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        api = new OpenFoodAPIClient(getActivity());
-        apiClientForWikiData = new WikidataApiClient();
-        mFragment = this;
-        return createView(inflater, container, R.layout.fragment_ingredients_product);
-    }
+	@Override
+	public View onCreateView( LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState )
+	{
+		api = new OpenFoodAPIClient( getActivity() );
+		apiClientForWikiData = new WikidataApiClient();
+		mFragment = this;
+		return createView( inflater, container, R.layout.fragment_ingredients_product );
+	}
 
-    @Override
-    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-        Intent intent = getActivity().getIntent();
-        mState = (State) intent.getExtras().getSerializable("state");
-        refreshView(mState);
-    }
+	@Override
+	public void onViewCreated( View view, @Nullable Bundle savedInstanceState )
+	{
+		super.onViewCreated( view, savedInstanceState );
+		Intent intent = getActivity().getIntent();
+		mState = (State) intent.getExtras().getSerializable( "state" );
+		refreshView( mState );
+	}
 
-    @Override
-    public void refreshView(State state) {
-        super.refreshView(state);
-        mState = state;
+	@Override
+	public void refreshView( State state )
+	{
+		super.refreshView( state );
+		mState = state;
 
-        if(getArguments()!=null){
-            mSendProduct = (SendProduct) getArguments().getSerializable("sendProduct");
-        }
+		if( getArguments() != null )
+		{
+			mSendProduct = (SendProduct) getArguments().getSerializable( "sendProduct" );
+		}
 
-        mAdditiveDao = Utils.getAppDaoSession(getActivity()).getAdditiveDao();
+		mAdditiveDao = Utils.getAppDaoSession( getActivity() ).getAdditiveDao();
 
-        // If Battery Level is low and the user has checked the Disable Image in Preferences , then set isLowBatteryMode to true
-        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(getContext());
-        Utils.DISABLE_IMAGE_LOAD = preferences.getBoolean("disableImageLoad", false);
-        if (Utils.DISABLE_IMAGE_LOAD && Utils.getBatteryLevel(getContext())) {
-            isLowBatteryMode = true;
-        }
+		// If Battery Level is low and the user has checked the Disable Image in Preferences , then set isLowBatteryMode to true
+		SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences( getContext() );
+		Utils.DISABLE_IMAGE_LOAD = preferences.getBoolean( "disableImageLoad", false );
+		if( Utils.DISABLE_IMAGE_LOAD && Utils.getBatteryLevel( getContext() ) )
+		{
+			isLowBatteryMode = true;
+		}
 
-        final Product product = mState.getProduct();
-        barcode = product.getCode();
-        List<String> vitaminTagsList = product.getVitaminTags();
-        List<String> aminoAcidTagsList = product.getAminoAcidTags();
-        List<String> mineralTags = product.getMineralTags();
-        List<String> otherNutritionTags = product.getOtherNutritionTags();
-        String prefix = " ";
+		final Product product = mState.getProduct();
+		barcode = product.getCode();
+		List<String> vitaminTagsList = product.getVitaminTags();
+		List<String> aminoAcidTagsList = product.getAminoAcidTags();
+		List<String> mineralTags = product.getMineralTags();
+		List<String> otherNutritionTags = product.getOtherNutritionTags();
+		String prefix = " ";
 
-        if (!vitaminTagsList.isEmpty()) {
-            StringBuilder vitaminStringBuilder = new StringBuilder();
-            vitaminsTagsTextCardView.setVisibility(View.VISIBLE);
-            vitaminTagsTextView.setText(bold(getString(R.string.vitamin_tags_text)));
-            for (String vitamins : vitaminTagsList) {
-                vitaminStringBuilder.append(prefix);
-                prefix = ", ";
-                vitaminStringBuilder.append(trimLanguagePartFromString(vitamins));
-            }
-            vitaminTagsTextView.append(vitaminStringBuilder.toString());
-        }
+		if( !vitaminTagsList.isEmpty() )
+		{
+			StringBuilder vitaminStringBuilder = new StringBuilder();
+			vitaminsTagsTextCardView.setVisibility( View.VISIBLE );
+			vitaminTagsTextView.setText( bold( getString( R.string.vitamin_tags_text ) ) );
+			for( String vitamins : vitaminTagsList )
+			{
+				vitaminStringBuilder.append( prefix );
+				prefix = ", ";
+				vitaminStringBuilder.append( trimLanguagePartFromString( vitamins ) );
+			}
+			vitaminTagsTextView.append( vitaminStringBuilder.toString() );
+		}
 
-        if (!aminoAcidTagsList.isEmpty()) {
-            String aminoPrefix = " ";
-            StringBuilder aminoAcidStringBuilder = new StringBuilder();
-            aminoAcidTagsTextCardView.setVisibility(View.VISIBLE);
-            aminoAcidTagsTextView.setText(bold(getString(R.string.amino_acid_tags_text)));
-            for (String aminoAcid : aminoAcidTagsList) {
-                aminoAcidStringBuilder.append(aminoPrefix);
-                aminoPrefix = ", ";
-                aminoAcidStringBuilder.append(trimLanguagePartFromString(aminoAcid));
-            }
-            aminoAcidTagsTextView.append(aminoAcidStringBuilder.toString());
-        }
+		if( !aminoAcidTagsList.isEmpty() )
+		{
+			String aminoPrefix = " ";
+			StringBuilder aminoAcidStringBuilder = new StringBuilder();
+			aminoAcidTagsTextCardView.setVisibility( View.VISIBLE );
+			aminoAcidTagsTextView.setText( bold( getString( R.string.amino_acid_tags_text ) ) );
+			for( String aminoAcid : aminoAcidTagsList )
+			{
+				aminoAcidStringBuilder.append( aminoPrefix );
+				aminoPrefix = ", ";
+				aminoAcidStringBuilder.append( trimLanguagePartFromString( aminoAcid ) );
+			}
+			aminoAcidTagsTextView.append( aminoAcidStringBuilder.toString() );
+		}
 
-        if (!mineralTags.isEmpty()) {
-            String mineralPrefix = " ";
-            StringBuilder mineralsStringBuilder = new StringBuilder();
-            mineralTagsTextCardView.setVisibility(View.VISIBLE);
-            mineralTagsTextView.setText(bold(getString(R.string.mineral_tags_text)));
-            for (String mineral : mineralTags) {
-                mineralsStringBuilder.append(mineralPrefix);
-                mineralPrefix = ", ";
-                mineralsStringBuilder.append(trimLanguagePartFromString(mineral));
-            }
-            mineralTagsTextView.append(mineralsStringBuilder);
-        }
+		if( !mineralTags.isEmpty() )
+		{
+			String mineralPrefix = " ";
+			StringBuilder mineralsStringBuilder = new StringBuilder();
+			mineralTagsTextCardView.setVisibility( View.VISIBLE );
+			mineralTagsTextView.setText( bold( getString( R.string.mineral_tags_text ) ) );
+			for( String mineral : mineralTags )
+			{
+				mineralsStringBuilder.append( mineralPrefix );
+				mineralPrefix = ", ";
+				mineralsStringBuilder.append( trimLanguagePartFromString( mineral ) );
+			}
+			mineralTagsTextView.append( mineralsStringBuilder );
+		}
 
-        if (!otherNutritionTags.isEmpty()) {
-            String otherNutritionPrefix = " ";
-            StringBuilder otherNutritionStringBuilder = new StringBuilder();
-            otherNutritionTagTextView.setVisibility(View.VISIBLE);
-            otherNutritionTagTextView.setText(bold(getString(R.string.other_tags_text)));
-            for (String otherSubstance : otherNutritionTags) {
-                otherNutritionStringBuilder.append(otherNutritionPrefix);
-                otherNutritionPrefix = ", ";
-                otherNutritionStringBuilder.append(trimLanguagePartFromString(otherSubstance));
-            }
-            otherNutritionTagTextView.append(otherNutritionStringBuilder.toString());
-        }
+		if( !otherNutritionTags.isEmpty() )
+		{
+			String otherNutritionPrefix = " ";
+			StringBuilder otherNutritionStringBuilder = new StringBuilder();
+			otherNutritionTagTextView.setVisibility( View.VISIBLE );
+			otherNutritionTagTextView.setText( bold( getString( R.string.other_tags_text ) ) );
+			for( String otherSubstance : otherNutritionTags )
+			{
+				otherNutritionStringBuilder.append( otherNutritionPrefix );
+				otherNutritionPrefix = ", ";
+				otherNutritionStringBuilder.append( trimLanguagePartFromString( otherSubstance ) );
+			}
+			otherNutritionTagTextView.append( otherNutritionStringBuilder.toString() );
+		}
 
-        additiveProduct.setText(bold(getString(R.string.txtAdditives)));
-        presenter.loadAdditives();
+		additiveProduct.setText( bold( getString( R.string.txtAdditives ) ) );
+		presenter.loadAdditives();
 
-        if (isNotBlank(product.getImageIngredientsUrl())) {
-            addPhotoLabel.setVisibility(View.GONE);
+		if( isNotBlank( product.getImageIngredientsUrl() ) )
+		{
+			addPhotoLabel.setVisibility( View.GONE );
 
-            // Load Image if isLowBatteryMode is false
-            if (!isLowBatteryMode) {
-                Picasso.with(getContext())
-                        .load(product.getImageIngredientsUrl())
-                        .into(mImageIngredients);
-            } else {
-                mImageIngredients.setVisibility(View.GONE);
-            }
+			// Load Image if isLowBatteryMode is false
+			if( !isLowBatteryMode )
+			{
+				Picasso.with( getContext() )
+						.load( product.getImageIngredientsUrl() )
+						.into( mImageIngredients );
+			}
+			else
+			{
+				mImageIngredients.setVisibility( View.GONE );
+			}
 
-            mUrlImage = product.getImageIngredientsUrl();
-        }
+			mUrlImage = product.getImageIngredientsUrl();
+		}
 
-        //useful when this fragment is used in offline saving
-        if (mSendProduct != null && isNotBlank(mSendProduct.getImgupload_ingredients())) {
-            addPhotoLabel.setVisibility(View.GONE);
-            mUrlImage = mSendProduct.getImgupload_ingredients();
-            Picasso.with(getContext()).load("file://" + mUrlImage).config(Bitmap.Config.RGB_565).into(mImageIngredients);
-        }
+		//useful when this fragment is used in offline saving
+		if( mSendProduct != null && isNotBlank( mSendProduct.getImgupload_ingredients() ) )
+		{
+			addPhotoLabel.setVisibility( View.GONE );
+			mUrlImage = mSendProduct.getImgupload_ingredients();
+			Picasso.with( getContext() ).load( "file://" + mUrlImage ).config( Bitmap.Config.RGB_565 ).into( mImageIngredients );
+		}
 
-        List<String> allergens = getAllergens();
+		List<String> allergens = getAllergens();
 
-        if (mState != null && product.getIngredientsText() != null) {
-            textIngredientProductCardView.setVisibility(View.VISIBLE);
-            SpannableStringBuilder txtIngredients = new SpannableStringBuilder(product.getIngredientsText().replace("_", ""));
-            txtIngredients = setSpanBoldBetweenTokens(txtIngredients, allergens);
-            int ingredientsListAt = Math.max(0, txtIngredients.toString().indexOf(":"));
-            if (!txtIngredients.toString().substring(ingredientsListAt).trim().isEmpty()) {
-                ingredientsProduct.setText(txtIngredients);
-            }
-        }
-        presenter.loadAllergens();
+		if( mState != null && product.getIngredientsText() != null )
+		{
+			textIngredientProductCardView.setVisibility( View.VISIBLE );
+			SpannableStringBuilder txtIngredients = new SpannableStringBuilder( product.getIngredientsText().replace( "_", "" ) );
+			txtIngredients = setSpanBoldBetweenTokens( txtIngredients, allergens );
+			int ingredientsListAt = Math.max( 0, txtIngredients.toString().indexOf( ":" ) );
+			if( !txtIngredients.toString().substring( ingredientsListAt ).trim().isEmpty() )
+			{
+				ingredientsProduct.setText( txtIngredients );
+			}
+		}
+		presenter.loadAllergens();
 
-        if (!isBlank(product.getTraces())) {
-            textTraceProductCardView.setVisibility(View.VISIBLE);
-            traceProduct.setMovementMethod(LinkMovementMethod.getInstance());
-            traceProduct.setText(bold(getString(R.string.txtTraces)));
-            traceProduct.append(" ");
+		if( !isBlank( product.getTraces() ) )
+		{
+			textTraceProductCardView.setVisibility( View.VISIBLE );
+			traceProduct.setMovementMethod( LinkMovementMethod.getInstance() );
+			traceProduct.setText( bold( getString( R.string.txtTraces ) ) );
+			traceProduct.append( " " );
 
-            String trace;
-            String traces[] = product.getTraces().split(",");
-            for (int i = 0; i < traces.length - 1; i++) {
-                trace = traces[i];
-                traceProduct.append(Utils.getClickableText(trace, trace, SearchType.TRACE, getActivity(), customTabsIntent));
-                traceProduct.append(", ");
-            }
+			String trace;
+			String traces[] = product.getTraces().split( "," );
+			for( int i = 0; i < traces.length - 1; i++ )
+			{
+				trace = traces[i];
+				traceProduct.append( Utils.getClickableText( trace, trace, SearchType.TRACE, getActivity(), customTabsIntent ) );
+				traceProduct.append( ", " );
+			}
 
-            trace = traces[traces.length - 1];
-            traceProduct.append(Utils.getClickableText(trace, trace, SearchType.TRACE, getActivity(), customTabsIntent));
-        }
+			trace = traces[traces.length - 1];
+			traceProduct.append( Utils.getClickableText( trace, trace, SearchType.TRACE, getActivity(), customTabsIntent ) );
+		}
 
-        if (!(product.getIngredientsFromPalmOilN() == 0 && product.getIngredientsFromOrThatMayBeFromPalmOilN() == 0)) {
-            textPalmOilProductCardView.setVisibility(View.VISIBLE);
-            mayBeFromPalmOilProduct.setVisibility(View.VISIBLE);
-            if (!product.getIngredientsFromPalmOilTags().isEmpty()) {
-                palmOilProduct.setText(bold(getString(R.string.txtPalmOilProduct)));
-                palmOilProduct.append(" ");
-                palmOilProduct.append(product.getIngredientsFromPalmOilTags().toString().replaceAll("[\\[,\\]]", ""));
-            } else {
-                palmOilProduct.setVisibility(View.GONE);
-            }
-            if (!product.getIngredientsThatMayBeFromPalmOilTags().isEmpty()) {
-                mayBeFromPalmOilProduct.setText(bold(getString(R.string.txtMayBeFromPalmOilProduct)));
-                mayBeFromPalmOilProduct.append(" ");
-                mayBeFromPalmOilProduct.append(product.getIngredientsThatMayBeFromPalmOilTags().toString().replaceAll("[\\[,\\]]", ""));
-            } else {
-                mayBeFromPalmOilProduct.setVisibility(View.GONE);
-            }
-        }
-    }
+		if( !( product.getIngredientsFromPalmOilN() == 0 && product.getIngredientsFromOrThatMayBeFromPalmOilN() == 0 ) )
+		{
+			textPalmOilProductCardView.setVisibility( View.VISIBLE );
+			mayBeFromPalmOilProduct.setVisibility( View.VISIBLE );
+			if( !product.getIngredientsFromPalmOilTags().isEmpty() )
+			{
+				palmOilProduct.setText( bold( getString( R.string.txtPalmOilProduct ) ) );
+				palmOilProduct.append( " " );
+				palmOilProduct.append( product.getIngredientsFromPalmOilTags().toString().replaceAll( "[\\[,\\]]", "" ) );
+			}
+			else
+			{
+				palmOilProduct.setVisibility( View.GONE );
+			}
+			if( !product.getIngredientsThatMayBeFromPalmOilTags().isEmpty() )
+			{
+				mayBeFromPalmOilProduct.setText( bold( getString( R.string.txtMayBeFromPalmOilProduct ) ) );
+				mayBeFromPalmOilProduct.append( " " );
+				mayBeFromPalmOilProduct.append( product.getIngredientsThatMayBeFromPalmOilTags().toString().replaceAll( "[\\[,\\]]", "" ) );
+			}
+			else
+			{
+				mayBeFromPalmOilProduct.setVisibility( View.GONE );
+			}
+		}
+	}
 
+	private CharSequence getAdditiveTag(AdditiveName additive) {
+		SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
 
-    private CharSequence getAdditiveTag(AdditiveName additive) {
-        SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder();
+		ClickableSpan clickableSpan = new ClickableSpan() {
+			@Override
+			public void onClick(View view) {
+				if (additive.getIsWikiDataIdPresent()) {
+					apiClientForWikiData.doSomeThing(additive.getWikiDataId(), (value, result) -> {
+						ProductActivity productActivity = (ProductActivity) getActivity();
+						if (value) {
+							if (productActivity != null && !productActivity.isFinishing()) {
+								productActivity.showBottomScreen(result, additive);
+							}
+						} else {
+							if (additive.hasOverexposureData()) {
+								productActivity.showBottomScreen(null, additive);
+							} else {
+								ProductBrowsingListActivity.startActivity(getContext(), additive.getName(), SearchType.ADDITIVE);
+							}
+						}
+					});
+				} else {
+					ProductActivity productActivity = (ProductActivity) getActivity();
+					if (additive.hasOverexposureData()) {
+						productActivity.showBottomScreen(null, additive);
+					} else {
+						ProductBrowsingListActivity.startActivity(getContext(), additive.getName(), SearchType.ADDITIVE);
+					}
+				}
+			}
+		};
 
-        ClickableSpan clickableSpan = new ClickableSpan() {
-            @Override
-            public void onClick(View view) {
-                if (additive.getIsWikiDataIdPresent()) {
-                    apiClientForWikiData.doSomeThing(additive.getWikiDataId(), new WikidataApiClient.OnWikiResponse() {
-                        @Override
-                        public void onresponse(boolean value, JSONObject result) {
-                            if (value) {
-                                ProductActivity productActivity = (ProductActivity) getActivity();
-                                if (productActivity != null && !productActivity.isFinishing()) {
-                                    productActivity.showBottomScreen(result, additive);
-                                }
-                            } else {
-                                ProductBrowsingListActivity.startActivity(getContext(), additive.getName(), SearchType.ADDITIVE);
-                            }
-                        }
-                    });
-                } else {
-                    ProductBrowsingListActivity.startActivity(getContext(), additive.getName(), SearchType.ADDITIVE);
-                }
-            }
-        };
+		spannableStringBuilder.append( additive.getName() );
+		spannableStringBuilder.setSpan( clickableSpan, 0, spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE );
 
-        spannableStringBuilder.append( additive.getName() );
-        spannableStringBuilder.setSpan( clickableSpan, 0, spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE );
+		// if the additive has an overexposure risk ("high" or "moderate") then append the warning message to it
+		if( additive.hasOverexposureData() )
+		{
+			boolean isHighRisk = "high".equalsIgnoreCase( additive.getOverexposureRisk() );
+			Drawable riskIcon;
+			String riskWarningStr;
+			int riskWarningColor;
+			if( isHighRisk )
+			{
+				riskIcon = ContextCompat.getDrawable( getContext(), R.drawable.ic_additive_high_risk );
+				riskWarningStr = getString( R.string.overexposure_high );
+				riskWarningColor = getColor( getContext(), R.color.overexposure_high );
+			}
+			else
+			{
+				riskIcon = ContextCompat.getDrawable( getContext(), R.drawable.ic_additive_moderate_risk );
+				riskWarningStr = getString( R.string.overexposure_moderate );
+				riskWarningColor = getColor( getContext(), R.color.overexposure_moderate );
+			}
+			riskIcon.setBounds( 0, 0, riskIcon.getIntrinsicWidth(), riskIcon.getIntrinsicHeight() );
+			ImageSpan iconSpan = new ImageSpan( riskIcon, ImageSpan.ALIGN_BOTTOM );
 
-        // if the additive has an overexposure risk ("high" or "moderate") then append the warning message to it
-        if( additive.getOverexposureRisk() != null && !"no".equalsIgnoreCase( additive.getOverexposureRisk() ) )
-        {
-            boolean isHighRisk = "high".equalsIgnoreCase( additive.getOverexposureRisk() );
-            Drawable riskIcon;
-            String riskWarningStr;
-            int riskWarningColor;
-            if( isHighRisk )
-            {
-                riskIcon = ContextCompat.getDrawable( getContext(), R.drawable.ic_additive_high_risk );
-                riskWarningStr = getString( R.string.overexposure_high );
-                riskWarningColor = getColor( getContext(), R.color.overexposure_high );
-            }
-            else
-            {
-                riskIcon = ContextCompat.getDrawable( getContext(), R.drawable.ic_additive_moderate_risk );
-                riskWarningStr = getString( R.string.overexposure_moderate );
-                riskWarningColor = getColor( getContext(), R.color.overexposure_moderate );
-            }
-            riskIcon.setBounds( 0, 0, riskIcon.getIntrinsicWidth(), riskIcon.getIntrinsicHeight() );
-            ImageSpan iconSpan = new ImageSpan( riskIcon, ImageSpan.ALIGN_BOTTOM );
+			spannableStringBuilder.append( " - " ); // this will be replaced with the risk icon
+			spannableStringBuilder.setSpan( iconSpan, spannableStringBuilder.length() - 2, spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE );
 
-            spannableStringBuilder.append( " - " ); // this will be replaced with the risk icon
-            spannableStringBuilder.setSpan( iconSpan, spannableStringBuilder.length() - 2, spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE );
+			spannableStringBuilder.append( riskWarningStr );
+			spannableStringBuilder.setSpan( new ForegroundColorSpan( riskWarningColor ), spannableStringBuilder.length() - riskWarningStr.length(), spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE );
+		}
 
-            spannableStringBuilder.append( riskWarningStr );
-            spannableStringBuilder.setSpan( new ForegroundColorSpan( riskWarningColor ), spannableStringBuilder.length() - riskWarningStr.length(), spannableStringBuilder.length(), SPAN_EXCLUSIVE_EXCLUSIVE );
-        }
+		return spannableStringBuilder;
+	}
 
-        return spannableStringBuilder;
-    }
+	private CharSequence getAllergensTag( AllergenName allergen )
+	{
+		SpannableStringBuilder ssb = new SpannableStringBuilder();
 
-    private CharSequence getAllergensTag(AllergenName allergen) {
-        SpannableStringBuilder ssb = new SpannableStringBuilder();
+		ClickableSpan clickableSpan = new ClickableSpan()
+		{
+			@Override
+			public void onClick( View view )
+			{
+				if( allergen.getIsWikiDataIdPresent() )
+				{
+					apiClientForWikiData.doSomeThing(
+							allergen.getWikiDataId(),
+							( value, result ) -> {
+								if( value )
+								{
+									ProductActivity productActivity = (ProductActivity) getActivity();
+									if( productActivity != null && !productActivity.isFinishing() )
+									{
+										productActivity.showBottomScreen( result, allergen );
+									}
+								}
+								else
+								{
+									ProductBrowsingListActivity.startActivity( getContext(), allergen.getName(), SearchType.ALLERGEN );
+								}
+							} );
+				}
+				else
+				{
+					ProductBrowsingListActivity.startActivity( getContext(), allergen.getName(), SearchType.ALLERGEN );
+				}
+			}
+		};
 
-        ClickableSpan clickableSpan = new ClickableSpan() {
-            @Override
-            public void onClick(View view) {
-                if (allergen.getIsWikiDataIdPresent()) {
-                    apiClientForWikiData.doSomeThing(
-                            allergen.getWikiDataId(),
-                            (value, result) -> {
-                                if (value) {
-                                    ProductActivity productActivity = (ProductActivity) getActivity();
-                                    if (productActivity != null && !productActivity.isFinishing()) {
-                                        productActivity.showBottomScreen(result, allergen);
-                                    }
-                                } else {
-                                    ProductBrowsingListActivity.startActivity(getContext(), allergen.getName(), SearchType.ALLERGEN);
-                                }
-                            });
-                } else {
-                    ProductBrowsingListActivity.startActivity(getContext(), allergen.getName(), SearchType.ALLERGEN);
-                }
-            }
-        };
+		ssb.append( allergen.getName() );
+		ssb.setSpan( clickableSpan, 0, ssb.length(), SPAN_EXCLUSIVE_EXCLUSIVE );
+		// If allergen is not in the taxonomy list then italicize it
+		if( !allergen.isNotNull() )
+		{
+			StyleSpan iss =
+					new StyleSpan( android.graphics.Typeface.ITALIC ); //Span to make text italic
+			ssb.setSpan( iss, 0, ssb.length(), SPAN_EXCLUSIVE_EXCLUSIVE );
+		}
+		return ssb;
+	}
 
-        ssb.append(allergen.getName());
-        ssb.setSpan(clickableSpan, 0, ssb.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
-        // If allergen is not in the taxonomy list then italicize it
-        if (!allergen.isNotNull()) {
-            StyleSpan iss =
-                    new StyleSpan(android.graphics.Typeface.ITALIC); //Span to make text italic
-            ssb.setSpan(iss, 0, ssb.length(), SPAN_EXCLUSIVE_EXCLUSIVE);
-        }
-        return ssb;
-    }
+	/**
+	 * @return the string after trimming the language code from the tags
+	 * like it returns folic-acid for en:folic-acid
+	 */
+	private String trimLanguagePartFromString( String string )
+	{
+		return string.substring( 3 );
+	}
 
-    /**
-     * @return the string after trimming the language code from the tags
-     * like it returns folic-acid for en:folic-acid
-     */
-    private String trimLanguagePartFromString(String string) {
-        return string.substring(3);
-    }
+	private SpannableStringBuilder setSpanBoldBetweenTokens( CharSequence text, List<String> allergens )
+	{
+		final SpannableStringBuilder ssb = new SpannableStringBuilder( text );
+		Matcher m = INGREDIENT_PATTERN.matcher( ssb );
+		while( m.find() )
+		{
+			final String tm = m.group();
+			final String allergenValue = tm.replaceAll( "[(),.-]+", "" );
 
-    private SpannableStringBuilder setSpanBoldBetweenTokens(CharSequence text, List<String> allergens) {
-        final SpannableStringBuilder ssb = new SpannableStringBuilder(text);
-        Matcher m = INGREDIENT_PATTERN.matcher(ssb);
-        while (m.find()) {
-            final String tm = m.group();
-            final String allergenValue = tm.replaceAll("[(),.-]+", "");
+			for( String allergen : allergens )
+			{
+				if( allergen.equalsIgnoreCase( allergenValue ) )
+				{
+					int start = m.start();
+					int end = m.end();
 
-            for (String allergen : allergens) {
-                if (allergen.equalsIgnoreCase(allergenValue)) {
-                    int start = m.start();
-                    int end = m.end();
+					if( tm.contains( "(" ) )
+					{
+						start += 1;
+					}
+					else if( tm.contains( ")" ) )
+					{
+						end -= 1;
+					}
 
-                    if (tm.contains("(")) {
-                        start += 1;
-                    } else if (tm.contains(")")) {
-                        end -= 1;
-                    }
+					ssb.setSpan( new StyleSpan( Typeface.BOLD ), start, end, SPAN_EXCLUSIVE_EXCLUSIVE );
+				}
+			}
+		}
+		ssb.insert( 0, Utils.bold( getString( R.string.txtIngredients ) + ' ' ) );
+		return ssb;
+	}
 
-                    ssb.setSpan(new StyleSpan(Typeface.BOLD), start, end, SPAN_EXCLUSIVE_EXCLUSIVE);
-                }
-            }
-        }
-        ssb.insert(0, Utils.bold(getString(R.string.txtIngredients) + ' '));
-        return ssb;
-    }
+	private SpannableString buildAdditivesList( List<AdditiveName> additives )
+	{
+		return null;
+	}
 
-    private SpannableString buildAdditivesList(List<AdditiveName> additives) {
-        return null;
-    }
+	@Override
+	public void showAdditives( List<AdditiveName> additives )
+	{
+		additiveProduct.setText( bold( getString( R.string.txtAdditives ) ) );
+		additiveProduct.setMovementMethod( LinkMovementMethod.getInstance() );
+		additiveProduct.append( " " );
+		additiveProduct.append( "\n" );
+		additiveProduct.setClickable( true );
+		additiveProduct.setMovementMethod( LinkMovementMethod.getInstance() );
 
-    @Override
-    public void showAdditives(List<AdditiveName> additives) {
-        additiveProduct.setText(bold(getString(R.string.txtAdditives)));
-        additiveProduct.setMovementMethod(LinkMovementMethod.getInstance());
-        additiveProduct.append(" ");
-        additiveProduct.append("\n");
-        additiveProduct.setClickable(true);
-        additiveProduct.setMovementMethod(LinkMovementMethod.getInstance());
+		for( int i = 0; i < additives.size() - 1; i++ )
+		{
+			additiveProduct.append( getAdditiveTag( additives.get( i ) ) );
+			additiveProduct.append( "\n" );
+		}
 
-        for (int i = 0; i < additives.size() - 1; i++) {
-            additiveProduct.append(getAdditiveTag(additives.get(i)));
-            additiveProduct.append("\n");
-        }
+		additiveProduct.append( getAdditiveTag( ( additives.get( additives.size() - 1 ) ) ) );
+	}
 
-        additiveProduct.append(getAdditiveTag((additives.get(additives.size() - 1))));
-    }
+	@Override
+	public void showAdditivesState( String state )
+	{
+		switch( state )
+		{
+			case LOADING:
+			{
+				textAdditiveProductCardView.setVisibility( View.VISIBLE );
+				additiveProduct.append( getString( R.string.txtLoading ) );
+				break;
+			}
+			case EMPTY:
+			{
+				textAdditiveProductCardView.setVisibility( View.GONE );
+				break;
+			}
+		}
+	}
 
-    @Override
-    public void showAdditivesState(String state) {
-        switch (state) {
-            case LOADING: {
-                textAdditiveProductCardView.setVisibility(View.VISIBLE);
-                additiveProduct.append(getString(R.string.txtLoading));
-                break;
-            }
-            case EMPTY: {
-                textAdditiveProductCardView.setVisibility(View.GONE);
-                break;
-            }
-        }
-    }
+	@Override
+	public void showAllergens( List<AllergenName> allergens )
+	{
+		substanceProduct.setMovementMethod( LinkMovementMethod.getInstance() );
+		substanceProduct.setText( bold( getString( R.string.txtSubstances ) ) );
+		substanceProduct.append( " " );
 
-    @Override
-    public void showAllergens(List<AllergenName> allergens) {
-        substanceProduct.setMovementMethod(LinkMovementMethod.getInstance());
-        substanceProduct.setText(bold(getString(R.string.txtSubstances)));
-        substanceProduct.append(" ");
+		for( int i = 0, lastIdx = allergens.size() - 1; i <= lastIdx; i++ )
+		{
+			AllergenName allergen = allergens.get( i );
+			substanceProduct.append( getAllergensTag( allergen ) );
+			// Add comma if not the last item
+			if( i != lastIdx )
+			{
+				substanceProduct.append( ", " );
+			}
+		}
+	}
 
-        for (int i = 0, lastIdx = allergens.size() - 1; i <= lastIdx; i++) {
-            AllergenName allergen = allergens.get(i);
-            substanceProduct.append(getAllergensTag(allergen));
-            // Add comma if not the last item
-            if (i != lastIdx) substanceProduct.append(", ");
-        }
-    }
+	@Override
+	public void showAllergensState( String state )
+	{
+		switch( state )
+		{
+			case LOADING:
+			{
+				textSubstanceProductCardView.setVisibility( View.VISIBLE );
+				substanceProduct.append( getString( R.string.txtLoading ) );
+				break;
+			}
+			case EMPTY:
+			{
+				textSubstanceProductCardView.setVisibility( View.GONE );
+				break;
+			}
+		}
+	}
 
-    @Override
-    public void showAllergensState(String state) {
-        switch (state) {
-            case LOADING: {
-                textSubstanceProductCardView.setVisibility(View.VISIBLE);
-                substanceProduct.append(getString(R.string.txtLoading));
-                break;
-            }
-            case EMPTY: {
-                textSubstanceProductCardView.setVisibility(View.GONE);
-                break;
-            }
-        }
-    }
+	private List<String> getAllergens()
+	{
+		List<String> allergens = mState.getProduct().getAllergensTags();
+		if( mState.getProduct() == null || allergens == null || allergens.isEmpty() )
+		{
+			return Collections.emptyList();
+		}
+		else
+		{
+			return allergens;
+		}
+	}
 
-    private List<String> getAllergens() {
-        List<String> allergens = mState.getProduct().getAllergensTags();
-        if (mState.getProduct() == null || allergens == null || allergens.isEmpty()) {
-            return Collections.emptyList();
-        } else {
-            return allergens;
-        }
-    }
-
-    @OnClick(R.id.imageViewIngredients)
-    public void openFullScreen(View v) {
-        if (mUrlImage != null) {
-            Intent intent = new Intent(v.getContext(), FullScreenImage.class);
-            Bundle bundle = new Bundle();
-            bundle.putString("imageurl", mUrlImage);
-            intent.putExtras(bundle);
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                ActivityOptionsCompat options = ActivityOptionsCompat.
-                        makeSceneTransitionAnimation(getActivity(), (View) mImageIngredients,
-                                getActivity().getString(R.string.product_transition));
-                startActivity(intent, options.toBundle());
-            } else {
-                startActivity(intent);
-            }
-
-        } else {
-            // take a picture
-            if (ContextCompat.checkSelfPermission(getActivity(), CAMERA) != PERMISSION_GRANTED) {
-                ActivityCompat.requestPermissions(getActivity(), new String[]{CAMERA}, MY_PERMISSIONS_REQUEST_CAMERA);
-            } else {
-                EasyImage.openCamera(this, 0);
+	@OnClick( R.id.imageViewIngredients )
+	public void openFullScreen( View v )
+	{
+		if( mUrlImage != null )
+		{
+			Intent intent = new Intent( v.getContext(), FullScreenImage.class );
+			Bundle bundle = new Bundle();
+			bundle.putString( "imageurl", mUrlImage );
+			intent.putExtras( bundle );
+			if( Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP )
+			{
+				ActivityOptionsCompat options = ActivityOptionsCompat.
+						makeSceneTransitionAnimation( getActivity(), (View) mImageIngredients,
+								getActivity().getString( R.string.product_transition ) );
+				startActivity( intent, options.toBundle() );
+			}
+			else
+			{
+				startActivity( intent );
+			}
+		}
+		else
+		{
+			// take a picture
+			if( ContextCompat.checkSelfPermission( getActivity(), CAMERA ) != PERMISSION_GRANTED )
+			{
+				ActivityCompat.requestPermissions( getActivity(), new String[]{ CAMERA }, MY_PERMISSIONS_REQUEST_CAMERA );
+			}
+			else
+			{
+				EasyImage.openCamera( this, 0 );
 //                EasyImage.openGallery(this);
-            }
-        }
-    }
+			}
+		}
+	}
 
-    private void onPhotoReturned(File photoFile) {
-        ProductImage image = new ProductImage(barcode, INGREDIENTS, photoFile);
-        image.setFilePath(photoFile.getAbsolutePath());
-        api.postImg(getContext(), image);
-        addPhotoLabel.setVisibility(View.GONE);
-        mUrlImage = photoFile.getAbsolutePath();
+	private void onPhotoReturned( File photoFile )
+	{
+		ProductImage image = new ProductImage( barcode, INGREDIENTS, photoFile );
+		image.setFilePath( photoFile.getAbsolutePath() );
+		api.postImg( getContext(), image );
+		addPhotoLabel.setVisibility( View.GONE );
+		mUrlImage = photoFile.getAbsolutePath();
 
-        Picasso.with(getContext())
-                .load(photoFile)
-                .fit()
-                .into(mImageIngredients);
-    }
+		Picasso.with( getContext() )
+				.load( photoFile )
+				.fit()
+				.into( mImageIngredients );
+	}
 
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
-            CropImage.ActivityResult result = CropImage.getActivityResult(data);
-            if (resultCode == RESULT_OK) {
-                Uri resultUri = result.getUri();
-                onPhotoReturned(new File(resultUri.getPath()));
-            } else if (resultCode == CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE) {
-                Exception error = result.getError();
-            }
-        }
+	@Override
+	public void onActivityResult( int requestCode, int resultCode, Intent data )
+	{
+		super.onActivityResult( requestCode, resultCode, data );
+		if( requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE )
+		{
+			CropImage.ActivityResult result = CropImage.getActivityResult( data );
+			if( resultCode == RESULT_OK )
+			{
+				Uri resultUri = result.getUri();
+				onPhotoReturned( new File( resultUri.getPath() ) );
+			}
+			else if( resultCode == CropImage.CROP_IMAGE_ACTIVITY_RESULT_ERROR_CODE )
+			{
+				Exception error = result.getError();
+			}
+		}
 
-        EasyImage.handleActivityResult(requestCode, resultCode, data, getActivity(), new DefaultCallback() {
-            @Override
-            public void onImagePickerError(Exception e, EasyImage.ImageSource source, int type) {
-                //Some error handling
-            }
+		EasyImage.handleActivityResult( requestCode, resultCode, data, getActivity(), new DefaultCallback()
+		{
+			@Override
+			public void onImagePickerError( Exception e, EasyImage.ImageSource source, int type )
+			{
+				//Some error handling
+			}
 
-            @Override
-            public void onImagesPicked(List<File> imageFiles, EasyImage.ImageSource source, int type) {
-                CropImage.activity(Uri.fromFile(imageFiles.get(0)))
-                        .setCropMenuCropButtonIcon(R.drawable.ic_check_white_24dp)
-                        .setAllowFlipping(false)
-                        .setOutputUri(Utils.getOutputPicUri(getContext()))
-                        .start(getContext(), mFragment);
-            }
+			@Override
+			public void onImagesPicked( List<File> imageFiles, EasyImage.ImageSource source, int type )
+			{
+				CropImage.activity( Uri.fromFile( imageFiles.get( 0 ) ) )
+						.setCropMenuCropButtonIcon( R.drawable.ic_check_white_24dp )
+						.setAllowFlipping( false )
+						.setOutputUri( Utils.getOutputPicUri( getContext() ) )
+						.start( getContext(), mFragment );
+			}
 
-            @Override
-            public void onCanceled(EasyImage.ImageSource source, int type) {
-                //Cancel handling, you might wanna remove taken photo if it was canceled
-                if (source == EasyImage.ImageSource.CAMERA) {
-                    File photoFile = EasyImage.lastlyTakenButCanceledPhoto(getContext());
-                    if (photoFile != null) photoFile.delete();
-                }
-            }
-        });
-    }
+			@Override
+			public void onCanceled( EasyImage.ImageSource source, int type )
+			{
+				//Cancel handling, you might wanna remove taken photo if it was canceled
+				if( source == EasyImage.ImageSource.CAMERA )
+				{
+					File photoFile = EasyImage.lastlyTakenButCanceledPhoto( getContext() );
+					if( photoFile != null )
+					{
+						photoFile.delete();
+					}
+				}
+			}
+		} );
+	}
 
-    @Override
-    public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[], @NonNull int[] grantResults) {
-        switch (requestCode) {
-            case MY_PERMISSIONS_REQUEST_CAMERA: {
-                if (grantResults.length <= 0 || grantResults[0] != PERMISSION_GRANTED) {
-                    new MaterialDialog.Builder(getActivity())
-                            .title(R.string.permission_title)
-                            .content(R.string.permission_denied)
-                            .negativeText(R.string.txtNo)
-                            .positiveText(R.string.txtYes)
-                            .onPositive((dialog, which) -> {
-                                Intent intent = new Intent();
-                                intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-                                Uri uri = Uri.fromParts("package", getActivity().getPackageName(), null);
-                                intent.setData(uri);
-                                startActivity(intent);
-                            })
-                            .show();
-                } else {
-                    EasyImage.openCamera(this, 0);
-                }
-            }
-        }
-    }
+	@Override
+	public void onRequestPermissionsResult( int requestCode, @NonNull String permissions[], @NonNull int[] grantResults )
+	{
+		switch( requestCode )
+		{
+			case MY_PERMISSIONS_REQUEST_CAMERA:
+			{
+				if( grantResults.length <= 0 || grantResults[0] != PERMISSION_GRANTED )
+				{
+					new MaterialDialog.Builder( getActivity() )
+							.title( R.string.permission_title )
+							.content( R.string.permission_denied )
+							.negativeText( R.string.txtNo )
+							.positiveText( R.string.txtYes )
+							.onPositive( ( dialog, which ) -> {
+								Intent intent = new Intent();
+								intent.setAction( Settings.ACTION_APPLICATION_DETAILS_SETTINGS );
+								Uri uri = Uri.fromParts( "package", getActivity().getPackageName(), null );
+								intent.setData( uri );
+								startActivity( intent );
+							} )
+							.show();
+				}
+				else
+				{
+					EasyImage.openCamera( this, 0 );
+				}
+			}
+		}
+	}
 
-    public String getIngredients() {
-        return mUrlImage;
-    }
+	public String getIngredients()
+	{
+		return mUrlImage;
+	}
 
-    @Override
-    public void onDestroyView() {
-        presenter.dispose();
-        super.onDestroyView();
-    }
+	@Override
+	public void onDestroyView()
+	{
+		presenter.dispose();
+		super.onDestroyView();
+	}
 }

--- a/app/src/main/res/layout/fragment_product_attribute_details.xml
+++ b/app/src/main/res/layout/fragment_product_attribute_details.xml
@@ -60,33 +60,25 @@
             </LinearLayout>
 
 
-            <LinearLayout
-                android:id="@+id/descriptionContainer"
+            <TextView
+                android:id="@+id/description"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_below="@+id/titleContainer"
                 android:layout_margin="@dimen/spacing_tiny"
                 android:background="@color/grey_50"
-                android:gravity="center_vertical"
-                android:padding="@dimen/spacing_small">
-
-
-                <TextView
-                    android:id="@+id/description"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:text="@string/description_activity_product"
-                    android:textAlignment="center"
-                    android:textSize="@dimen/font_normal"/>
-            </LinearLayout>
+                android:gravity="center"
+                android:padding="@dimen/spacing_small"
+                android:text="@string/description_activity_product"
+                android:textAlignment="center"
+                android:textSize="@dimen/font_normal"/>
 
             <include
                 android:id="@+id/exposureEvalTable"
                 layout="@layout/exposure_eval_table"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@+id/descriptionContainer"
+                android:layout_below="@+id/description"
                 android:visibility="gone"/>
 
             <LinearLayout


### PR DESCRIPTION
Signed-off-by: Rares Petrescu <petrescu.rares@gmail.com>

Change the default behaviour when clicking a moderate/high additive by showing the overexposure table even if wikidata is missing.

Before this change, if the wikidata was missing, a click on the additive name will automatically search for products containing the additive.
With this patch, if wikidata is missing, we hide the description and the wiki button from additive details popup, but we still display the overexposure table and the search button.