### PR TITLE
Refresh instantaneously after edit and fix display of calculated additives and allergens

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ProductActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ProductActivity.java
@@ -64,6 +64,7 @@ public class ProductActivity extends BaseActivity implements OnRefreshListener
 {
 
 	private static final int LOGIN_ACTIVITY_REQUEST_CODE = 1;
+	private static final int EDIT_REQUEST_CODE = 2;
 	@BindView( R.id.pager )
 	ViewPager viewPager;
 	@BindView( R.id.toolbar )
@@ -177,10 +178,10 @@ public class ProductActivity extends BaseActivity implements OnRefreshListener
 								.build().show();
 					}
 					else
-					{
+					{	mState = (State) getIntent().getExtras().getSerializable( "state" );
 						Intent intent = new Intent( ProductActivity.this, AddProductActivity.class );
 						intent.putExtra( "edit_product", mState.getProduct() );
-						startActivity( intent );
+						startActivityForResult( intent, EDIT_REQUEST_CODE );
 					}
 					break;
 
@@ -201,6 +202,9 @@ public class ProductActivity extends BaseActivity implements OnRefreshListener
 		} );
 		CoordinatorLayout.LayoutParams layoutParams = (CoordinatorLayout.LayoutParams) bottomNavigationView.getLayoutParams();
 		layoutParams.setBehavior( new BottomNavigationBehavior() );
+
+		//To update the product details
+		onRefresh();
 	}
 
 	@Override
@@ -212,6 +216,10 @@ public class ProductActivity extends BaseActivity implements OnRefreshListener
 			Intent intent = new Intent( ProductActivity.this, AddProductActivity.class );
 			intent.putExtra( "edit_product", mState.getProduct() );
 			startActivity( intent );
+		}
+		if( requestCode == EDIT_REQUEST_CODE && resultCode == RESULT_OK)
+		{
+			onRefresh();
 		}
 	}
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
@@ -25,6 +25,7 @@ import android.text.style.ClickableSpan;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.ImageSpan;
 import android.text.style.StyleSpan;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -187,6 +188,7 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
         }
 
         final Product product = mState.getProduct();
+        presenter = new IngredientsProductPresenter(product, this);
         barcode = product.getCode();
         List<String> vitaminTagsList = product.getVitaminTags();
         List<String> aminoAcidTagsList = product.getAminoAcidTags();
@@ -280,6 +282,8 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
             if (!txtIngredients.toString().substring(ingredientsListAt).trim().isEmpty()) {
                 ingredientsProduct.setText(txtIngredients);
             }
+        } else {
+            textIngredientProductCardView.setVisibility(View.GONE);
         }
         presenter.loadAllergens();
 
@@ -299,6 +303,8 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
 
             trace = traces[traces.length - 1];
             traceProduct.append(Utils.getClickableText(trace, trace, SearchType.TRACE, getActivity(), customTabsIntent));
+        } else {
+            textTraceProductCardView.setVisibility(View.GONE);
         }
 
         if (!(product.getIngredientsFromPalmOilN() == 0 && product.getIngredientsFromOrThatMayBeFromPalmOilN() == 0)) {


### PR DESCRIPTION
## Description

Now product is refreshed as soon as edit is made, and changes are reflected immediately in the edit fields too. Computed additives/allergens and traces also work as expected now. 

 
 ## Screen-shots, if any
 
![whatsapp image 2019-01-09 at 6 17 33 pm](https://user-images.githubusercontent.com/35020024/50900346-e8ecc300-143a-11e9-932a-070fca9dfd57.jpeg)

