### PR TITLE
Fixes #2155: White square between the Nutrition table and the prompt

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition/NutritionProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition/NutritionProductFragment.java
@@ -179,6 +179,10 @@ public class NutritionProductFragment extends BaseFragment implements CustomTabA
 
         Nutriments nutriments = product.getNutriments();
 
+        if (nutriments != null && !nutriments.contains(Nutriments.CARBON_FOOTPRINT)) {
+            carbonFootprint.setVisibility(View.GONE);
+        }
+
         NutrientLevels nutrientLevels = product.getNutrientLevels();
         NutrimentLevel fat = null;
         NutrimentLevel saturatedFat = null;


### PR DESCRIPTION
## Description

The white box was due to the TextView for Carbon Footprint. A condition has been added that tests for the presence of a carbon footprint and removes the View if not present.

## Related issues and discussion
#fixes #2155 
 
 ## Screen-shots, if any
See attached, 
![device-2019-02-02-084155](https://user-images.githubusercontent.com/42271776/52165815-90ec6800-272b-11e9-9f24-13ba9b0d4d34.png)

