### PR TITLE
Fixes #2124: Remove the exclamation mark in History when there is no Nutri-Score

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
@@ -300,11 +300,7 @@ public class Utils {
     }
 
     public static int getSmallImageGrade(String grade) {
-        int drawable;
-
-        if (grade == null) {
-            return R.drawable.ic_error;
-        }
+        int drawable = 0;
 
         switch (grade.toLowerCase(Locale.getDefault())) {
             case "a":
@@ -321,9 +317,6 @@ public class Utils {
                 break;
             case "e":
                 drawable = R.drawable.nnc_small_e;
-                break;
-            default:
-                drawable = R.drawable.ic_error;
                 break;
         }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/HistoryListAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/HistoryListAdapter.java
@@ -70,7 +70,11 @@ public class HistoryListAdapter extends RecyclerView.Adapter<HistoryScanHolder> 
         if(BuildConfig.FLAVOR.equals("opf")||BuildConfig.FLAVOR.equals("opff")||BuildConfig.FLAVOR.equals("obf")){
             holder.imgNutritionGrade.setVisibility(View.GONE);
         }
-        holder.imgNutritionGrade.setImageDrawable(ContextCompat.getDrawable(mActivity, Utils.getSmallImageGrade(item.getNutritionGrade())));
+        if (Utils.getSmallImageGrade(item.getNutritionGrade()) != 0) {
+            holder.imgNutritionGrade.setImageDrawable(ContextCompat.getDrawable(mActivity, Utils.getSmallImageGrade(item.getNutritionGrade())));
+        } else {
+            holder.imgNutritionGrade.setVisibility(View.INVISIBLE);
+        }
         if (item.getUrl() == null) {
             holder.historyImageProgressbar.setVisibility(View.GONE);
         }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/ProductsRecyclerViewAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/ProductsRecyclerViewAdapter.java
@@ -108,6 +108,8 @@ public class ProductsRecyclerViewAdapter extends RecyclerView.Adapter {
             if (isNotEmpty(product.getNutritionGradeFr())) {
                 productHolder.vProductGrade.setImageDrawable(ContextCompat.getDrawable(context, Utils.getSmallImageGrade(product
                         .getNutritionGradeFr())));
+            } else {
+                productHolder.vProductGrade.setVisibility(View.INVISIBLE);
             }
 
             productHolder.vProductDetails.setText(stringBuilder.toString());

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/ProductsRecyclerViewAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/ProductsRecyclerViewAdapter.java
@@ -106,8 +106,12 @@ public class ProductsRecyclerViewAdapter extends RecyclerView.Adapter {
             }
 
             if (isNotEmpty(product.getNutritionGradeFr())) {
-                productHolder.vProductGrade.setImageDrawable(ContextCompat.getDrawable(context, Utils.getSmallImageGrade(product
-                        .getNutritionGradeFr())));
+                if(Utils.getSmallImageGrade(product.getNutritionGradeFr()) != 0) {
+                    productHolder.vProductGrade.setImageDrawable(ContextCompat.getDrawable(context, Utils.getSmallImageGrade(product
+                            .getNutritionGradeFr())));
+                } else {
+                    productHolder.vProductGrade.setVisibility(View.INVISIBLE);
+                }
             } else {
                 productHolder.vProductGrade.setVisibility(View.INVISIBLE);
             }


### PR DESCRIPTION
## Description

The exclamation mark is no longer passed as a default case, even when the nutriscore is not computed. Furthermore, the incorrect nutrigrades were displayed in 'Products To Be Completed' on scrolling the recyclerview, which was also fixed. 

## Related issues and discussion
#fixes #2124 

