### PR TITLE
Change the Allergen Fragment to show a message when empty

### DIFF
--- a/app/src/main/res/layout/fragment_alert_allergens.xml
+++ b/app/src/main/res/layout/fragment_alert_allergens.xml
@@ -4,6 +4,30 @@
     android:layout_height="match_parent"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <LinearLayout
+        android:id="@+id/emptyAllergensView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:layout_margin="16dp"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="16dp"
+            android:text="@string/alert_dialog_warning_title"
+            android:textColor="@color/md_black_1000"
+            android:textSize="22sp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/warning_alert_data"
+            android:textSize="16sp" />
+    </LinearLayout>
+
     <android.support.v7.widget.RecyclerView
         android:id="@+id/allergens_recycle"
         android:layout_width="match_parent"


### PR DESCRIPTION
## Description
The message which was supposed to be a popup is now embedded in the fragment view. It is visible when the list is empty and is hidden if the list has one element. According to me it was a better option as the view was quite empty when no items were present in the list. 
Make sure that the code is fine. I have tried to use variable names as self-explanatory as possible.

#fixes 429 Transfer the allergen warning popup into the view
 
 ## Checklist
 Simple UI change with few changes in code.
So satisfied almost all the checklist items
