### PR TITLE
Fixes #2177: Prepared nutrition facts are not displayed

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/Nutriments.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/Nutriments.java
@@ -126,6 +126,8 @@ public class Nutriments implements Serializable {
     public static final String IRON = "iron";
     public static final String MAGNESIUM = "magnesium";
 
+    public static final String PREPARED = "_prepared";
+
     public static final Map<String, Integer> MINERALS_MAP = new HashMap<String, Integer>() {{
         put(Nutriments.SILICA, R.string.silica);
         put(Nutriments.BICARBONATE, R.string.bicarbonate);
@@ -201,16 +203,23 @@ public class Nutriments implements Serializable {
     private boolean containsMinerals;
 
     public Nutriment get(String nutrimentName){
-        if (nutrimentName.isEmpty() || !additionalProperties.containsKey(nutrimentName)) {
+        if (nutrimentName.isEmpty() || (!additionalProperties.containsKey(nutrimentName)
+                //Forcing to check _prepared in case only _prepared is available in the response.
+                && !additionalProperties.containsKey(nutrimentName + PREPARED))) {
             return null;
         }
-
         try{
             return new Nutriment(additionalProperties.get(nutrimentName).toString(), get100g(nutrimentName), getServing(nutrimentName), getUnit(nutrimentName));
         }catch (NullPointerException e){
-            // In case one of the getters was unable to get data as string
-            String stacktrace = Log.getStackTraceString(e);
-            Log.e("NUTRIMENTS-MODEL",stacktrace);
+            nutrimentName += PREPARED;
+            try {
+                return new Nutriment(additionalProperties.get(nutrimentName).toString(), get100g(nutrimentName), getServing(nutrimentName), getUnit(nutrimentName));
+            }catch (NullPointerException e2) {
+                // In case one of the getters was unable to get data as string
+                String stacktrace = Log.getStackTraceString(e2);
+                Log.e("NUTRIMENTS-MODEL",stacktrace);
+            }
+
         }
         return null;
     }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition/NutritionProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/nutrition/NutritionProductFragment.java
@@ -478,12 +478,13 @@ public class NutritionProductFragment extends BaseFragment implements CustomTabA
             nutrimentItems.addAll(getNutrimentItems(nutriments, VITAMINS_MAP));
         }
 
-        // Minerals
-        if (nutriments.hasMinerals()) {
+        // Minerals.  Display all that are avialable, regardless of nutriments.hasMinerals() flag.
+        List<NutrimentItem> minerals = getNutrimentItems(nutriments, MINERALS_MAP);
+        if (minerals.size() > 0) {
             nutrimentItems.add(new HeaderNutrimentItem(getString(R.string.nutrition_minerals)));
-
-            nutrimentItems.addAll(getNutrimentItems(nutriments, MINERALS_MAP));
+            nutrimentItems.addAll(minerals);
         }
+
 
         RecyclerView.Adapter adapter = new NutrimentsRecyclerViewAdapter(nutrimentItems);
         nutrimentsRecyclerView.setAdapter(adapter);


### PR DESCRIPTION
## Description

Changed the get method in Nutriments.java to also check if "prepared" value is available, when not "prepared" attribute is missing from the returned JSON.  This allows the app to fall back on the "prepared" values when others are missing.

Changed the part of the code that populates minerals in NutritionProductFragment.java to display minerals if they exists regardless of what Nutriments.hasMinerals() returns.

## Related issues and discussion
#fixes #2177: Prepared nutrition facts are not displayed 
 
 ## Screen-shots, if any

![screenshot_20190218-143834_openfoodfacts](https://user-images.githubusercontent.com/46454576/52977740-ae583d80-338b-11e9-99b3-86e334713f13.png)


