### PR TITLE
Fixes #2225: Display a special message when the product doesn't have …

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition/NutritionProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition/NutritionProductFragment.java
@@ -127,6 +127,12 @@ public class NutritionProductFragment extends BaseFragment implements CustomTabA
     TextView textNutriScoreInfo;
     @BindView(R.id.nutrient_levels_card_view)
     CardView nutrientLevelsCardView;
+    @BindView(R.id.calculateNutritionFacts)
+    Button calculateNutritionFacts;
+    @BindView(R.id.nutrimentsCardView)
+    CardView nutrimentsCardView;
+    @BindView(R.id.textNoNutritionData)
+    TextView textNoNutritionData;
 
     private String mUrlImage;
     private String barcode;
@@ -140,6 +146,8 @@ public class NutritionProductFragment extends BaseFragment implements CustomTabA
     //the following booleans indicate whether the prompts are to be made visible
     private boolean showNutritionPrompt = false;
     private boolean showCategoryPrompt = false;
+    //boolean to determine if nutrition data should be shown
+    private boolean showNutritionData=true;
     private Product product;
     private State mState;
 
@@ -176,6 +184,7 @@ public class NutritionProductFragment extends BaseFragment implements CustomTabA
         }
         if (product.getNoNutritionData() != null && product.getNoNutritionData().equals("on")) {
             showNutritionPrompt = false;
+            showNutritionData = false;
         } else {
             if (statesTags.contains("en:nutrition-facts-to-be-completed")) {
                 showNutritionPrompt = true;
@@ -191,6 +200,16 @@ public class NutritionProductFragment extends BaseFragment implements CustomTabA
             } else if (showCategoryPrompt) {
                 nutriscorePrompt.setText(getString(R.string.add_category_prompt_text));
             }
+        }
+
+        if (!showNutritionData) {
+            mImageNutrition.setVisibility(View.GONE);
+            addPhotoLabel.setVisibility(View.GONE);
+            imageGradeLayout.setVisibility(View.GONE);
+            calculateNutritionFacts.setVisibility(View.GONE);
+            nutrimentsCardView.setVisibility(View.GONE);
+            textNoNutritionData.setVisibility(View.VISIBLE);
+
         }
 
         List<NutrientLevelItem> levelItem = new ArrayList<>();

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
@@ -219,6 +219,8 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
     private boolean addingIngredientsImage = false;
     //boolean to indicate if the image clicked was that of nutrition
     private boolean addingNutritionImage = false;
+    //boolean to determine if nutrition data should be shown
+    private boolean showNutritionData=true;
 
     @Override
     public void onAttach(Context context) {
@@ -301,6 +303,7 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         }
         if (product.getNoNutritionData() != null && product.getNoNutritionData().equals("on")) {
             showNutrientPrompt = false;
+            showNutritionData= false;
         } else {
             if (statesTags.contains("en:nutrition-facts-to-be-completed")) {
                 showNutrientPrompt = true;
@@ -316,6 +319,10 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
             } else if (showCategoryPrompt) {
                 addNutriScorePrompt.setText(getString(R.string.add_category_prompt_text));
             }
+        }
+
+        if (!showNutritionData) {
+            nutritionImagePromptLayout.setVisibility(View.GONE);
         }
 
         presenter.loadAllergens();
@@ -350,7 +357,7 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         }
 
         if(!BuildConfig.FLAVOR.equals( "obf" ) && !BuildConfig.FLAVOR.equals( "opf" )) {
-            if (isBlank(product.getImageNutritionUrl())) {
+            if (isBlank(product.getImageNutritionUrl()) && showNutritionData) {
                 nutritionImagePromptLayout.setVisibility(View.VISIBLE);
             }
         }

--- a/app/src/main/res/layout/fragment_nutrition_product.xml
+++ b/app/src/main/res/layout/fragment_nutrition_product.xml
@@ -107,6 +107,17 @@
                 android:textIsSelectable="true"
                 android:textSize="@dimen/font_normal" />
 
+            <TextView
+                android:id="@+id/textNoNutritionData"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="16dp"
+                android:layout_gravity="center"
+                android:gravity="center_horizontal"
+                android:text="@string/txt_no_nutrition_data"
+                android:textSize="18sp"
+                android:visibility="gone" />
+
 
             <android.support.v7.widget.CardView
                 android:id="@+id/serving_size_card_view"
@@ -200,7 +211,8 @@
 
             <android.support.v7.widget.CardView
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
+                android:layout_height="match_parent"
+                android:id="@+id/nutrimentsCardView">
 
                 <RelativeLayout
                     android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -937,6 +937,7 @@
     <string name="fast_addition_mode">Enables fast addition of products with fewer attributes</string>
     <string name="addtive_search">Search for a additive</string>
     <string name="additives">Additives</string>
+    <string name="txt_no_nutrition_data">This product doesn\'t have any nutrition information on the packaging. If this has changed, you can edit the product.</string>
 
     <!-- Used for diets AddOn -->
 </resources>


### PR DESCRIPTION
…nutrition info

## Description

Based on the result of the condition to check if the nutrition info is not provided on the product package or not, the views like "Take picture of nutrition facts" icon, "Calculate nutrition facts" button and the nutrition table headers are hidden in the nutrition tab and the summary tab.
Also, a message is displayed to let the user know that the nutrition info is not provided on the product  package.


## Related issues and discussion
#fixes #2225 
 
 ## Screen-shots, if any
 
 
![no-nutrition-info1](https://user-images.githubusercontent.com/26673203/52905190-c5e4d880-325c-11e9-8d1b-81f669bb0459.jpg)
![no-nutrition-info2](https://user-images.githubusercontent.com/26673203/52905191-c5e4d880-325c-11e9-84ce-9cd98717e693.jpg)

