### PR TITLE
Fixes: #2086: Trash icon visible after swiping in History section.

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/SwipeController.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/SwipeController.java
@@ -14,6 +14,7 @@ import android.view.View;
 
 import openfoodfacts.github.scrachx.openfood.R;
 
+import static android.support.v7.widget.helper.ItemTouchHelper.ACTION_STATE_IDLE;
 import static android.support.v7.widget.helper.ItemTouchHelper.ACTION_STATE_SWIPE;
 import static android.support.v7.widget.helper.ItemTouchHelper.LEFT;
 import static android.support.v7.widget.helper.ItemTouchHelper.RIGHT;
@@ -83,7 +84,11 @@ public class SwipeController extends Callback {
                 setTouchListener(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive);
             }
         }
-
+        if(actionState == ACTION_STATE_IDLE){
+            if (buttonShowedState == ButtonsState.GONE) {
+                super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive);
+            }
+        }
         if (buttonShowedState == ButtonsState.GONE) {
             super.onChildDraw(c, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive);
         }


### PR DESCRIPTION
## Description

Trash icon visible after swiping in History section. After, figuring out the the why trash icon is visible after right swipe, I saw that the button is visible when the actionstate is `ACTION_STATE_SWIPE` and it remains visible if the actionstate changed to `ACTION_STATE_IDLE` so, I have applied a condition when actionstate is `ACTION_STATE_IDLE`  then the button should not be visible on left swipe.

## Related issues and discussion
### Fixes #2086 
 
 ## Screen-shots
![to](https://user-images.githubusercontent.com/30935658/51743515-d624f000-20c2-11e9-9614-11c9b53a78ae.gif)

