### PR TITLE
Expand the home message to other flavors.

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
@@ -77,6 +77,7 @@ public class HomeFragment extends NavigationBaseFragment implements CustomTabAct
         apiClient = new OpenFoodAPIClient(getActivity()).getAPIService();
         checkUserCredentials();
         sp = PreferenceManager.getDefaultSharedPreferences(getContext());
+        getTagline();
     }
 
     @Override
@@ -209,9 +210,7 @@ public class HomeFragment extends NavigationBaseFragment implements CustomTabAct
                     }
                 });
 
-        if (BuildConfig.FLAVOR.equals("off")){
-            getTagline();
-        }
+        getTagline();
 
         if (getActivity() instanceof AppCompatActivity) {
             ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
@@ -233,32 +232,32 @@ public class HomeFragment extends NavigationBaseFragment implements CustomTabAct
     }
 
     private void getTagline(){
+        OpenFoodAPIService openFoodAPIService = new OpenFoodAPIClient(getActivity(), "https://ssl-api.openfoodfacts.org").getAPIService();
+        Call<ArrayList<TaglineLanguageModel>> call = openFoodAPIService.getTagline();
+        call.enqueue(new Callback<ArrayList<TaglineLanguageModel>>() {
+            @Override
+            public void onResponse(Call<ArrayList<TaglineLanguageModel>> call, Response<ArrayList<TaglineLanguageModel>> response) {
+                if(response.isSuccessful()){
+                    String locale = String.valueOf(Resources.getSystem().getConfiguration().locale);
+                    boolean isLanguageFound = false;
+                    for (int i = 0; i < response.body().size(); i++){
+                        if (response.body().get(i).getLanguage().equals(locale)){
+                            taglineURL = response.body().get(i).getTaglineModel().getUrl();
+                            tvDailyFoodFact.setText(response.body().get(i).getTaglineModel().getMessage());
+                            tvDailyFoodFact.setVisibility(View.VISIBLE);
+                            isLanguageFound = true;
+                        }
+                    }
+                    if (!isLanguageFound){
+                        taglineURL = response.body().get(response.body().size() -1).getTaglineModel().getUrl();
+                        tvDailyFoodFact.setText(response.body().get(response.body().size() -1).getTaglineModel().getMessage());
+                        tvDailyFoodFact.setVisibility(View.VISIBLE);
+                    }
+                }
+            }
 
-       Call<ArrayList<TaglineLanguageModel>> call = apiClient.getTagline();
-       call.enqueue(new Callback<ArrayList<TaglineLanguageModel>>() {
-           @Override
-           public void onResponse(Call<ArrayList<TaglineLanguageModel>> call, Response<ArrayList<TaglineLanguageModel>> response) {
-               if(response.isSuccessful()){
-                   String locale = String.valueOf(Resources.getSystem().getConfiguration().locale);
-                   boolean isLanguageFound = false;
-                   for (int i = 0; i < response.body().size(); i++){
-                       if (response.body().get(i).getLanguage().equals(locale)){
-                           taglineURL = response.body().get(i).getTaglineModel().getUrl();
-                           tvDailyFoodFact.setText(response.body().get(i).getTaglineModel().getMessage());
-                           tvDailyFoodFact.setVisibility(View.VISIBLE);
-                           isLanguageFound = true;
-                       }
-                   }
-                   if (!isLanguageFound){
-                       taglineURL = response.body().get(response.body().size() -1).getTaglineModel().getUrl();
-                       tvDailyFoodFact.setText(response.body().get(response.body().size() -1).getTaglineModel().getMessage());
-                       tvDailyFoodFact.setVisibility(View.VISIBLE);
-                   }
-               }
-           }
-
-           @Override
-           public void onFailure(Call<ArrayList<TaglineLanguageModel>> call, Throwable t) { }
-       });
+            @Override
+            public void onFailure(Call<ArrayList<TaglineLanguageModel>> call, Throwable t) { }
+        });
     }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIService.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIService.java
@@ -9,6 +9,7 @@ import io.reactivex.Single;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
+import openfoodfacts.github.scrachx.openfood.BuildConfig;
 import openfoodfacts.github.scrachx.openfood.models.Search;
 import openfoodfacts.github.scrachx.openfood.models.SendProduct;
 import openfoodfacts.github.scrachx.openfood.models.State;
@@ -358,7 +359,7 @@ public interface OpenFoodAPIService {
     @GET("/1.json?fields=null")
     Single<Search> getTotalProductCount();
 
-    @GET("/files/tagline/tagline.json")
+    @GET("/files/tagline/tagline-"+ BuildConfig.FLAVOR+".json")
     Call<ArrayList<TaglineLanguageModel>> getTagline();
 
 


### PR DESCRIPTION
## Description
Made a new OpenFoodAPIService in HomeFragment with a static foodFact URL since all tagline falls under this URL. Example (https://world.openfoodfacts.org/files/tagline/tagline-opf.json). And made changes in the OpenFoodAPIService getTagline method so now the changed getRequest is  @GET("/files/tagline/tagline-"+BuildConfig.FLAVOR+".json"). So now all flavors show the tagline on homeFragment.

## Related issues and discussion
#fixes {#2193}
 
 ## Screen-shots, if any
 
![screenshot_2019-02-17-12-04-17-569_org openpetfoodfacts scanner](https://user-images.githubusercontent.com/32436867/52909295-7f1ecf00-32ac-11e9-8535-d68374f2dc4a.png)
![screenshot_2019-02-17-12-04-20-562_org openproductsfacts scanner](https://user-images.githubusercontent.com/32436867/52909296-7f1ecf00-32ac-11e9-8c92-5d5725fe92e0.png)
![screenshot_2019-02-17-12-04-23-076_openfoodfacts github scrachx openbeauty](https://user-images.githubusercontent.com/32436867/52909297-7f1ecf00-32ac-11e9-8ccd-2154c9310637.png)
![screenshot_2019-02-17-12-04-30-066_openfoodfacts github scrachx openfood](https://user-images.githubusercontent.com/32436867/52909298-7fb76580-32ac-11e9-842f-afbaa4da48be.png)
