### PR TITLE
fixes #2274 : when user types a password less than 6 characters,text view error is overlapping with see password button. 

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoginActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoginActivity.java
@@ -155,7 +155,7 @@ public class LoginActivity extends BaseActivity implements CustomTabActivityHelp
             return;
         }
         if (!(password.length() >= 6)) {
-            passwordView.setError(getString(R.string.error_invalid_password));
+            Toast.makeText(this,getText(R.string.error_invalid_password),Toast.LENGTH_SHORT).show();
             passwordView.requestFocus();
             return;
         }

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout="@layout/fastscroller">
 
     <PreferenceCategory android:title="@string/preference_header_general">
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory android:title="@string/preference_header_general">
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout="@layout/fastscroller">
 
     <PreferenceCategory android:title="@string/preference_header_general">
 


### PR DESCRIPTION
## Description

Edited loginactivity.java so that instead of setError method,used a toast message as when user types a password less than 6 characters,text view error is overlapping with see password button. 

## Related issues and discussion
#2274 

## screenshots
![error set](https://user-images.githubusercontent.com/43813438/53295715-5e63f580-3827-11e9-8544-14345544d90f.jpg)

 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
