### PR TITLE
Fixes #2262: Exception when scanning twice the same product from compare mode

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
@@ -231,12 +231,11 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         customTabsIntent = CustomTabsHelper.getCustomTabsIntent(getContext(), customTabActivityHelper.getSession());
 
         Intent intent = getActivity().getIntent();
-        if (intent.getExtras() != null) {
+        if (intent.getExtras() != null && intent.getExtras().getSerializable("state") != null) {
             state = (State) intent.getExtras().getSerializable("state");
         } else {
             state = ProductFragment.mState;
         }
-        product = state.getProduct();
 
         presenter = new SummaryProductPresenter(product, this);
     }


### PR DESCRIPTION
## Description

The condition for setting the state of the product in `SummaryProductFragment` was strengthened include the case when the state is `null`.

## Related issues and discussion
#fixes #2262 
 
 ## Screen-shots, if any
See attached,
![device-2019-02-22-022702](https://user-images.githubusercontent.com/42271776/53231160-47e65e80-36ae-11e9-80eb-188396f47b7b.png)
