### PR TITLE
Fixes #2087: Space increase on refresh in Nutrition Facts tab

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition/NutritionProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition/NutritionProductFragment.java
@@ -120,6 +120,9 @@ public class NutritionProductFragment extends BaseFragment implements CustomTabA
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         Intent intent = getActivity().getIntent();
+        // use VERTICAL divider
+        DividerItemDecoration dividerItemDecoration = new DividerItemDecoration(nutrimentsRecyclerView.getContext(), VERTICAL);
+        nutrimentsRecyclerView.addItemDecoration(dividerItemDecoration);
         refreshView((State) intent.getExtras().getSerializable("state"));
     }
 
@@ -280,10 +283,6 @@ public class NutritionProductFragment extends BaseFragment implements CustomTabA
         nutrimentsRecyclerView.setLayoutManager(mLayoutManager);
 
         nutrimentsRecyclerView.setNestedScrollingEnabled(false);
-
-        // use VERTICAL divider
-        DividerItemDecoration dividerItemDecoration = new DividerItemDecoration(nutrimentsRecyclerView.getContext(), VERTICAL);
-        nutrimentsRecyclerView.addItemDecoration(dividerItemDecoration);
 
         // Header hack
         nutrimentItems.add(new NutrimentItem(null, null, null, null, null));


### PR DESCRIPTION
## Description

A divider was being added to the items of the nutrimentsRecyclerView in refreshView(), thus every time the user refreshed the screen, the spacing between items increased. This was solved by shifting the addition of dividers to onViewCreated() instead of refreshView(), so its called only once.

## Related issues and discussion
#fixes #2087
 
 ## Screen-shots, if any
See attached