### PR TITLE
Fixes #2270: The environment infocard is blank (master)

### DIFF
--- a/app/src/main/res/layout/fragment_environment_product.xml
+++ b/app/src/main/res/layout/fragment_environment_product.xml
@@ -45,6 +45,19 @@
                     android:textIsSelectable="true"
                     android:textSize="@dimen/font_normal" />
 
+            </android.support.v7.widget.CardView>
+
+            <android.support.v7.widget.CardView
+                android:id="@+id/environment_info_cv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
+                app:cardElevation="4dp">
+
                 <TextView
                     android:id="@+id/environment_info_text"
                     android:layout_width="match_parent"


### PR DESCRIPTION
## Description

The layout for the Environment tab was adjusted to have a separate card for the environment infocard. Earlier, it was clubbed with the carbon footprint card which made the information disappear in the absence of a carbon footprint.

## Related issues and discussion
#fixes #2270
 
 ## Screen-shots, if any
See attached, 
![device-2019-02-22-020027](https://user-images.githubusercontent.com/42271776/53229577-a3165200-36aa-11e9-9640-b13b9814773e.png)
