### PR TITLE
fixes #2377 : Color of ADD Fab button in alert allergens fragment is looking overlapped with item number indicated as it is blue in colour. 

### DIFF
--- a/app/src/main/res/layout/fragment_alert_allergens.xml
+++ b/app/src/main/res/layout/fragment_alert_allergens.xml
@@ -49,7 +49,7 @@
         android:clickable="true"
         android:focusable="true"
         android:tint="@android:color/white"
-        fab:backgroundTint="@color/blue"
+        fab:backgroundTint="@color/red"
         fab:fabSize="normal"
         fab:srcCompat="@drawable/plus" />
 


### PR DESCRIPTION
## Description
updated fragment

Screenshots:
![img1](https://user-images.githubusercontent.com/43813438/54031794-c1656d00-41d5-11e9-8cd8-dd2a7756e717.jpg)
fixes:
#2377 

 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
