### PR TITLE
Fix : Null object reference on isEmpty() in IngredientsProductFragment

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
@@ -303,7 +303,7 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
 
         List<String> allergens = getAllergens();
 
-        if (mState != null && !product.getIngredientsText().isEmpty()) {
+        if (mState != null && product.getIngredientsText() != null && !product.getIngredientsText().isEmpty()) {
             textIngredientProductCardView.setVisibility(View.VISIBLE);
             SpannableStringBuilder txtIngredients = new SpannableStringBuilder(product.getIngredientsText().replace("_", ""));
             txtIngredients = setSpanBoldBetweenTokens(txtIngredients, allergens);


### PR DESCRIPTION
## Description
     Added null check on product.getIngredientsText() which was causing null object refrence.

#fixes 
#2201 'boolean java.lang.String.isEmpty()' on a null object reference.