### PR TITLE
fixes #2273 : When no items are added to offline edit, Text is misplaced 

### DIFF
--- a/app/src/main/res/layout/fragment_offline_edit.xml
+++ b/app/src/main/res/layout/fragment_offline_edit.xml
@@ -1,10 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
-<android.support.constraint.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:layout_editor_absoluteY="25dp">
@@ -78,6 +75,7 @@
             android:layout_width="@dimen/img_width_height"
             android:layout_height="@dimen/img_width_height"
             android:layout_margin="@dimen/padding_normal"
+            android:layout_below="@id/noDataText"
             android:paddingTop="@dimen/padding_large"
             android:layout_centerHorizontal="true"
             android:visibility="visible"
@@ -88,7 +86,6 @@
             android:id="@+id/noDataText"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@+id/noDataImg"
             android:layout_centerHorizontal="true"
             android:gravity="center"
             android:layout_margin="@dimen/padding_normal"
@@ -141,4 +138,3 @@
 
 
 </android.support.constraint.ConstraintLayout>
-</ScrollView>

--- a/app/src/main/res/layout/fragment_offline_edit.xml
+++ b/app/src/main/res/layout/fragment_offline_edit.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+<android.support.constraint.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:layout_editor_absoluteY="25dp">

--- a/app/src/main/res/layout/fragment_offline_edit.xml
+++ b/app/src/main/res/layout/fragment_offline_edit.xml
@@ -141,3 +141,4 @@
 
 
 </android.support.constraint.ConstraintLayout>
+</ScrollView>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout="@layout/fastscroller">
 
     <PreferenceCategory android:title="@string/preference_header_general">
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout="@layout/fastscroller">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory android:title="@string/preference_header_general">
 


### PR DESCRIPTION
## Description
Edited fragments_offline_edit.xml as  when no items are added to offline edit, Text is misplaced 

## Related issues and discussion
#2273 
![offpic](https://user-images.githubusercontent.com/43813438/53286284-1d6dd180-3792-11e9-9f9f-7920aced8a6e.jpg)


 


 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
