### PR TITLE
Fixes #2406 : Add a toast message when user successfully changes units and resolution of images in preferences. 

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
@@ -225,6 +225,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements INa
         energyUnitPreference.setEntryValues(energyUnits);
         energyUnitPreference.setOnPreferenceChangeListener((preference, newValue) -> {
             settings.edit().putString("energyUnitPreference", (String) newValue).apply();
+            Toast.makeText(getActivity(),getString(R.string.changes_saved),Toast.LENGTH_SHORT).show();
             return true;
         });
 
@@ -234,6 +235,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements INa
         volumeUnitPreference.setEntryValues(volumeUnits);
         volumeUnitPreference.setOnPreferenceChangeListener(((preference, newValue) -> {
             settings.edit().putString("volumeUnitPreference", (String) newValue).apply();
+            Toast.makeText(getActivity(),getString(R.string.changes_saved),Toast.LENGTH_SHORT).show();
             return true;
         }));
 
@@ -243,6 +245,7 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements INa
         imageUploadPref.setEntryValues(values);
         imageUploadPref.setOnPreferenceChangeListener((preference, newValue) -> {
             settings.edit().putString("imageUpload", (String) newValue).apply();
+            Toast.makeText(getActivity(),getString(R.string.changes_saved),Toast.LENGTH_SHORT).show();
             return true;
         });
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -637,7 +637,7 @@
     <string name="device_on_mobile_data_warning_message">Upload on mobile data is disabled, please connect to WiFi or change this in preferences</string>
     <string name="device_on_mobile_data_warning_positive">Preferences</string>
     <string name="device_on_mobile_data_warning_negative">Upload anyway</string>
-
+    <string name="changes_saved">Changes saved successfully</string>
     <string name="preference_choose_language_dialog_title">Choose language</string>
 
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout="@layout/fastscroller">
 
     <PreferenceCategory android:title="@string/preference_header_general">
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout="@layout/fastscroller">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
     <PreferenceCategory android:title="@string/preference_header_general">
 


### PR DESCRIPTION
## Description
added some toasts and a string.

## Related issues and discussion
#2406 

Screenshots:
![20190313_003911](https://user-images.githubusercontent.com/43813438/54228818-fdc40080-4528-11e9-85e7-1c57e303649e.gif)



 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
