### PR TITLE
Fixes #2141: Hide the nutrient level card if there are no nutrient levels

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition/NutritionProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition/NutritionProductFragment.java
@@ -15,6 +15,7 @@ import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.ActivityOptionsCompat;
 import android.support.v4.content.ContextCompat;
 import android.support.v7.preference.PreferenceManager;
+import android.support.v7.widget.CardView;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -98,6 +99,8 @@ public class NutritionProductFragment extends BaseFragment implements CustomTabA
     TextView addPhotoLabel;
     @BindView(R.id.nutriments_recycler_view)
     RecyclerView nutrimentsRecyclerView;
+    @BindView(R.id.nutrient_levels_card_view)
+    CardView nutrientLevelsCardView;
 
     private String mUrlImage;
     private String barcode;
@@ -147,7 +150,7 @@ public class NutritionProductFragment extends BaseFragment implements CustomTabA
         }
 
         if (fat == null && salt == null && saturatedFat == null && sugars == null) {
-            textNutrientTxt.setText(" " + getString(R.string.txtNoData));
+            nutrientLevelsCardView.setVisibility(View.GONE);
             levelItem.add(new NutrientLevelItem("", "", "", 0));
         } else {
             // prefetch the uri

--- a/app/src/main/res/layout/fragment_nutrition_product.xml
+++ b/app/src/main/res/layout/fragment_nutrition_product.xml
@@ -83,6 +83,7 @@
             </android.support.v7.widget.CardView>
 
             <android.support.v7.widget.CardView
+                android:id="@+id/nutrient_levels_card_view"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="16dp"


### PR DESCRIPTION
## Description

The nutrient level CardView was hidden whenever there were no nutrient levels specified, instead of showing the "No Data" message.

## Related issues and discussion
#fixes #2141 
 
 ## Screen-shots, if any
See attached
![device-2019-01-25-211633](https://user-images.githubusercontent.com/42271776/51756296-a8ea3900-20e6-11e9-9f15-577f12c75d89.png)

