### PR TITLE
Fixes #2072: Remove the pictures from the "Contributions" tab

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/ContributorsFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/ContributorsFragment.java
@@ -52,12 +52,6 @@ public class ContributorsFragment extends BaseFragment {
     TextView otherEditorsText;
     @BindView(R.id.states)
     TextView statesText;
-    @BindView(R.id.contribute_image_front)
-    ImageView imgFront;
-    @BindView(R.id.contribute_image_ingredients)
-    ImageView imgIngredients;
-    @BindView(R.id.contribute_image_nutrients)
-    ImageView imgNutrients;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
@@ -122,17 +116,6 @@ public class ContributorsFragment extends BaseFragment {
             }
         }
 
-        if (isNotBlank(product.getImageFrontUrl())) {
-            Picasso.with(getContext()).load(product.getImageFrontUrl()).into(imgFront);
-        }
-
-        if (isNotBlank(product.getImageIngredientsUrl())) {
-            Picasso.with(getContext()).load(product.getImageIngredientsUrl()).into(imgIngredients);
-        }
-
-        if (isNotBlank(product.getImageNutritionUrl())) {
-            Picasso.with(getContext()).load(product.getImageNutritionUrl()).into(imgNutrients);
-        }
     }
 
     private String[] getDateTime(String dateTime) {

--- a/app/src/main/res/layout/fragment_contributors.xml
+++ b/app/src/main/res/layout/fragment_contributors.xml
@@ -84,49 +84,6 @@
                 android:padding="16dp"
                 app:cardElevation="4dp">
 
-                <android.support.v4.widget.NestedScrollView
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal">
-
-                        <ImageView
-                            android:id="@+id/contribute_image_front"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_margin="16dp"
-                            android:contentDescription="TODO" />
-
-                        <ImageView
-                            android:id="@+id/contribute_image_ingredients"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_margin="16dp"
-                            android:contentDescription="TODO" />
-
-                        <ImageView
-                            android:id="@+id/contribute_image_nutrients"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_margin="16dp"
-                            android:contentDescription="TODO" />
-
-                    </LinearLayout>
-                </android.support.v4.widget.NestedScrollView>
-
-            </android.support.v7.widget.CardView>
-
-
-            <android.support.v7.widget.CardView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_margin="8dp"
-                android:padding="16dp"
-                app:cardElevation="4dp">
-
                 <TextView
                     android:id="@+id/states"
                     android:layout_width="match_parent"


### PR DESCRIPTION
## Description

The product images were removed from the "Contributions" tab, since they were already present in the "Product Photos" tab.

## Related issues and discussion
#fixes #2072 
 
 ## Screen-shots, if any
See attached
![device-2019-01-12-123004](https://user-images.githubusercontent.com/42271776/51070350-d60a0680-1665-11e9-8c1e-f606e8acdaa7.png)

