### PR TITLE
Fixes #2237 : Remove the Home text in the home

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
@@ -215,7 +215,7 @@ public class HomeFragment extends NavigationBaseFragment implements CustomTabAct
         if (getActivity() instanceof AppCompatActivity) {
             ActionBar actionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();
             if (actionBar != null) {
-                actionBar.setTitle(R.string.home_drawer);
+                actionBar.setTitle("");
             }
         }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -208,7 +208,6 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         } else {
             fragmentManager.beginTransaction().replace(R.id.fragment_container, new HomeFragment
                     ()).commit();
-            getSupportActionBar().setTitle(getResources().getString(R.string.home_drawer));
         }
 
         // chrome custom tab init


### PR DESCRIPTION
## Description

Removed the Home title on the toolbar of Home page.

## Related issues and discussion
#fixes #2237 
 
 ## Screen-shots, if any
 
 
![home1](https://user-images.githubusercontent.com/26673203/53200863-a4169780-3648-11e9-938c-710fedd32d6c.jpg)
