### PR TITLE
Fixed: Changing languages changes connexion status in side menu.

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -274,7 +274,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
 
         // Add Manage Account profile if the user is connected
         SharedPreferences preferences = getSharedPreferences("login", 0);
-        String userLogin = preferences.getString(getResources().getString(R.string.user), null);
+        String userLogin = preferences.getString("user", null);
         String userSession = preferences.getString("user_session", null);
         boolean isUserConnected = userLogin != null && userSession != null;
         isConnected = userLogin != null;


### PR DESCRIPTION
## Description
The user preferences are saved in the English language not according to app language, so I've changed it to a hardcoded string "user". Thus fixing the issue.

## Related issues and discussion
#fixes #1869 
 
 ## Screen-shots, if any
 
![screenshot_2019-01-09-22-56-04-397_openfoodfacts github scrachx openfood](https://user-images.githubusercontent.com/32436867/50916741-e9e51b00-1461-11e9-8e5d-f32d845e1233.png)
