### PR TITLE
Fixes #2137: java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String java.lang.String.toLowerCase(java.util.Locale)' on a null object reference at openfoodfacts.github.scrachx.openfood.utils.Utils.getSmallImageGrade(Utils.java:305)

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
@@ -302,6 +302,10 @@ public class Utils {
     public static int getSmallImageGrade(String grade) {
         int drawable = 0;
 
+        if (grade == null) {
+            return drawable;
+        }
+
         switch (grade.toLowerCase(Locale.getDefault())) {
             case "a":
                 drawable = R.drawable.nnc_small_a;


### PR DESCRIPTION
## Description

Added a case for when the nutriscore grade is set to null, so there's no longer a npe thrown.

## Related issues and discussion
#fixes #2137 
