### PR TITLE
Fixes #2202: Calculate nutrition facts doesn't take liquid units into…

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/Nutriments.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/Nutriments.java
@@ -332,6 +332,12 @@ public class Nutriments implements Serializable {
             } else if (unit.equals("µg")) {
                 float value = Float.valueOf(stringValue);
                 return getRoundNumber(value * 1000000);
+            } else if (unit.equals("l")) {
+                float value = Float.valueOf(stringValue);
+                return getRoundNumber(value / 1000);
+            } else if (unit.equals("cl")) {
+                float value = Float.valueOf(stringValue);
+                return getRoundNumber(value / 10);
             }
             else {
                 return stringValue;
@@ -363,7 +369,15 @@ public class Nutriments implements Serializable {
                 float value = Float.valueOf(strValue);
                 value = (userSetServing / 100000) * value;
                 return getRoundNumber(value);
-            } else {
+            } else if (unit.equals("l")) {
+                float value = Float.valueOf(strValue);
+                value = (userSetServing * 10) * value;
+                return getRoundNumber(value);
+            } else if (unit.equals("cl")) {
+                float value = Float.valueOf(strValue);
+                value = (userSetServing / 10) * value;
+                return getRoundNumber(value);
+            }else {
                 return strValue;
             }
         }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/CalculateDetails.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/CalculateDetails.java
@@ -191,6 +191,12 @@ public class CalculateDetails extends BaseActivity {
             case "kg":
                 weightInG = weight * 1000;
                 break;
+            case "l":
+                weightInG = weight * 1000;
+                break;
+            case "cl":
+                weightInG = weight * 10;
+                break;
             default:
                 weightInG = weight;
                 break;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,6 +67,8 @@
         <item>g</item>
         <item>mg</item>
         <item>kg</item>
+        <item>l</item>
+        <item>cl</item>
     </string-array>
 
     <!-- nutrition energy units -->


### PR DESCRIPTION
… account

## Description

Added liquid units l and cl to calculate nutrition facts of the product.

## Related issues and discussion
#fixes #2202 
 
 ## Screen-shots, if any
 
![screenshot_20190207-231235](https://user-images.githubusercontent.com/26673203/52431462-4c4b3d00-2b2e-11e9-81b6-2a0090fa30a5.jpg)
![screenshot_20190207-231308](https://user-images.githubusercontent.com/26673203/52431463-4c4b3d00-2b2e-11e9-834a-07530deafcc2.jpg)
![screenshot_20190207-231322](https://user-images.githubusercontent.com/26673203/52431465-4ce3d380-2b2e-11e9-8f6e-4454bd0d3879.jpg)



 