### PR TITLE
Fixes: #2145, NullPointerException on EditText

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductNutritionFactsFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductNutritionFactsFragment.java
@@ -297,6 +297,7 @@ public class AddProductNutritionFactsFragment extends BaseFragment {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         Bundle b = getArguments();
+        lastEditText = alcohol;
         if (b != null) {
             product = (Product) b.getSerializable("product");
             mOfflineSavedProduct = (OfflineSavedProduct) b.getSerializable("edit_offline_product");
@@ -317,7 +318,6 @@ public class AddProductNutritionFactsFragment extends BaseFragment {
             activity.finish();
         }
         alcohol.setImeOptions(EditorInfo.IME_ACTION_DONE);
-        lastEditText = alcohol;
     }
 
     /**


### PR DESCRIPTION
## Description

NullPointerException on EditText. The `lastEditText` was not initialized before calling its methods. So I initialized it in `onViewCreated` before calling its methods in function `addNutrientRow`.

## Related issues and discussion
### Fixes #2145 