### PR TITLE
use only flag View.SYSTEM_UI_FLAG_FULLSCREEN

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
@@ -535,11 +535,8 @@ public class ContinuousScanActivity extends android.support.v7.app.AppCompatActi
         View decorView = getWindow().getDecorView();
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             decorView.setSystemUiVisibility(
-                    View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                            | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                            | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                            // Hide the status bar
-                            | View.SYSTEM_UI_FLAG_FULLSCREEN);
+                    View.SYSTEM_UI_FLAG_FULLSCREEN
+            );
         } else {
             decorView.setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
         }


### PR DESCRIPTION
product continuous scan was not showing results, and was displaing weird bug (white line) on an Android 8.0.0 Samsung S8 with bottom status bar in "lock mode" (always displayed).