### PR TITLE
Add Uri null check for share image intent (#2444)

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -73,6 +73,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Hashtable;
 import java.util.Objects;
 
@@ -899,7 +900,6 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         Uri selectedImage = null;
         ArrayList<Uri> selectedImagesArray = new ArrayList<>();
         selectedImage = intent.getParcelableExtra(Intent.EXTRA_STREAM);
-        boolean isBarCodePresent = false;
         if (selectedImage != null) {
             selectedImagesArray.add(selectedImage);
             chooseDialog(selectedImagesArray);
@@ -909,6 +909,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
     private void handleSendMultipleImages(Intent intent) {
         ArrayList<Uri> selectedImagesArray = intent.getParcelableArrayListExtra(Intent.EXTRA_STREAM);
         if (selectedImagesArray != null) {
+            selectedImagesArray.removeAll(Collections.singleton(null));
             chooseDialog(selectedImagesArray);
         }
     }


### PR DESCRIPTION
## Description

If app is opened from a multiple image share intent and an image has
invalid Uri (null), this check fixes openInputStream acting on null

`getContentResolver.openInputStream(uri)` throws a NullPointerException if the Uri is null (invalid), so a null check is made at start of Uri list iteration

Problem exists as single image check in `handleSendImage` does check for null, but `handleSendMultipleImages` does not check individual list entries for null so modifications were made to ensure null check occurs in every instance

## Related issues and discussion
fixes #2444 