### PR TITLE
Fixes: #2168, Origin of ingredients is not clickable

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIClient.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIClient.java
@@ -755,6 +755,43 @@ public class OpenFoodAPIClient {
 
     }
 
+    public void getProductsByOrigin(final String origin, final int page, final OnStoreCallback onStoreCallback) {
+        apiService.getProductsByOrigin(origin, page).enqueue(new Callback<Search>() {
+            @Override
+            public void onResponse(@NonNull Call<Search> call, @NonNull Response<Search> response) {
+                if (response.isSuccessful()) {
+                    onStoreCallback.onStoreResponse(true, response.body());
+                } else {
+                    onStoreCallback.onStoreResponse(false, null);
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<Search> call, @NonNull Throwable t) {
+                onStoreCallback.onStoreResponse(false, null);
+            }
+        });
+
+    }
+    public void getProductsByManufacturingPlace(final String manufacturingPlace, final int page, final OnStoreCallback onStoreCallback) {
+        apiService.getProductsByManufacturingPlace(manufacturingPlace, page).enqueue(new Callback<Search>() {
+            @Override
+            public void onResponse(@NonNull Call<Search> call, @NonNull Response<Search> response) {
+                if (response.isSuccessful()) {
+                    onStoreCallback.onStoreResponse(true, response.body());
+                } else {
+                    onStoreCallback.onStoreResponse(false, null);
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<Search> call, @NonNull Throwable t) {
+                onStoreCallback.onStoreResponse(false, null);
+            }
+        });
+
+    }
+
 
     public void getProductsByCountry(String country, final int page, final onCountryCallback onCountryCallback) {
         apiService.getProductsByCountry(country, page).enqueue(new Callback<Search>() {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIService.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIService.java
@@ -220,7 +220,7 @@ public interface OpenFoodAPIService {
     @GET("origin/{origin}/{page}.json")
     Call<Search> getProductsByOrigin(@Path("origin") String origin, @Path("page") int page);
 
-    @GET("country/{manufacturing-place}/{page}.json")
+    @GET("manufacturing-place/{manufacturing-place}/{page}.json")
     Call<Search> getProductsByManufacturingPlace(@Path("manufacturing-place") String manufacturingPlace, @Path("page") int page);
 
     @GET("store/{store}/{page}.json")

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIService.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIService.java
@@ -217,6 +217,12 @@ public interface OpenFoodAPIService {
     @GET("country/{country}/{page}.json")
     Call<Search> getProductsByCountry(@Path("country") String country, @Path("page") int page);
 
+    @GET("origin/{origin}/{page}.json")
+    Call<Search> getProductsByOrigin(@Path("origin") String origin, @Path("page") int page);
+
+    @GET("country/{manufacturing-place}/{page}.json")
+    Call<Search> getProductsByManufacturingPlace(@Path("manufacturing-place") String manufacturingPlace, @Path("page") int page);
+
     @GET("store/{store}/{page}.json")
     Call<Search> getProductByStores(@Path("store") String store, @Path("page") int page);
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/SearchType.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/SearchType.java
@@ -28,7 +28,9 @@ import static openfoodfacts.github.scrachx.openfood.utils.SearchType.*;
         TRACE,
         CONTRIBUTOR,
         STATE,
-        INCOMPLETE_PRODUCT
+        INCOMPLETE_PRODUCT,
+        ORIGIN,
+        MANUFACTURING_PLACE
 })
 public @interface SearchType {
 
@@ -46,6 +48,8 @@ public @interface SearchType {
     String CONTRIBUTOR = "contributor";
     String INCOMPLETE_PRODUCT = "incomplete_product";
     String STATE = "state";
+    String ORIGIN = "origin";
+    String MANUFACTURING_PLACE = "manufacturing-place";
 
     HashMap<String, String> URLS = new HashMap<String, String>() {{
         put(ALLERGEN, BuildConfig.OFWEBSITE + "allergens/");

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
@@ -272,6 +272,12 @@ public class ProductBrowsingListActivity extends BaseActivity {
             case SearchType.COUNTRY:
                 toolbar.setSubtitle(R.string.country_string);
                 break;
+            case SearchType.ORIGIN:
+                toolbar.setSubtitle(R.string.origin_of_ingredients);
+                break;
+            case SearchType.MANUFACTURING_PLACE:
+                toolbar.setSubtitle(R.string.manufacturing_place);
+                break;
             case SearchType.ADDITIVE:
                 toolbar.setSubtitle(R.string.additive_string);
                 break;
@@ -367,6 +373,14 @@ public class ProductBrowsingListActivity extends BaseActivity {
             case SearchType.COUNTRY:
                 apiClient.getProductsByCountry(searchQuery, pageAddress,  (value, country) ->
                         loadSearchProducts(value, country, R.string.txt_no_matching_country_products));
+                break;
+            case SearchType.ORIGIN:
+                apiClient.getProductsByOrigin(searchQuery, pageAddress, (value, origin) ->
+                        loadSearchProducts(value, origin, R.string.txt_no_matching_country_products));
+                break;
+            case SearchType.MANUFACTURING_PLACE:
+                apiClient.getProductsByManufacturingPlace(searchQuery, pageAddress, (value, manufacturingPlace) ->
+                        loadSearchProducts(value, manufacturingPlace, R.string.txt_no_matching_country_products));
                 break;
             case SearchType.ADDITIVE:
                 apiClient.getProductsByAdditive(searchQuery, pageAddress, (value, additive) ->

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
@@ -384,8 +384,17 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
             brandProduct.setVisibility(View.GONE);
         }
         if (isNotBlank(product.getManufacturingPlaces())) {
+            manufacturingProduct.setClickable(true);
+            manufacturingProduct.setMovementMethod(LinkMovementMethod.getInstance());
             manufacturingProduct.setText(bold(getString(R.string.txtManufacturing)));
-            manufacturingProduct.append(' ' + product.getManufacturingPlaces());
+            manufacturingProduct.append(" ");
+
+            String[] origins = product.getManufacturingPlaces().split(",");
+            for (int i = 0; i < origins.length - 1; i++) {
+                manufacturingProduct.append(Utils.getClickableText(origins[i].trim(), "", SearchType.MANUFACTURING_PLACE, getActivity(), customTabsIntent));
+                manufacturingProduct.append(", ");
+            }
+            manufacturingProduct.append(Utils.getClickableText(origins[origins.length - 1].trim(), "", SearchType.MANUFACTURING_PLACE, getActivity(), customTabsIntent));
         } else {
             manufacturingProduct.setVisibility(View.GONE);
         }
@@ -393,8 +402,17 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         if (isBlank(product.getOrigins())) {
             ingredientsOrigin.setVisibility(View.GONE);
         } else {
+            ingredientsOrigin.setClickable(true);
+            ingredientsOrigin.setMovementMethod(LinkMovementMethod.getInstance());
             ingredientsOrigin.setText(bold(getString(R.string.txtIngredientsOrigins)));
-            ingredientsOrigin.append(' ' + product.getOrigins());
+            ingredientsOrigin.append(" ");
+
+            String[] origins = product.getOrigins().split(",");
+            for (int i = 0; i < origins.length - 1; i++) {
+                ingredientsOrigin.append(Utils.getClickableText(origins[i].trim(), "", SearchType.ORIGIN, getActivity(), customTabsIntent));
+                ingredientsOrigin.append(", ");
+            }
+            ingredientsOrigin.append(Utils.getClickableText(origins[origins.length - 1].trim(), "", SearchType.ORIGIN, getActivity(), customTabsIntent));
         }
 
         if (product.getEmbTags() != null && !product.getEmbTags().toString().trim().equals("[]")) {

--- a/app/src/main/res/layout/fragment_summary_product.xml
+++ b/app/src/main/res/layout/fragment_summary_product.xml
@@ -456,6 +456,7 @@
                         android:layout_marginRight="@dimen/spacing_normal"
                         android:layout_marginTop="@dimen/spacing_tiny"
                         android:padding="@dimen/padding_too_short"
+                        android:textColorLink="@color/light_blue_A700"
                         android:textIsSelectable="true"
                         android:textSize="@dimen/font_normal" />
 
@@ -468,6 +469,7 @@
                         android:layout_marginRight="@dimen/spacing_normal"
                         android:layout_marginTop="@dimen/spacing_tiny"
                         android:padding="@dimen/padding_too_short"
+                        android:textColorLink="@color/light_blue_A700"
                         android:textIsSelectable="true"
                         android:textSize="@dimen/font_normal"
                         android:visibility="gone" />


### PR DESCRIPTION
## Description

Origin of ingredients and Transformation place do not seem clickable. I have first made the origin textview clickable then added two new fields in `SearchType` interface namely `ORIGIN` and `MANUFACTURING_PLACE` then, added two new methods in `OpenFoodAPIService.java` and `OpenFoodAPIClient.java` then, called them in `ProductBrowsingListActivity.java`.

## Related issues and discussion
### Fixes issue #2168
 
 ## Screen-shots
![whatsappvideo20190128at23](https://user-images.githubusercontent.com/30935658/51806994-f57c7280-22a6-11e9-987d-8c645828d249.gif)

 
