### PR TITLE
Fixes #2071: Moving recycling instructions to the environnement tab

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/environment/EnvironmentProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/environment/EnvironmentProductFragment.java
@@ -5,6 +5,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v7.widget.CardView;
 import android.text.Html;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -27,6 +28,14 @@ public class EnvironmentProductFragment extends BaseFragment {
     TextView carbonFootprint;
     @BindView(R.id.environment_info_text)
     TextView environmentInfoText;
+    @BindView(R.id.recyclingInstructionToDiscard)
+    TextView recyclingInstructionToDiscardText;
+    @BindView(R.id.recyclingInstructionToRecycle)
+    TextView recyclingInstructionToRecycleText;
+    @BindView(R.id.recycling_instructions_discard_cv)
+    CardView recyclingInstructionsToDiscardCv;
+    @BindView(R.id.recycling_instructions_recycle_cv)
+    CardView recyclingInstructionsToRecycleCv;
 
     private State mState;
 
@@ -60,6 +69,20 @@ public class EnvironmentProductFragment extends BaseFragment {
             } else {
                 environmentInfoText.append(Html.fromHtml(product.getEnvironmentInfocard()));
             }
+        }
+
+        if(product.getRecyclingInstructionsToDiscard() != null && !product.getRecyclingInstructionsToDiscard().isEmpty()) {
+            recyclingInstructionToDiscardText.setText(bold("Recycling instructions - To discard: "));
+            recyclingInstructionToDiscardText.append(product.getRecyclingInstructionsToDiscard());
+        } else {
+            recyclingInstructionsToDiscardCv.setVisibility(View.GONE);
+        }
+
+        if (product.getRecyclingInstructionsToRecycle() != null && !product.getRecyclingInstructionsToRecycle().isEmpty()) {
+            recyclingInstructionToRecycleText.setText(bold("Recycling instructions - To recycle:"));
+            recyclingInstructionToRecycleText.append(product.getRecyclingInstructionsToRecycle());
+        } else {
+            recyclingInstructionsToRecycleCv.setVisibility(View.GONE);
         }
 
         refreshView(mState);

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/environment/EnvironmentProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/environment/EnvironmentProductFragment.java
@@ -36,6 +36,8 @@ public class EnvironmentProductFragment extends BaseFragment {
     CardView recyclingInstructionsToDiscardCv;
     @BindView(R.id.recycling_instructions_recycle_cv)
     CardView recyclingInstructionsToRecycleCv;
+    @BindView(R.id.carbon_footprint_cv)
+    CardView carbonFootprintCardView;
 
     private State mState;
 
@@ -61,6 +63,8 @@ public class EnvironmentProductFragment extends BaseFragment {
             carbonFootprint.setText(bold(getString(R.string.textCarbonFootprint)));
             carbonFootprint.append(carbonFootprintNutriment.getFor100g());
             carbonFootprint.append(carbonFootprintNutriment.getUnit());
+        } else {
+            carbonFootprintCardView.setVisibility(View.GONE);
         }
 
         if (product.getEnvironmentInfocard() != null && !product.getEnvironmentInfocard().isEmpty()) {

--- a/app/src/main/res/layout/fragment_environment_product.xml
+++ b/app/src/main/res/layout/fragment_environment_product.xml
@@ -59,6 +59,58 @@
 
             </android.support.v7.widget.CardView>
 
+            <android.support.v7.widget.CardView
+                android:id="@+id/recycling_instructions_discard_cv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
+                app:cardElevation="4dp">
+
+                <TextView
+                    android:id="@+id/recyclingInstructionToDiscard"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/spacing_tiny"
+                    android:layout_marginLeft="@dimen/spacing_normal"
+                    android:layout_marginRight="@dimen/spacing_normal"
+                    android:layout_marginTop="@dimen/spacing_tiny"
+                    android:background="@drawable/textview_full"
+                    android:padding="@dimen/spacing_small"
+                    android:textIsSelectable="true"
+                    android:textSize="@dimen/font_normal" />
+
+            </android.support.v7.widget.CardView>
+
+            <android.support.v7.widget.CardView
+                android:id="@+id/recycling_instructions_recycle_cv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
+                app:cardElevation="4dp">
+
+                <TextView
+                    android:id="@+id/recyclingInstructionToRecycle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/spacing_tiny"
+                    android:layout_marginLeft="@dimen/spacing_normal"
+                    android:layout_marginRight="@dimen/spacing_normal"
+                    android:layout_marginTop="@dimen/spacing_tiny"
+                    android:background="@drawable/textview_full"
+                    android:padding="@dimen/spacing_small"
+                    android:textIsSelectable="true"
+                    android:textSize="@dimen/font_normal"/>
+
+            </android.support.v7.widget.CardView>
+
         </LinearLayout>
 
     </android.support.v4.widget.NestedScrollView>

--- a/app/src/main/res/layout/fragment_environment_product.xml
+++ b/app/src/main/res/layout/fragment_environment_product.xml
@@ -22,6 +22,7 @@
             android:orientation="vertical">
 
             <android.support.v7.widget.CardView
+                android:id="@+id/carbon_footprint_cv"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"


### PR DESCRIPTION
## Description

The environment tab was modified to show the `recycling_instructions_to_discard` and the `recycling_instructions_to_recycle` fields of the product if they were not empty.

## Related issues and discussion
#fixes #2071 
 
 ## Screen-shots, if any
See attached,
![device-2019-02-15-053457](https://user-images.githubusercontent.com/42271776/52855746-54b40100-3148-11e9-933c-2902ff738bae.png)
