### PR TITLE
Fixes #2243: Fatal exception when starting comparison mode from the additives list

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/ProductComparisonAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/ProductComparisonAdapter.java
@@ -291,13 +291,13 @@ public class ProductComparisonAdapter extends RecyclerView.Adapter<ProductCompar
                     holder.nutrientsRecyclerView.setAdapter(new NutrientLevelListAdapter(context, loadLevelItems(product)));
                 }
             } else {
-                holder.productComparisonImageGrade.setImageDrawable(ContextCompat.getDrawable(context, Utils.getImageGrade(null)));
+                holder.productComparisonImageGrade.setVisibility(View.INVISIBLE);
             }
 
             if (product.getNovaGroups() != null) {
                 holder.productComparisonNovaGroup.setImageResource(Utils.getNovaGroupDrawable(product.getNovaGroups()));
             } else {
-                holder.productComparisonNovaGroup.setImageResource(Utils.getNovaGroupDrawable(null));
+                holder.productComparisonNovaGroup.setVisibility(View.INVISIBLE);
             }
 
             if(product.getEnvironmentImpactLevelTags()!=null) {


### PR DESCRIPTION
## Description

If the nutriscore or the nova group for a product hadn't been computed, the comparison feature is now modified to set those fields as invisible in order to maintain the same height.

## Related issues and discussion
#fixes #2243 

