### PR TITLE
Fixes #2133: The send updated image is redirecting to the Contributions tab (if enabled)

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductIngredientsFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductIngredientsFragment.java
@@ -155,6 +155,9 @@ public class AddProductIngredientsFragment extends BaseFragment {
             if(b.getBoolean("perform_ocr")) {
                 extractIngredients();
             }
+            if (b.getBoolean("send_updated")) {
+                newIngredientsImage();
+            }
         } else {
             Toast.makeText(activity, R.string.error_adding_ingredients, Toast.LENGTH_SHORT).show();
             activity.finish();

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
@@ -242,6 +242,9 @@ public class AddProductOverviewFragment extends BaseFragment {
             if(b.getBoolean("perform_ocr")) {
                 ((AddProductActivity) activity).proceed();
             }
+            if (b.getBoolean("send_updated")) {
+                ((AddProductActivity) activity).proceed();
+            }
         } else {
             Toast.makeText(activity, R.string.error_adding_product_details, Toast.LENGTH_SHORT).show();
             activity.finish();

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/AddProductActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/AddProductActivity.java
@@ -248,6 +248,10 @@ public class AddProductActivity extends AppCompatActivity {
             bundle.putBoolean("perform_ocr",true);
         }
 
+        if (getIntent().getBooleanExtra("send_updated", false)) {
+            bundle.putBoolean("send_updated", true);
+        }
+
         if (state != null) {
             mProduct = state.getProduct();
             // Search if the barcode already exists in the OfflineSavedProducts db

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
@@ -56,6 +56,7 @@ import openfoodfacts.github.scrachx.openfood.utils.SearchType;
 import openfoodfacts.github.scrachx.openfood.utils.Utils;
 import openfoodfacts.github.scrachx.openfood.views.AddProductActivity;
 import openfoodfacts.github.scrachx.openfood.views.FullScreenImage;
+import openfoodfacts.github.scrachx.openfood.views.LoginActivity;
 import openfoodfacts.github.scrachx.openfood.views.ProductBrowsingListActivity;
 import openfoodfacts.github.scrachx.openfood.views.adapters.ProductFragmentPagerAdapter;
 import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabActivityHelper;
@@ -88,6 +89,8 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
 
     public static final Pattern INGREDIENT_PATTERN = Pattern.compile("[\\p{L}\\p{Nd}(),.-]+");
     public static final Pattern ALLERGEN_PATTERN = Pattern.compile("[\\p{L}\\p{Nd}]+[\\p{L}\\p{Nd}\\p{Z}\\p{P}&&[^,]]*");
+    private static final int LOGIN_ACTIVITY_REQUEST_CODE = 1;
+    private static final int EDIT_REQUEST_CODE = 2;
     @BindView(R.id.textIngredientProduct)
     TextView ingredientsProduct;
     @BindView(R.id.textSubstanceProduct)
@@ -149,6 +152,7 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
     private CustomTabsIntent customTabsIntent;
     private IIngredientsProductPresenter.Actions presenter;
     private ProductFragmentPagerAdapter pagerAdapter;
+    private boolean sendUpdatedIngredientsImage = false;
 
     //boolean to determine if image should be loaded or not
     private boolean isLowBatteryMode = false;
@@ -546,11 +550,38 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
 
     @OnClick(R.id.change_ing_img)
     public void change_ing_image(View v) {
+        sendUpdatedIngredientsImage = true;
 
 
         ViewPager viewPager = (ViewPager) getActivity().findViewById(
                 R.id.pager);
-        if (BuildConfig.FLAVOR.equals("off") || BuildConfig.FLAVOR.equals("opff")) {
+        if (BuildConfig.FLAVOR.equals("off")) {
+            final SharedPreferences settings = getActivity().getSharedPreferences( "login", 0 );
+            final String login = settings.getString( "user", "" );
+            if( login.isEmpty() )
+            {
+                new MaterialDialog.Builder( getContext() )
+                        .title( R.string.sign_in_to_edit )
+                        .positiveText( R.string.txtSignIn )
+                        .negativeText( R.string.dialog_cancel )
+                        .onPositive( ( dialog, which ) -> {
+                            Intent intent = new Intent( getContext(), LoginActivity.class );
+                            startActivityForResult( intent, LOGIN_ACTIVITY_REQUEST_CODE );
+                            dialog.dismiss();
+                        } )
+                        .onNegative( ( dialog, which ) -> dialog.dismiss() )
+                        .build().show();
+            }
+            else
+            {
+                mState = (State) getActivity().getIntent().getExtras().getSerializable( "state" );
+                Intent intent = new Intent( getContext(), AddProductActivity.class );
+                intent.putExtra("send_updated", sendUpdatedIngredientsImage);
+                intent.putExtra( "edit_product", mState.getProduct() );
+                startActivityForResult( intent, EDIT_REQUEST_CODE );
+            }
+        }
+        if (BuildConfig.FLAVOR.equals("opff")) {
             viewPager.setCurrentItem(4);
         }
 
@@ -637,6 +668,20 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
+
+        //added case for sending updated ingredients image
+        if( requestCode == LOGIN_ACTIVITY_REQUEST_CODE && resultCode == RESULT_OK )
+        {
+            Intent intent = new Intent( getContext(), AddProductActivity.class );
+            intent.putExtra("send_updated", sendUpdatedIngredientsImage);
+            intent.putExtra( "edit_product", mState.getProduct() );
+            startActivity( intent );
+        }
+        if( requestCode == EDIT_REQUEST_CODE && resultCode == RESULT_OK)
+        {
+            onRefresh();
+        }
+
         if (requestCode == CropImage.CROP_IMAGE_ACTIVITY_REQUEST_CODE) {
             CropImage.ActivityResult result = CropImage.getActivityResult(data);
             if (resultCode == RESULT_OK) {


### PR DESCRIPTION
## Description

Clicking the 'Send Updated Image' button in the ingredients tab would now redirect to editing the product and would allow the user to take a new picture of the ingredients and perform the OCR again.

## Related issues and discussion
#fixes #2133 

