### PR TITLE
Fixes #2244 : The project tagline should always fit on one line

### DIFF
--- a/app/src/main/res/layout-v26/fragment_home.xml
+++ b/app/src/main/res/layout-v26/fragment_home.xml
@@ -24,16 +24,22 @@
             android:scaleType="fitCenter"
             app:srcCompat="@drawable/ic_openfacts_logo_no_tagline" />
 
-        <TextView
+        <android.support.v7.widget.AppCompatTextView
             android:id="@+id/taglineHome"
             android:layout_width="184dp"
-            android:layout_height="32dp"
-            android:layout_gravity="center_horizontal"
-            android:autoSizeTextType="uniform"
-            android:contentDescription="@string/OFFlogo"
+            android:layout_height="30dp"
             android:gravity="center_horizontal"
+            android:textStyle="bold"
+            android:layout_gravity="center_horizontal"
+            app:autoSizeMaxTextSize="28sp"
+            app:autoSizeMinTextSize="12sp"
+            app:autoSizeStepGranularity="0.1sp"
+            app:autoSizeTextType="uniform"
+            android:contentDescription="@string/OFFlogo"
             android:text="@string/tagline"
-            android:textStyle="bold" />
+            app:layout_constraintEnd_toEndOf="@id/imageHome"
+            app:layout_constraintStart_toStartOf="@id/imageHome"
+            app:layout_constraintTop_toBottomOf="@id/imageHome" />
 
         <TextView
             android:id="@+id/textHome"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -26,15 +26,21 @@
             android:scaleType="fitCenter"
             app:srcCompat="@drawable/ic_openfacts_logo_no_tagline" />
 
-        <TextView
+        <android.support.v7.widget.AppCompatTextView
             android:id="@+id/taglineHome"
             android:layout_width="184dp"
-            android:layout_height="32dp"
-            android:layout_gravity="center_horizontal"
-            android:contentDescription="@string/OFFlogo"
+            android:layout_height="30dp"
             android:gravity="center_horizontal"
+            android:textStyle="bold"
+            app:autoSizeMaxTextSize="28sp"
+            app:autoSizeMinTextSize="12sp"
+            app:autoSizeStepGranularity="0.1sp"
+            app:autoSizeTextType="uniform"
+            android:contentDescription="@string/OFFlogo"
             android:text="@string/tagline"
-            android:textStyle="bold" />
+            app:layout_constraintEnd_toEndOf="@id/imageHome"
+            app:layout_constraintStart_toStartOf="@id/imageHome"
+            app:layout_constraintTop_toBottomOf="@id/imageHome" />
 
         <TextView
             android:id="@+id/textHome"


### PR DESCRIPTION
## Description

Changed the Textview to AppCompatTextView so that it functions similar to the one in Splash Activity. 

## Related issues and discussion
#fixes #2244 
 
 ## Screen-shots, if any
 
![home-tagline](https://user-images.githubusercontent.com/26673203/53079975-a16b5380-351d-11e9-8cdc-e50365c7f84e.jpg)

