### PR TITLE
Fixes #2239: Crash when scanning 3256224069164 and sliding up

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
@@ -86,6 +86,7 @@ import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabActivityH
 import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabsHelper;
 import openfoodfacts.github.scrachx.openfood.views.customtabs.WebViewFallback;
 import openfoodfacts.github.scrachx.openfood.views.product.ProductActivity;
+import openfoodfacts.github.scrachx.openfood.views.product.ProductFragment;
 import pl.aprilapps.easyphotopicker.DefaultCallback;
 import pl.aprilapps.easyphotopicker.EasyImage;
 
@@ -196,6 +197,7 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
     TextView customerService;
     @BindView(R.id.compare_product_button)
     Button compareProductButton;
+    private State state;
     private Product product;
     private OpenFoodAPIClient api;
     private WikidataApiClient apiClientForWikiData;
@@ -229,7 +231,11 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         customTabsIntent = CustomTabsHelper.getCustomTabsIntent(getContext(), customTabActivityHelper.getSession());
 
         Intent intent = getActivity().getIntent();
-        State state = (State) intent.getExtras().getSerializable("state");
+        if (intent.getExtras() != null) {
+            state = (State) intent.getExtras().getSerializable("state");
+        } else {
+            state = ProductFragment.mState;
+        }
         product = state.getProduct();
 
         presenter = new SummaryProductPresenter(product, this);
@@ -247,7 +253,7 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         Intent intent = getActivity().getIntent();
-        refreshView((State) intent.getExtras().getSerializable("state"));
+        refreshView(state);
     }
 
     @Override


### PR DESCRIPTION
## Description

Additional condition was added to check if the intent extras were null and if they were, the state of the product was referenced from the ProductFragment.

## Related issues and discussion
#fixes #2239 

