### PR TITLE
Screenshots generation on developper computer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Data about food is of public interest and has to be open. The complete database 
 
 <img src="https://lh3.googleusercontent.com/PYEw9fMLJ5ETPqB2mxeekfVTTNOkJHscs4MRHo546GJzwgIoj3SiJFsZDx4_D-EAUA=w720-h310" height="300"><img src="https://lh3.googleusercontent.com/q7NWz-hc4x39q8N7EW0cz5GZDHN5-F0ttZPHFPvf8-cTG2RImWi_C2J7zCY1Wtc_qZw=w1280-h636" height="300"><img src="https://lh3.googleusercontent.com/HXGodB99lZDp3lusX4ZdnkKJxcKiFv5ohfvaiMB7iX-i_QrcvWzUXPxmlSp8nq8SkBc=w1280-h636" height="300"><img src="https://lh3.googleusercontent.com/t_AWYLEzr2O4n7KVli8GV_gpT_N1FKhq5EwReUvJjXdJNoPTBTwD-3cKTfZUrkyQAMM=w1280-h636" height="300">
 
+To generate screenshot on local computer, launch the command `gradlew connectedOffScreenshotsAndroidTest --stacktrace --info -PtestBuildType=screenshots`
+
 ## Translations
 
 ### Translate Open Food Facts in your language

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,9 +1,24 @@
 apply plugin: 'com.android.application'
 apply plugin: 'de.timfreiheit.resourceplaceholders.plugin'
 
+def obtainTestBuildType() {
+    //to activate  screenshots buildType in IDE; uncomment next line and comment other
+    //otherwise the folder androidTestScreenshots is not recognized as a test folder.
+    def result="screenshots"
+//    def result = "debug";
+
+    if (project.hasProperty("testBuildType")) {
+        result = project.getProperties().get("testBuildType")
+    }
+
+    result
+}
+
 android {
     compileSdkVersion 27
     buildToolsVersion '28.0.3'
+
+    testBuildType obtainTestBuildType()
 
     defaultConfig {
         applicationId "openfoodfacts.github.scrachx.openfood"
@@ -14,11 +29,21 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }
-    
+
     buildTypes {
         release {
             crunchPngs true
         }
+
+        screenshots {
+            //to generate screenshots launch the grade task connectedOffScreenshotsAndroidTest -PtestBuildType=screenshots
+
+            initWith debug
+            defaultConfig.minSdkVersion 18
+        }
+
+
+
     }
 
     dataBinding {
@@ -35,6 +60,7 @@ android {
             buildConfigField 'String', 'OFWEBSITE', '"https://world.openfoodfacts.org/"'
             buildConfigField 'String', 'WIKIDATA', '"https://www.wikidata.org/wiki/Special:EntityData/"'
         }
+
 
         obf {
             applicationId "openfoodfacts.github.scrachx.openbeauty"
@@ -105,6 +131,8 @@ android {
         execution 'ANDROID_TEST_ORCHESTRATOR'
     }
 }
+
+
 
 buildscript {
     repositories {
@@ -254,6 +282,7 @@ dependencies {
         exclude group: 'com.android.support', module: 'design'
         exclude module: 'recyclerview-v7'
     }
+    androidTestImplementation 'tools.fastlane:screengrab:1.2.0'
     resourcePlaceholders {
         files = ['xml/shortcuts.xml']
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'de.timfreiheit.resourceplaceholders.plugin'
 def obtainTestBuildType() {
     //to activate  screenshots buildType in IDE; uncomment next line and comment other
     //otherwise the folder androidTestScreenshots is not recognized as a test folder.
-    def result="screenshots"
-//    def result = "debug";
+//    def result="screenshots"
+    def result = "debug"
 
     if (project.hasProperty("testBuildType")) {
         result = project.getProperties().get("testBuildType")

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,8 +4,8 @@ apply plugin: 'de.timfreiheit.resourceplaceholders.plugin'
 def obtainTestBuildType() {
     //to activate  screenshots buildType in IDE; uncomment next line and comment other
     //otherwise the folder androidTestScreenshots is not recognized as a test folder.
-//    def result="screenshots"
-    def result = "debug"
+    def result="screenshots"
+//    def result = "debug"
 
     if (project.hasProperty("testBuildType")) {
         result = project.getProperties().get("testBuildType")

--- a/app/src/androidTest/java/openfoodfacts/github/scrachx/openfood/models/OfflineSavedProductTest.java
+++ b/app/src/androidTest/java/openfoodfacts/github/scrachx/openfood/models/OfflineSavedProductTest.java
@@ -1,3 +1,5 @@
+package openfoodfacts.github.scrachx.openfood.models;
+
 import android.support.test.filters.SmallTest;
 import android.support.test.runner.AndroidJUnit4;
 import openfoodfacts.github.scrachx.openfood.models.Nutriments;

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/AbstractScreenshotTest.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/AbstractScreenshotTest.java
@@ -1,0 +1,98 @@
+package openfoodfacts.github.scrachx.openfood;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.support.test.rule.GrantPermissionRule;
+import android.util.Log;
+import openfoodfacts.github.scrachx.openfood.fragments.PreferencesFragment;
+import openfoodfacts.github.scrachx.openfood.test.ScreenshotActivityTestRule;
+import openfoodfacts.github.scrachx.openfood.test.ScreenshotParameter;
+import openfoodfacts.github.scrachx.openfood.test.ScreenshotsLocaleProvider;
+import openfoodfacts.github.scrachx.openfood.utils.LocaleHelper;
+import openfoodfacts.github.scrachx.openfood.views.OFFApplication;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Collection;
+import java.util.Locale;
+
+/**
+ * Take screenshots...
+ */
+@RunWith(JUnit4.class)
+public class AbstractScreenshotTest {
+    public static final String ACTION_NAME = "actionNmae";
+    private static final String LOG_TAG = AbstractScreenshotTest.class.getSimpleName();
+    @Rule
+    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.CHANGE_CONFIGURATION);
+    private static Locale initLocale;
+    private static String initCountry;
+    protected ScreenshotsLocaleProvider localeProvider = new ScreenshotsLocaleProvider();
+
+    protected void startScreenshotActivityTestRules(ScreenshotParameter screenshotParameter, ScreenshotActivityTestRule<? extends Activity>... activityRules) {
+        changeLocale(screenshotParameter);
+        for (ScreenshotActivityTestRule activityRule : activityRules) {
+            activityRule.finishActivity();
+            activityRule.setScreenshotParameter(screenshotParameter);
+            activityRule.launchActivity(null);
+        }
+    }
+
+    protected void startScreenshotActivityTestRules(ScreenshotParameter screenshotParameter, ScreenshotActivityTestRule<? extends Activity> activityRule,
+                                                    Collection<Intent> intents) {
+        changeLocale(screenshotParameter);
+        for (Intent intent : intents) {
+            String title = intent.getStringExtra(ACTION_NAME);
+            if (title != null) {
+                activityRule.setName(title);
+            }
+            activityRule.setActivityIntent(intent);
+            activityRule.setScreenshotParameter(screenshotParameter);
+            activityRule.launchActivity(null);
+        }
+    }
+
+    protected void changeLocale(ScreenshotParameter parameter) {
+        Log.d(LOG_TAG, "Change parameters to " + parameter);
+        LocaleHelper.setLocale(parameter.getLocale());
+        final String countryName = parameter.getCountryTag();
+        setCountyInPrefs(countryName);
+    }
+
+    private static void setCountyInPrefs(String countryName) {
+        SharedPreferences settings = OFFApplication.getInstance().getSharedPreferences("prefs", 0);
+        SharedPreferences.Editor editor = settings.edit();
+        editor.putString(PreferencesFragment.USER_COUNTRY_PREFERENCE_KEY, countryName);
+        editor.apply();
+    }
+
+    public void startForAllLocales(ScreenshotActivityTestRule<? extends Activity>... activityRule) {
+        for (ScreenshotParameter screenshotParameter : localeProvider.getParameters()) {
+            startScreenshotActivityTestRules(screenshotParameter, activityRule);
+        }
+    }
+
+    @AfterClass
+    public static void resetLanguage() {
+        LocaleHelper.setLocale(initLocale);
+        if (initCountry != null) {
+            setCountyInPrefs(initCountry);
+        }
+    }
+
+    @BeforeClass
+    public static void initLanguage() {
+        initLocale = LocaleHelper.getLocale();
+        initCountry = getCountryInPrefs();
+    }
+
+    public static String getCountryInPrefs() {
+        SharedPreferences settings = OFFApplication.getInstance().getSharedPreferences("prefs", 0);
+        return settings.getString(PreferencesFragment.USER_COUNTRY_PREFERENCE_KEY, null);
+    }
+}

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/FileWritingScreenshotCallback.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/FileWritingScreenshotCallback.java
@@ -1,0 +1,110 @@
+package openfoodfacts.github.scrachx.openfood;//
+
+import android.graphics.Bitmap;
+import android.graphics.Bitmap.CompressFormat;
+import android.os.Environment;
+import android.util.Log;
+import openfoodfacts.github.scrachx.openfood.BuildConfig;
+import openfoodfacts.github.scrachx.openfood.utils.LocaleHelper;
+import openfoodfacts.github.scrachx.openfood.views.OFFApplication;
+import tools.fastlane.screengrab.file.Chmod;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class FileWritingScreenshotCallback implements tools.fastlane.screengrab.ScreenshotCallback {
+    private static final String LOG_TAG = FileWritingScreenshotCallback.class.getSimpleName();
+    private DateFormat dateFormat = new SimpleDateFormat("YYYY-MM-dd-HHmm");
+
+    public FileWritingScreenshotCallback() {
+    }
+
+    public void screenshotCaptured(String screenshotName, Bitmap screenshot) {
+        try {
+            final Locale locale = LocaleHelper.getLocale();
+            File screenshotDirectory = getFilesDirectory(locale);
+            File screenshotFile = this.getScreenshotFile(screenshotDirectory, localeToDirName(locale) + "-" + screenshotName);
+            try (BufferedOutputStream fos = new BufferedOutputStream(new FileOutputStream(screenshotFile))) {
+                screenshot.compress(CompressFormat.PNG, 100, fos);
+                Chmod.chmodPlusR(screenshotFile);
+            } finally {
+                screenshot.recycle();
+            }
+
+            Log.d(LOG_TAG, "Captured screenshot \"" + screenshotFile.getName() + "\"");
+        } catch (Exception var10) {
+            throw new RuntimeException("Unable to capture screenshot.", var10);
+        }
+    }
+
+    private File getScreenshotFile(File screenshotDirectory, String screenshotName) {
+        String screenshotFileName = screenshotName + "_" + dateFormat.format(new Date()) + ".png";
+        return new File(screenshotDirectory, screenshotFileName);
+    }
+
+    /* Checks if external storage is available for read and write */
+    private static boolean isExternalStorageWritable() {
+        String state = Environment.getExternalStorageState();
+        if (Environment.MEDIA_MOUNTED.equals(state)) {
+            return true;
+        }
+        return false;
+    }
+
+    private File getFilesDirectory(Locale locale) throws IOException {
+
+        if (!isExternalStorageWritable()) {
+            Log.e(LOG_TAG, "Can't write to external storage check your installation");
+            throw new IOException("Can't write to external storage");
+        }
+
+        File targetDirectory = new File(Environment.getExternalStoragePublicDirectory(
+            Environment.DIRECTORY_PICTURES), BuildConfig.FLAVOR + "Screenshots");
+        Log.w(LOG_TAG, "Screenshots created in " + targetDirectory.getAbsolutePath());
+        File internalDir = new File(targetDirectory, localeToDirName(locale));
+        File directory = initializeDirectory(internalDir);
+
+        if (directory == null) {
+            throw new IOException("Unable to get a screenshot storage directory");
+        } else {
+            Log.d(LOG_TAG, "Using screenshot storage directory: " + directory.getAbsolutePath());
+            return directory;
+        }
+    }
+
+    private static File initializeDirectory(File dir) {
+        try {
+
+            createPathTo(dir);
+            if (dir.isDirectory() && dir.canWrite()) {
+                return dir;
+            }
+        } catch (IOException exception) {
+            Log.e(LOG_TAG, "Failed to initialize directory: " + dir.getAbsolutePath(), exception);
+        }
+
+        return null;
+    }
+
+    private static String localeToDirName(Locale locale) {
+        String localeCountry = locale.getCountry();
+        if (localeCountry != null && localeCountry.length() != 0) {
+            return locale.getLanguage() + "-" + localeCountry;
+        }
+        return locale.getLanguage();
+    }
+
+    private static void createPathTo(File dir) throws IOException {
+        if (!dir.exists() && !dir.mkdirs()) {
+            throw new IOException("Unable to create output dir: " + dir.getAbsolutePath());
+        } else {
+            Chmod.chmodPlusRWX(dir);
+        }
+    }
+}

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/TakeScreenshotIncompleteProductsTest.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/TakeScreenshotIncompleteProductsTest.java
@@ -1,0 +1,35 @@
+package openfoodfacts.github.scrachx.openfood;
+
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.annotation.UiThreadTest;
+import android.support.test.runner.AndroidJUnit4;
+import openfoodfacts.github.scrachx.openfood.test.ScreenshotActivityTestRule;
+import openfoodfacts.github.scrachx.openfood.utils.SearchInfo;
+import openfoodfacts.github.scrachx.openfood.views.OFFApplication;
+import openfoodfacts.github.scrachx.openfood.views.ProductBrowsingListActivity;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Take screenshots...
+ */
+@RunWith(AndroidJUnit4.class)
+public class TakeScreenshotIncompleteProductsTest extends AbstractScreenshotTest {
+    @Rule
+    public ScreenshotActivityTestRule<ProductBrowsingListActivity> incompleteRule = new ScreenshotActivityTestRule(ProductBrowsingListActivity.class, "incompleteProducts",
+        createSearchIntent(SearchInfo.emptySearchInfo()));
+
+    private static Intent createSearchIntent(SearchInfo searchInfo) {
+        Intent intent = new Intent(OFFApplication.getInstance(), ProductBrowsingListActivity.class);
+        intent.putExtra(ProductBrowsingListActivity.SEARCH_INFO, searchInfo);
+        return intent;
+    }
+
+    @Test
+    public void testTakeScreenshot() {
+        startForAllLocales(incompleteRule);
+    }
+}

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/TakeScreenshotMainActivityTest.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/TakeScreenshotMainActivityTest.java
@@ -1,0 +1,63 @@
+package openfoodfacts.github.scrachx.openfood;
+
+import android.Manifest;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.rule.GrantPermissionRule;
+import android.util.Log;
+import openfoodfacts.github.scrachx.openfood.utils.LocaleHelper;
+import openfoodfacts.github.scrachx.openfood.views.MainActivity;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import tools.fastlane.screengrab.FalconScreenshotStrategy;
+import tools.fastlane.screengrab.Screengrab;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+/**
+ * Take screenshots...
+ */
+@RunWith(JUnit4.class)
+public class TakeScreenshotMainActivityTest {
+    private static final String LOG_TAG = TakeScreenshotMainActivityTest.class.getSimpleName();
+
+    @Rule
+    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(android.Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.CHANGE_CONFIGURATION);
+    @Rule
+    public ActivityTestRule<MainActivity> activityRule = new ActivityTestRule<>(MainActivity.class, false, false);
+    private FileWritingScreenshotCallback callback = new FileWritingScreenshotCallback();
+    private static Locale initLocale;
+
+    public static Iterable<Locale> getLocales() {
+        return Arrays.asList(Locale.FRENCH, Locale.ENGLISH, Locale.ITALY);
+    }
+
+    @Test
+    public void testTakeScreenshot() {
+        for (Locale locale : getLocales()) {
+            testTakeScreenshot(locale);
+        }
+    }
+
+    public void testTakeScreenshot(Locale locale) {
+        Log.d(LOG_TAG, "Start screenshots for locale "+locale);
+        LocaleHelper.setLocale(locale);
+        activityRule.launchActivity(null);
+        Screengrab.screenshot("mainactivity", new FalconScreenshotStrategy(activityRule.getActivity()), callback);
+        activityRule.finishActivity();
+    }
+
+    @AfterClass
+    public static void resetLanguage() {
+        LocaleHelper.setLocale(initLocale);
+    }
+
+    @BeforeClass
+    public static void initLanguage() {
+        initLocale = LocaleHelper.getLocale();
+    }
+}

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/TakeScreenshotMainActivityTest.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/TakeScreenshotMainActivityTest.java
@@ -1,63 +1,24 @@
 package openfoodfacts.github.scrachx.openfood;
 
-import android.Manifest;
-import android.support.test.rule.ActivityTestRule;
-import android.support.test.rule.GrantPermissionRule;
-import android.util.Log;
-import openfoodfacts.github.scrachx.openfood.utils.LocaleHelper;
+import android.support.test.annotation.UiThreadTest;
+import android.support.test.runner.AndroidJUnit4;
+import openfoodfacts.github.scrachx.openfood.test.ScreenshotActivityTestRule;
 import openfoodfacts.github.scrachx.openfood.views.MainActivity;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import tools.fastlane.screengrab.FalconScreenshotStrategy;
-import tools.fastlane.screengrab.Screengrab;
-
-import java.util.Arrays;
-import java.util.Locale;
 
 /**
  * Take screenshots...
  */
-@RunWith(JUnit4.class)
-public class TakeScreenshotMainActivityTest {
-    private static final String LOG_TAG = TakeScreenshotMainActivityTest.class.getSimpleName();
-
+@RunWith(AndroidJUnit4.class)
+public class TakeScreenshotMainActivityTest extends AbstractScreenshotTest {
     @Rule
-    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(android.Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.CHANGE_CONFIGURATION);
-    @Rule
-    public ActivityTestRule<MainActivity> activityRule = new ActivityTestRule<>(MainActivity.class, false, false);
-    private FileWritingScreenshotCallback callback = new FileWritingScreenshotCallback();
-    private static Locale initLocale;
-
-    public static Iterable<Locale> getLocales() {
-        return Arrays.asList(Locale.FRENCH, Locale.ENGLISH, Locale.ITALY);
-    }
+    public ScreenshotActivityTestRule<MainActivity> activityRule = new ScreenshotActivityTestRule<>(MainActivity.class);
 
     @Test
     public void testTakeScreenshot() {
-        for (Locale locale : getLocales()) {
-            testTakeScreenshot(locale);
-        }
-    }
-
-    public void testTakeScreenshot(Locale locale) {
-        Log.d(LOG_TAG, "Start screenshots for locale "+locale);
-        LocaleHelper.setLocale(locale);
-        activityRule.launchActivity(null);
-        Screengrab.screenshot("mainactivity", new FalconScreenshotStrategy(activityRule.getActivity()), callback);
-        activityRule.finishActivity();
-    }
-
-    @AfterClass
-    public static void resetLanguage() {
-        LocaleHelper.setLocale(initLocale);
-    }
-
-    @BeforeClass
-    public static void initLanguage() {
-        initLocale = LocaleHelper.getLocale();
+        startForAllLocales(activityRule);
     }
 }

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/TakeScreenshotShowProductsTest.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/TakeScreenshotShowProductsTest.java
@@ -1,0 +1,48 @@
+package openfoodfacts.github.scrachx.openfood;
+
+import android.content.Intent;
+import android.support.test.runner.AndroidJUnit4;
+import openfoodfacts.github.scrachx.openfood.models.Product;
+import openfoodfacts.github.scrachx.openfood.models.State;
+import openfoodfacts.github.scrachx.openfood.test.ScreenshotActivityTestRule;
+import openfoodfacts.github.scrachx.openfood.test.ScreenshotParameter;
+import openfoodfacts.github.scrachx.openfood.views.OFFApplication;
+import openfoodfacts.github.scrachx.openfood.views.product.ProductActivity;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Take screenshots...
+ */
+@RunWith(AndroidJUnit4.class)
+public class TakeScreenshotShowProductsTest extends AbstractScreenshotTest {
+    @Rule
+    public ScreenshotActivityTestRule<ProductActivity> activityShowProductRule = new ScreenshotActivityTestRule<>(ProductActivity.class);
+
+    private static Intent createProductIntent(String productCode) {
+        Intent intent = new Intent(OFFApplication.getInstance(), ProductActivity.class);
+        State st = new State();
+        Product pd = new Product();
+        pd.setCode(productCode);
+        st.setProduct(pd);
+        intent.putExtra("state", st);
+        intent.putExtra(ACTION_NAME, ProductActivity.class.getSimpleName() + "-" + productCode);
+        return intent;
+    }
+
+    @Test
+    public void testTakeScreenshot() {
+        for (ScreenshotParameter screenshotParameter : localeProvider.getParameters()) {
+            List<Intent> intents = new ArrayList<>();
+            intents.add(createProductIntent(screenshotParameter.getMainProductCode()));
+            for (String product : screenshotParameter.getOtherProductCodes()) {
+                intents.add(createProductIntent(product));
+            }
+            startScreenshotActivityTestRules(screenshotParameter, activityShowProductRule, intents);
+        }
+    }
+}

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/TakeScreenshotShowProductsTest.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/TakeScreenshotShowProductsTest.java
@@ -6,6 +6,7 @@ import openfoodfacts.github.scrachx.openfood.models.Product;
 import openfoodfacts.github.scrachx.openfood.models.State;
 import openfoodfacts.github.scrachx.openfood.test.ScreenshotActivityTestRule;
 import openfoodfacts.github.scrachx.openfood.test.ScreenshotParameter;
+import openfoodfacts.github.scrachx.openfood.views.HistoryScanActivity;
 import openfoodfacts.github.scrachx.openfood.views.OFFApplication;
 import openfoodfacts.github.scrachx.openfood.views.product.ProductActivity;
 import org.junit.Rule;
@@ -22,6 +23,8 @@ import java.util.List;
 public class TakeScreenshotShowProductsTest extends AbstractScreenshotTest {
     @Rule
     public ScreenshotActivityTestRule<ProductActivity> activityShowProductRule = new ScreenshotActivityTestRule<>(ProductActivity.class);
+    @Rule
+    public ScreenshotActivityTestRule<HistoryScanActivity> historyTestRule = new ScreenshotActivityTestRule<>(HistoryScanActivity.class);
 
     private static Intent createProductIntent(String productCode) {
         Intent intent = new Intent(OFFApplication.getInstance(), ProductActivity.class);
@@ -38,11 +41,11 @@ public class TakeScreenshotShowProductsTest extends AbstractScreenshotTest {
     public void testTakeScreenshot() {
         for (ScreenshotParameter screenshotParameter : localeProvider.getParameters()) {
             List<Intent> intents = new ArrayList<>();
-            intents.add(createProductIntent(screenshotParameter.getMainProductCode()));
-            for (String product : screenshotParameter.getOtherProductCodes()) {
+            for (String product : screenshotParameter.getProductCodes()) {
                 intents.add(createProductIntent(product));
             }
             startScreenshotActivityTestRules(screenshotParameter, activityShowProductRule, intents);
+            startScreenshotActivityTestRules(screenshotParameter, historyTestRule);
         }
     }
 }

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotActivityTestRule.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotActivityTestRule.java
@@ -1,0 +1,89 @@
+package openfoodfacts.github.scrachx.openfood.test;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.rule.ActivityTestRule;
+import android.util.Log;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.function.Consumer;
+
+public class ScreenshotActivityTestRule<T extends Activity> extends ActivityTestRule<T> {
+    String name;
+    private Intent activityIntent;
+    private ScreenshotParameter screenshotParameter;
+    Consumer<ScreenshotActivityTestRule> action;
+
+    public ScreenshotActivityTestRule(Class<T> activityClass) {
+        this(activityClass, activityClass.getSimpleName(), null);
+    }
+
+    public ScreenshotParameter getScreenshotParameter() {
+        return screenshotParameter;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public ScreenshotActivityTestRule(Class<T> activityClass, String name) {
+        this(activityClass, name, null);
+    }
+
+    public ScreenshotActivityTestRule(Class<T> activityClass, Intent intent) {
+        this(activityClass, activityClass.getSimpleName(), intent);
+    }
+
+    public ScreenshotActivityTestRule(Class<T> activityClass, String name, Intent intent) {
+        super(activityClass, false, false);
+        this.name = name;
+        this.activityIntent = intent;
+    }
+
+    public void setScreenshotParameter(ScreenshotParameter screenshotParameter) {
+        this.screenshotParameter = screenshotParameter;
+    }
+
+    public void setAction(Consumer<ScreenshotActivityTestRule> action) {
+        this.action = action;
+    }
+
+    public void setActivityIntent(Intent activityIntent) {
+        this.activityIntent = activityIntent;
+    }
+
+    @Override
+    protected void afterActivityLaunched() {
+        try {
+            Thread.sleep(5000);
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync();
+            if (action != null) {
+                action.accept(this);
+            } else {
+                takeScreenshot();
+            }
+            this.finishActivity();
+        } catch (Throwable throwable) {
+            Log.e(ScreenshotActivityTestRule.class.getSimpleName(), "run on ui", throwable);
+        }
+    }
+
+    public void takeScreenshot() {
+        takeScreenshot(StringUtils.EMPTY);
+    }
+
+    public void takeScreenshot(String suffix) {
+        ScreenshotTaker taker = new ScreenshotTaker();
+        taker.takeScreenshot(screenshotParameter, suffix, this);
+    }
+
+    @Override
+    protected Intent getActivityIntent() {
+        return activityIntent;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotParameter.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotParameter.java
@@ -6,8 +6,7 @@ import java.util.Locale;
 public class ScreenshotParameter {
     private String countryTag;
     private Locale locale;
-    private String mainProductCode;
-    private List<String> otherProductCodes;
+    private List<String> productCodes;
 
     public ScreenshotParameter(String countryTag, Locale language) {
         this.countryTag = countryTag;
@@ -31,19 +30,12 @@ public class ScreenshotParameter {
         return "country: " + countryTag + "; language: " + locale;
     }
 
-    public String getMainProductCode() {
-        return mainProductCode;
+
+    public List<String> getProductCodes() {
+        return productCodes;
     }
 
-    public void setMainProductCode(String mainProductCode) {
-        this.mainProductCode = mainProductCode;
-    }
-
-    public List<String> getOtherProductCodes() {
-        return otherProductCodes;
-    }
-
-    public void setOtherProductCodes(List<String> otherProductCodes) {
-        this.otherProductCodes = otherProductCodes;
+    public void setProductCodes(List<String> productCodes) {
+        this.productCodes = productCodes;
     }
 }

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotParameter.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotParameter.java
@@ -1,0 +1,49 @@
+package openfoodfacts.github.scrachx.openfood.test;
+
+import java.util.List;
+import java.util.Locale;
+
+public class ScreenshotParameter {
+    private String countryTag;
+    private Locale locale;
+    private String mainProductCode;
+    private List<String> otherProductCodes;
+
+    public ScreenshotParameter(String countryTag, Locale language) {
+        this.countryTag = countryTag;
+        this.locale = language;
+    }
+
+    public String getCountryTag() {
+        return countryTag;
+    }
+
+    public Locale getLocale() {
+        return locale;
+    }
+
+    public String getLanguage() {
+        return locale.getLanguage();
+    }
+
+    @Override
+    public String toString() {
+        return "country: " + countryTag + "; language: " + locale;
+    }
+
+    public String getMainProductCode() {
+        return mainProductCode;
+    }
+
+    public void setMainProductCode(String mainProductCode) {
+        this.mainProductCode = mainProductCode;
+    }
+
+    public List<String> getOtherProductCodes() {
+        return otherProductCodes;
+    }
+
+    public void setOtherProductCodes(List<String> otherProductCodes) {
+        this.otherProductCodes = otherProductCodes;
+    }
+}

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotParametersProvider.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotParametersProvider.java
@@ -1,0 +1,36 @@
+package openfoodfacts.github.scrachx.openfood.test;
+
+import openfoodfacts.github.scrachx.openfood.utils.LocaleHelper;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+public class ScreenshotParametersProvider {
+    /**
+     * @param countryTag see https://static.openfoodfacts.org/data/taxonomies/countries.json. the county tag is en:countryTag
+     */
+    public static ScreenshotParameter create(String countryTag, String languageCode, String mainProduct, String... otherProductsCode) {
+        return create(countryTag, LocaleHelper.getLocale(languageCode), mainProduct, otherProductsCode);
+    }
+
+    /**
+     * @param countryTag see https://static.openfoodfacts.org/data/taxonomies/countries.json. the county tag is en:countryTag
+     */
+    public static ScreenshotParameter create(String countryTag, Locale locale, String mainProduct, String... otherProductsCode) {
+        ScreenshotParameter parameter = new ScreenshotParameter(countryTag, locale);
+        parameter.setMainProductCode(mainProduct);
+        parameter.setOtherProductCodes(Arrays.asList(otherProductsCode));
+        return parameter;
+    }
+
+    public static List<ScreenshotParameter> createDefault() {
+        List<ScreenshotParameter> res = new ArrayList<>();
+        res.add(create("brazil", new Locale("pt", "BR"), "3017760002707", "3387390326574", "3179142054664"));
+        res.add(create("france", Locale.FRANCE, "3017760002707", "3387390326574", "3179142054664"));
+        res.add(create("united-kingdom", Locale.ENGLISH, "3017760002707", "3387390326574", "3179142054664"));
+
+        return res;
+    }
+}

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotParametersProvider.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotParametersProvider.java
@@ -11,23 +11,25 @@ public class ScreenshotParametersProvider {
     /**
      * @param countryTag see https://static.openfoodfacts.org/data/taxonomies/countries.json. the county tag is en:countryTag
      */
-    public static ScreenshotParameter create(String countryTag, String languageCode, String mainProduct, String... otherProductsCode) {
-        return create(countryTag, LocaleHelper.getLocale(languageCode), mainProduct, otherProductsCode);
+    public static ScreenshotParameter create(String countryTag, String languageCode, String... otherProductsCode) {
+        return create(countryTag, LocaleHelper.getLocale(languageCode), otherProductsCode);
     }
 
     /**
      * @param countryTag see https://static.openfoodfacts.org/data/taxonomies/countries.json. the county tag is en:countryTag
      */
-    public static ScreenshotParameter create(String countryTag, Locale locale, String mainProduct, String... otherProductsCode) {
+    public static ScreenshotParameter create(String countryTag, Locale locale, String... otherProductsCode) {
         ScreenshotParameter parameter = new ScreenshotParameter(countryTag, locale);
-        parameter.setMainProductCode(mainProduct);
-        parameter.setOtherProductCodes(Arrays.asList(otherProductsCode));
+        parameter.setProductCodes(Arrays.asList(otherProductsCode));
         return parameter;
     }
 
     public static List<ScreenshotParameter> createDefault() {
         List<ScreenshotParameter> res = new ArrayList<>();
-        res.add(create("brazil", new Locale("pt", "BR"), "3017760002707", "3387390326574", "3179142054664"));
+        String[] productCodes = {"3017760002707", "3387390326574", "3366321051631", "3179142054664", "4001724819400", "3179142054725", "7613034365774",
+            "30005501", "5412971096664", "9311627010183"};
+
+        res.add(create("brazil", new Locale("pt", "BR"), productCodes));
         res.add(create("france", Locale.FRANCE, "3017760002707", "3387390326574", "3179142054664"));
         res.add(create("united-kingdom", Locale.ENGLISH, "3017760002707", "3387390326574", "3179142054664"));
 

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotTaker.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotTaker.java
@@ -1,0 +1,25 @@
+package openfoodfacts.github.scrachx.openfood.test;
+
+import android.app.Activity;
+import android.util.Log;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import tools.fastlane.screengrab.FalconScreenshotStrategy;
+import tools.fastlane.screengrab.Screengrab;
+
+/**
+ * Take screenshots...
+ */
+@RunWith(JUnit4.class)
+public class ScreenshotTaker {
+    private static final String LOG_TAG = ScreenshotTaker.class.getSimpleName();
+    private FileWritingScreenshotCallback callback = new FileWritingScreenshotCallback();
+
+    public void takeScreenshot(ScreenshotParameter screenshotParameter, String suffix, ScreenshotActivityTestRule<? extends Activity> activityRule) {
+        final String screenshotName = activityRule.getName()+ suffix;
+        callback.setScreenshotParameter(screenshotParameter);
+        Log.d(LOG_TAG, "Start screenshots for screenshotParameter " + screenshotParameter + " for activity " + screenshotName);
+        Screengrab.screenshot(screenshotName, new FalconScreenshotStrategy(activityRule.getActivity()), callback);
+    }
+
+}

--- a/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotsLocaleProvider.java
+++ b/app/src/androidTestScreenshots/java/openfoodfacts/github/scrachx/openfood/test/ScreenshotsLocaleProvider.java
@@ -1,0 +1,33 @@
+package openfoodfacts.github.scrachx.openfood.test;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.Predicate;
+import org.apache.commons.collections4.PredicateUtils;
+
+import java.util.List;
+
+public class ScreenshotsLocaleProvider {
+    private static List<ScreenshotParameter> parameters;
+
+    private List<ScreenshotParameter> getAllParameters() {
+        if (parameters == null) {
+            parameters = ScreenshotParametersProvider.createDefault();
+        }
+        return parameters;
+    }
+
+    private Predicate<ScreenshotParameter> predicate = PredicateUtils.truePredicate();
+
+    /**
+     * @param predicate could be used to filter to use for a tests.
+     */
+    public void setPredicate(Predicate<ScreenshotParameter> predicate) {
+        this.predicate = predicate;
+    }
+
+    public List<ScreenshotParameter> getParameters() {
+        final List<ScreenshotParameter> allLocales = getAllParameters();
+        CollectionUtils.filter(allLocales, predicate);
+        return allLocales;
+    }
+}

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
@@ -367,7 +367,7 @@ public class AddProductOverviewFragment extends BaseFragment {
             }
             //Also add the country set by the user in preferences
             SharedPreferences sharedPref = PreferenceManager.getDefaultSharedPreferences(getContext());
-            String savedCountry = sharedPref.getString("user_country", "");
+            String savedCountry = sharedPref.getString(PreferencesFragment.USER_COUNTRY_PREFERENCE_KEY, "");
             if (!savedCountry.isEmpty()) {
                 chipValues.add(savedCountry);
             }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/FindProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/FindProductFragment.java
@@ -1,6 +1,7 @@
 package openfoodfacts.github.scrachx.openfood.fragments;
 
-
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -10,23 +11,26 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.TextView;
 import android.widget.Toast;
-
-import org.apache.commons.validator.routines.checkdigit.EAN13CheckDigit;
-
 import butterknife.BindView;
 import butterknife.OnClick;
 import openfoodfacts.github.scrachx.openfood.R;
 import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient;
 import openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener.NavigationDrawerType;
 import openfoodfacts.github.scrachx.openfood.utils.Utils;
+import openfoodfacts.github.scrachx.openfood.views.MainActivity;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.validator.routines.checkdigit.EAN13CheckDigit;
 
 import static openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener.ITEM_SEARCH_BY_CODE;
 
 public class FindProductFragment extends NavigationBaseFragment {
-
-    @BindView(R.id.editTextBarcode) EditText mBarCodeText;
-    @BindView(R.id.buttonBarcode) Button mLaunchButton;
+    public static final String BARCODE = "barcode";
+    @BindView(R.id.editTextBarcode)
+    EditText mBarCodeText;
+    @BindView(R.id.buttonBarcode)
+    Button mLaunchButton;
     private OpenFoodAPIClient api;
     private Toast mToast;
 
@@ -40,6 +44,18 @@ public class FindProductFragment extends NavigationBaseFragment {
         super.onViewCreated(view, savedInstanceState);
         mBarCodeText.setSelected(false);
         api = new OpenFoodAPIClient(getActivity());
+        if (getActivity().getIntent() != null) {
+            String barCode = getActivity().getIntent().getStringExtra(BARCODE);
+            if (StringUtils.isNotEmpty(barCode)) {
+                searchBarcode(barCode);
+            }
+        }
+    }
+
+    public static Intent createIntentToFindProduct(Context context, String barcode) {
+        Intent intent = new Intent(context, MainActivity.class);
+        intent.putExtra(BARCODE, barcode);
+        return intent;
     }
 
     @OnClick(R.id.buttonBarcode)
@@ -49,17 +65,22 @@ public class FindProductFragment extends NavigationBaseFragment {
             displayToast(getResources().getString(R.string.txtBarcodeRequire));
         } else {
             String barcodeText = mBarCodeText.getText().toString();
-            if(barcodeText.length()<=2){
+            if (barcodeText.length() <= 2) {
                 displayToast(getResources().getString(R.string.txtBarcodeNotValid));
-            }
-            else {
-                if (EAN13CheckDigit.EAN13_CHECK_DIGIT.isValid(barcodeText) && (!barcodeText.substring(0, 3).contains("977") ||!barcodeText.substring(0, 3).contains("978") || !barcodeText.substring(0, 3).contains("979"))) {
+            } else {
+                if (EAN13CheckDigit.EAN13_CHECK_DIGIT.isValid(barcodeText) && (!barcodeText.substring(0, 3).contains("977") || !barcodeText.substring(0, 3)
+                    .contains("978") || !barcodeText.substring(0, 3).contains("979"))) {
                     api.getProduct(mBarCodeText.getText().toString(), getActivity());
                 } else {
                     displayToast(getResources().getString(R.string.txtBarcodeNotValid));
                 }
             }
         }
+    }
+
+    private void searchBarcode(String code) {
+        mBarCodeText.setText(code, TextView.BufferType.EDITABLE);
+        onSearchBarcodeProduct();
     }
 
     @Override
@@ -69,11 +90,13 @@ public class FindProductFragment extends NavigationBaseFragment {
     }
 
     public void displayToast(String message) {
-        if (mToast != null)
+        if (mToast != null) {
             mToast.cancel();
+        }
         mToast = Toast.makeText(getContext(), message, Toast.LENGTH_SHORT);
         mToast.show();
     }
+
     public void onResume() {
 
         super.onResume();
@@ -83,13 +106,13 @@ public class FindProductFragment extends NavigationBaseFragment {
         } catch (NullPointerException e) {
             e.printStackTrace();
         }
-
     }
 
     @Override
     public void onPause() {
-        if (mToast != null)
+        if (mToast != null) {
             mToast.cancel();
+        }
 
         super.onPause();
     }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
@@ -48,7 +48,7 @@ import static openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListen
 public class PreferencesFragment extends PreferenceFragmentCompat implements INavigationItem {
     private AdditiveDao mAdditiveDao;
     private NavigationDrawerListener navigationDrawerListener;
-    private static final String USER_COUNTRY_PREFERENCE_KEY = "user_country";
+    public static final String USER_COUNTRY_PREFERENCE_KEY = "user_country";
     private Context context;
 
     @Override

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/LocaleHelper.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/LocaleHelper.java
@@ -6,6 +6,7 @@ import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.os.Build;
 import android.preference.PreferenceManager;
+import openfoodfacts.github.scrachx.openfood.views.OFFApplication;
 
 import java.util.Locale;
 
@@ -18,7 +19,6 @@ import java.util.Locale;
  * Created by gunhansancar on 07/10/15.
  */
 public class LocaleHelper {
-
     private static final String SELECTED_LANGUAGE = "Locale.Helper.Selected.Language";
 
     public static void onCreate(Context context) {
@@ -31,8 +31,16 @@ public class LocaleHelper {
         setLocale(context, lang);
     }
 
+    public static Locale getLocale() {
+        return getLocale(OFFApplication.getInstance());
+    }
+
+    public static void setLocale(Locale locale) {
+        setLocale(OFFApplication.getInstance(), locale);
+    }
+
     public static String getLanguage(Context context) {
-        String lang= getPersistedData(context, Locale.getDefault().getLanguage());
+        String lang = getPersistedData(context, Locale.getDefault().getLanguage());
         if (lang.contains("-")) {
             String langSplit[] = lang.split("-");
             lang = langSplit[0];
@@ -40,13 +48,36 @@ public class LocaleHelper {
         return lang;
     }
 
+    public static Locale getLocale(Context context) {
+        Resources resources = context.getResources();
+        Configuration configuration = resources.getConfiguration();
+        final Locale locale = configuration.locale;
+        return locale == null ? Locale.getDefault() : locale;
+    }
+
     public static void setLocale(Context context, String language) {
         PreferenceManager.getDefaultSharedPreferences(context)
-                .edit()
-                .putString(SELECTED_LANGUAGE, language)
-                .apply();
+            .edit()
+            .putString(SELECTED_LANGUAGE, language)
+            .apply();
 
         Locale locale = getLocale(language);
+
+        Locale.setDefault(locale);
+
+        Resources resources = context.getResources();
+
+        Configuration configuration = resources.getConfiguration();
+        configuration.locale = locale;
+
+        resources.updateConfiguration(configuration, resources.getDisplayMetrics());
+    }
+
+    public static void setLocale(Context context, Locale locale) {
+        PreferenceManager.getDefaultSharedPreferences(context)
+            .edit()
+            .putString(SELECTED_LANGUAGE, locale.getLanguage())
+            .apply();
 
         Locale.setDefault(locale);
 
@@ -68,7 +99,7 @@ public class LocaleHelper {
         String[] localeParts = locale.split("-");
         String language = localeParts[0];
         String country = localeParts.length == 2 ? localeParts[1] : "";
-        Locale localeObj=null;
+        Locale localeObj = null;
         if (locale.contains("+")) {
             localeParts = locale.split("\\+");
             language = localeParts[1];
@@ -82,9 +113,8 @@ public class LocaleHelper {
             } else {
                 localeObj = new Locale.Builder().setLanguage(language).setRegion(country).setScript(script).build();
             }
-
-        }else {
-            localeObj = new Locale(language,country);
+        } else {
+            localeObj = new Locale(language, country);
         }
         return localeObj;
     }
@@ -93,5 +123,4 @@ public class LocaleHelper {
         SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences(context);
         return preferences.getString(SELECTED_LANGUAGE, defaultLanguage);
     }
-
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -2,11 +2,7 @@ package openfoodfacts.github.scrachx.openfood.views;
 
 import android.Manifest;
 import android.app.SearchManager;
-import android.content.ActivityNotFoundException;
-import android.content.Context;
-import android.content.DialogInterface;
-import android.content.Intent;
-import android.content.SharedPreferences;
+import android.content.*;
 import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
@@ -40,18 +36,9 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.Toast;
-
+import butterknife.BindView;
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.google.zxing.BinaryBitmap;
-import com.google.zxing.ChecksumException;
-import com.google.zxing.DecodeHintType;
-import com.google.zxing.FormatException;
-import com.google.zxing.LuminanceSource;
-import com.google.zxing.MultiFormatReader;
-import com.google.zxing.NotFoundException;
-import com.google.zxing.RGBLuminanceSource;
-import com.google.zxing.Reader;
-import com.google.zxing.Result;
+import com.google.zxing.*;
 import com.google.zxing.common.HybridBinarizer;
 import com.mikepenz.fastadapter.commons.utils.RecyclerViewCacheUtil;
 import com.mikepenz.google_material_typeface_library.GoogleMaterial;
@@ -61,13 +48,20 @@ import com.mikepenz.materialdrawer.Drawer;
 import com.mikepenz.materialdrawer.DrawerBuilder;
 import com.mikepenz.materialdrawer.holder.BadgeStyle;
 import com.mikepenz.materialdrawer.holder.StringHolder;
-import com.mikepenz.materialdrawer.model.DividerDrawerItem;
-import com.mikepenz.materialdrawer.model.PrimaryDrawerItem;
-import com.mikepenz.materialdrawer.model.ProfileDrawerItem;
-import com.mikepenz.materialdrawer.model.ProfileSettingDrawerItem;
-import com.mikepenz.materialdrawer.model.SectionDrawerItem;
+import com.mikepenz.materialdrawer.model.*;
 import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem;
 import com.mikepenz.materialdrawer.model.interfaces.IProfile;
+import openfoodfacts.github.scrachx.openfood.BuildConfig;
+import openfoodfacts.github.scrachx.openfood.R;
+import openfoodfacts.github.scrachx.openfood.fragments.*;
+import openfoodfacts.github.scrachx.openfood.models.*;
+import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient;
+import openfoodfacts.github.scrachx.openfood.utils.*;
+import openfoodfacts.github.scrachx.openfood.views.adapters.PhotosAdapter;
+import openfoodfacts.github.scrachx.openfood.views.category.activity.CategoryActivity;
+import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabActivityHelper;
+import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabsHelper;
+import openfoodfacts.github.scrachx.openfood.views.customtabs.WebViewFallback;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -78,38 +72,10 @@ import java.util.Collections;
 import java.util.Hashtable;
 import java.util.Objects;
 
-import butterknife.BindView;
-import openfoodfacts.github.scrachx.openfood.BuildConfig;
-import openfoodfacts.github.scrachx.openfood.R;
-import openfoodfacts.github.scrachx.openfood.fragments.AllergensAlertFragment;
-import openfoodfacts.github.scrachx.openfood.fragments.FindProductFragment;
-import openfoodfacts.github.scrachx.openfood.fragments.HomeFragment;
-import openfoodfacts.github.scrachx.openfood.fragments.OfflineEditFragment;
-import openfoodfacts.github.scrachx.openfood.fragments.PreferencesFragment;
-import openfoodfacts.github.scrachx.openfood.models.LabelNameDao;
-import openfoodfacts.github.scrachx.openfood.models.OfflineSavedProductDao;
-import openfoodfacts.github.scrachx.openfood.models.Product;
-import openfoodfacts.github.scrachx.openfood.models.ProductImage;
-import openfoodfacts.github.scrachx.openfood.models.State;
-import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient;
-import openfoodfacts.github.scrachx.openfood.utils.LocaleHelper;
-import openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener;
-import openfoodfacts.github.scrachx.openfood.utils.RealPathUtil;
-import openfoodfacts.github.scrachx.openfood.utils.SearchSuggestionProvider;
-import openfoodfacts.github.scrachx.openfood.utils.SearchType;
-import openfoodfacts.github.scrachx.openfood.utils.ShakeDetector;
-import openfoodfacts.github.scrachx.openfood.utils.Utils;
-import openfoodfacts.github.scrachx.openfood.views.adapters.PhotosAdapter;
-import openfoodfacts.github.scrachx.openfood.views.category.activity.CategoryActivity;
-import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabActivityHelper;
-import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabsHelper;
-import openfoodfacts.github.scrachx.openfood.views.customtabs.WebViewFallback;
-
 import static openfoodfacts.github.scrachx.openfood.models.ProductImageField.OTHER;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 public class MainActivity extends BaseActivity implements CustomTabActivityHelper.ConnectionCallback, NavigationDrawerListener, SharedPreferences.OnSharedPreferenceChangeListener {
-
     private static final int LOGIN_REQUEST = 1;
     private static final long USER_ID = 500;
     private static final String CONTRIBUTIONS_SHORTCUT = "CONTRIBUTIONS";
@@ -143,7 +109,6 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
     // boolean to determine if scan on shake feature should be enabled
     private boolean scanOnShake;
     private SharedPreferences shakePreference;
-
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -205,11 +170,11 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         boolean isOpenOfflineEdit = extras != null && extras.getBoolean("openOfflineEdit");
         if (isOpenOfflineEdit) {
             fragmentManager.beginTransaction().replace(R.id.fragment_container, new
-                    OfflineEditFragment()).commit();
+                OfflineEditFragment()).commit();
             getSupportActionBar().setTitle(getResources().getString(R.string.offline_edit_drawer));
         } else {
             fragmentManager.beginTransaction().replace(R.id.fragment_container, new HomeFragment
-                    ()).commit();
+                ()).commit();
         }
 
         // chrome custom tab init
@@ -217,63 +182,58 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         customTabActivityHelper.setConnectionCallback(this);
 
         customTabsIntent = CustomTabsHelper.getCustomTabsIntent(getBaseContext(),
-        customTabActivityHelper.getSession());
-
+            customTabActivityHelper.getSession());
 
         // Create the AccountHeader
         headerResult = new AccountHeaderBuilder()
-                .withActivity(this)
-                .withTranslucentStatusBar(true)
-                .withHeaderBackground(R.drawable.header)
-                .addProfiles(profile)
-                .withOnAccountHeaderProfileImageListener(new AccountHeader.OnAccountHeaderProfileImageListener() {
-                    @Override
-                    public boolean onProfileImageClick(View view, IProfile profile, boolean current) {
+            .withActivity(this)
+            .withTranslucentStatusBar(true)
+            .withHeaderBackground(R.drawable.header)
+            .addProfiles(profile)
+            .withOnAccountHeaderProfileImageListener(new AccountHeader.OnAccountHeaderProfileImageListener() {
+                @Override
+                public boolean onProfileImageClick(View view, IProfile profile, boolean current) {
 
-                        SharedPreferences preferences = getSharedPreferences("login", 0);
-                        String userLogin = preferences.getString("user", null);
-                        boolean isConnected = userLogin != null;
-                        if (!isConnected) {
-                            startActivity(new Intent(MainActivity.this, LoginActivity.class));
-                        }
-                        return false;
-
-
+                    SharedPreferences preferences = getSharedPreferences("login", 0);
+                    String userLogin = preferences.getString("user", null);
+                    boolean isConnected = userLogin != null;
+                    if (!isConnected) {
+                        startActivity(new Intent(MainActivity.this, LoginActivity.class));
                     }
-
-                    @Override
-                    public boolean onProfileImageLongClick(View view, IProfile profile, boolean current) {
-                        return false;
-                    }
-                })
-                .withOnAccountHeaderSelectionViewClickListener(new AccountHeader.OnAccountHeaderSelectionViewClickListener() {
-                    @Override
-                    public boolean onClick(View view, IProfile profile) {
-                        SharedPreferences preferences = getSharedPreferences("login", 0);
-                        String userLogin = preferences.getString("user", null);
-                        boolean isConnected = userLogin != null;
-                        if (!isConnected) {
-                            startActivity(new Intent(MainActivity.this, LoginActivity.class));
-
-                        }
-                        return false;
-
-                    }
-                })
-                .withSelectionListEnabledForSingleProfile(false)
-                .withOnAccountHeaderListener((view, profile1, current) -> {
-                    if (profile1 instanceof IDrawerItem) {
-                        if (profile1.getIdentifier() == ITEM_MANAGE_ACCOUNT) {
-                            CustomTabActivityHelper.openCustomTab(MainActivity.this,
-                                    customTabsIntent, userAccountUri, new WebViewFallback());
-                        }
-                    }
-
-                    //false if you have not consumed the event and it should close the drawer
                     return false;
-                })
-                .withSavedInstance(savedInstanceState)
-                .build();
+                }
+
+                @Override
+                public boolean onProfileImageLongClick(View view, IProfile profile, boolean current) {
+                    return false;
+                }
+            })
+            .withOnAccountHeaderSelectionViewClickListener(new AccountHeader.OnAccountHeaderSelectionViewClickListener() {
+                @Override
+                public boolean onClick(View view, IProfile profile) {
+                    SharedPreferences preferences = getSharedPreferences("login", 0);
+                    String userLogin = preferences.getString("user", null);
+                    boolean isConnected = userLogin != null;
+                    if (!isConnected) {
+                        startActivity(new Intent(MainActivity.this, LoginActivity.class));
+                    }
+                    return false;
+                }
+            })
+            .withSelectionListEnabledForSingleProfile(false)
+            .withOnAccountHeaderListener((view, profile1, current) -> {
+                if (profile1 instanceof IDrawerItem) {
+                    if (profile1.getIdentifier() == ITEM_MANAGE_ACCOUNT) {
+                        CustomTabActivityHelper.openCustomTab(MainActivity.this,
+                            customTabsIntent, userAccountUri, new WebViewFallback());
+                    }
+                }
+
+                //false if you have not consumed the event and it should close the drawer
+                return false;
+            })
+            .withSavedInstance(savedInstanceState)
+            .build();
 
         // Add Manage Account profile if the user is connected
         SharedPreferences preferences = getSharedPreferences("login", 0);
@@ -284,7 +244,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
 
         if (isUserConnected) {
             userAccountUri = Uri.parse(getString(R.string.website) + "cgi/user.pl?type=edit&userid=" + userLogin + "&user_id=" + userLogin +
-                    "&user_session=" + userSession);
+                "&user_session=" + userSession);
             customTabActivityHelper.mayLaunchUrl(userAccountUri, null, null);
 
             headerResult.addProfiles(getProfileSettingDrawerItem());
@@ -292,182 +252,185 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         primaryDrawerItem = createOfflineEditDrawerItem();
         //Create the drawer
         result = new DrawerBuilder()
-                .withActivity(this)
-                .withToolbar(toolbar)
-                .withHasStableIds(true)
-                .withAccountHeader(headerResult) //set the AccountHeader we created earlier for the header
-                .withOnDrawerListener(new Drawer.OnDrawerListener() {
-                    @Override
-                    public void onDrawerOpened(View drawerView) {
-                        Utils.hideKeyboard(MainActivity.this);
-                    }
+            .withActivity(this)
+            .withToolbar(toolbar)
+            .withHasStableIds(true)
+            .withAccountHeader(headerResult) //set the AccountHeader we created earlier for the header
+            .withOnDrawerListener(new Drawer.OnDrawerListener() {
+                @Override
+                public void onDrawerOpened(View drawerView) {
+                    Utils.hideKeyboard(MainActivity.this);
+                }
 
-                    @Override
-                    public void onDrawerClosed(View drawerView) {
-                    }
+                @Override
+                public void onDrawerClosed(View drawerView) {
+                }
 
-                    @Override
+                @Override
 
-                    public void onDrawerSlide(View drawerView, float slideOffset) {
-                        Utils.hideKeyboard(MainActivity.this);
-                    }
-                })
-                .addDrawerItems(
-                        new PrimaryDrawerItem().withName(R.string.home_drawer).withIcon(GoogleMaterial.Icon.gmd_home).withIdentifier(ITEM_HOME),
-                        new SectionDrawerItem().withName(R.string.search_drawer),
-                        new PrimaryDrawerItem().withName(R.string.search_by_barcode_drawer).withIcon(GoogleMaterial.Icon.gmd_dialpad).withIdentifier(ITEM_SEARCH_BY_CODE),
-                        new PrimaryDrawerItem().withName(R.string.search_by_category).withIcon(GoogleMaterial.Icon.gmd_filter_list).withIdentifier(ITEM_CATEGORIES).withSelectable(false),
-                        new PrimaryDrawerItem().withName(R.string.additives).withIcon(getResources().getDrawable(R.drawable.additives)).withIdentifier(ITEM_ADDITIVES).withSelectable(false),
-                        new PrimaryDrawerItem().withName(R.string.scan_search).withIcon(R.drawable.barcode_grey_24dp).withIdentifier(ITEM_SCAN).withSelectable(false),
-                        new PrimaryDrawerItem().withName(R.string.compare_products).withIcon(GoogleMaterial.Icon.gmd_swap_horiz).withIdentifier(ITEM_COMPARE).withSelectable(false),
-                        new PrimaryDrawerItem().withName(R.string.advanced_search_title).withIcon(GoogleMaterial.Icon.gmd_insert_chart).withIdentifier(ITEM_ADVANCED_SEARCH).withSelectable(false),
-                        new PrimaryDrawerItem().withName(R.string.scan_history_drawer).withIcon(GoogleMaterial.Icon.gmd_history).withIdentifier(ITEM_HISTORY).withSelectable(false),
-                        new SectionDrawerItem().withName(R.string.user_drawer).withIdentifier(USER_ID),
-                        new PrimaryDrawerItem().withName(getString(R.string.action_contributes)).withIcon(GoogleMaterial.Icon.gmd_rate_review).withIdentifier(ITEM_MY_CONTRIBUTIONS).withSelectable(false),
-                        new PrimaryDrawerItem().withName(R.string.your_lists).withIcon(GoogleMaterial.Icon.gmd_list).withIdentifier(ITEM_YOUR_LISTS).withSelectable(false),
-                        new PrimaryDrawerItem().withName(R.string.products_to_be_completed).withIcon(GoogleMaterial.Icon.gmd_edit).withIdentifier(ITEM_INCOMPLETE_PRODUCTS).withSelectable(false),
-                        new PrimaryDrawerItem().withName(R.string.alert_drawer).withIcon(GoogleMaterial.Icon.gmd_warning).withIdentifier(ITEM_ALERT),
-                        new PrimaryDrawerItem().withName(R.string.action_preferences).withIcon(GoogleMaterial.Icon.gmd_settings).withIdentifier(ITEM_PREFERENCES),
-                        new DividerDrawerItem(),
-                        primaryDrawerItem,
-                        new DividerDrawerItem(),
-                        new PrimaryDrawerItem().withName(R.string.action_discover).withIcon(GoogleMaterial.Icon.gmd_info).withIdentifier(ITEM_ABOUT).withSelectable(false),
-                        new PrimaryDrawerItem().withName(R.string.contribute).withIcon(R.drawable.ic_group_grey_24dp).withIdentifier(ITEM_CONTRIBUTE).withSelectable(false),
-                        new PrimaryDrawerItem().withName(R.string.open_beauty_drawer).withIcon(GoogleMaterial.Icon.gmd_shop).withIdentifier(ITEM_OBF).withSelectable(false)
-                )
-                .withOnDrawerItemClickListener((view, position, drawerItem) -> {
+                public void onDrawerSlide(View drawerView, float slideOffset) {
+                    Utils.hideKeyboard(MainActivity.this);
+                }
+            })
+            .addDrawerItems(
+                new PrimaryDrawerItem().withName(R.string.home_drawer).withIcon(GoogleMaterial.Icon.gmd_home).withIdentifier(ITEM_HOME),
+                new SectionDrawerItem().withName(R.string.search_drawer),
+                new PrimaryDrawerItem().withName(R.string.search_by_barcode_drawer).withIcon(GoogleMaterial.Icon.gmd_dialpad).withIdentifier(ITEM_SEARCH_BY_CODE),
+                new PrimaryDrawerItem().withName(R.string.search_by_category).withIcon(GoogleMaterial.Icon.gmd_filter_list).withIdentifier(ITEM_CATEGORIES).withSelectable(false),
+                new PrimaryDrawerItem().withName(R.string.additives).withIcon(getResources().getDrawable(R.drawable.additives)).withIdentifier(ITEM_ADDITIVES)
+                    .withSelectable(false),
+                new PrimaryDrawerItem().withName(R.string.scan_search).withIcon(R.drawable.barcode_grey_24dp).withIdentifier(ITEM_SCAN).withSelectable(false),
+                new PrimaryDrawerItem().withName(R.string.compare_products).withIcon(GoogleMaterial.Icon.gmd_swap_horiz).withIdentifier(ITEM_COMPARE).withSelectable(false),
+                new PrimaryDrawerItem().withName(R.string.advanced_search_title).withIcon(GoogleMaterial.Icon.gmd_insert_chart).withIdentifier(ITEM_ADVANCED_SEARCH)
+                    .withSelectable(false),
+                new PrimaryDrawerItem().withName(R.string.scan_history_drawer).withIcon(GoogleMaterial.Icon.gmd_history).withIdentifier(ITEM_HISTORY).withSelectable(false),
+                new SectionDrawerItem().withName(R.string.user_drawer).withIdentifier(USER_ID),
+                new PrimaryDrawerItem().withName(getString(R.string.action_contributes)).withIcon(GoogleMaterial.Icon.gmd_rate_review).withIdentifier(ITEM_MY_CONTRIBUTIONS)
+                    .withSelectable(false),
+                new PrimaryDrawerItem().withName(R.string.your_lists).withIcon(GoogleMaterial.Icon.gmd_list).withIdentifier(ITEM_YOUR_LISTS).withSelectable(false),
+                new PrimaryDrawerItem().withName(R.string.products_to_be_completed).withIcon(GoogleMaterial.Icon.gmd_edit).withIdentifier(ITEM_INCOMPLETE_PRODUCTS)
+                    .withSelectable(false),
+                new PrimaryDrawerItem().withName(R.string.alert_drawer).withIcon(GoogleMaterial.Icon.gmd_warning).withIdentifier(ITEM_ALERT),
+                new PrimaryDrawerItem().withName(R.string.action_preferences).withIcon(GoogleMaterial.Icon.gmd_settings).withIdentifier(ITEM_PREFERENCES),
+                new DividerDrawerItem(),
+                primaryDrawerItem,
+                new DividerDrawerItem(),
+                new PrimaryDrawerItem().withName(R.string.action_discover).withIcon(GoogleMaterial.Icon.gmd_info).withIdentifier(ITEM_ABOUT).withSelectable(false),
+                new PrimaryDrawerItem().withName(R.string.contribute).withIcon(R.drawable.ic_group_grey_24dp).withIdentifier(ITEM_CONTRIBUTE).withSelectable(false),
+                new PrimaryDrawerItem().withName(R.string.open_beauty_drawer).withIcon(GoogleMaterial.Icon.gmd_shop).withIdentifier(ITEM_OBF).withSelectable(false)
+            )
+            .withOnDrawerItemClickListener((view, position, drawerItem) -> {
 
-                    if (drawerItem == null) {
-                        return false;
-                    }
-
-                    Fragment fragment = null;
-                    switch ((int) drawerItem.getIdentifier()) {
-                        case ITEM_HOME:
-                            fragment = new HomeFragment();
-                            break;
-                        case ITEM_SEARCH_BY_CODE:
-                            fragment = new FindProductFragment();
-                            break;
-                        case ITEM_CATEGORIES:
-                            startActivity(CategoryActivity.getIntent(this));
-                            break;
-
-                        case ITEM_ADDITIVES:
-                            startActivity(new Intent(this, AdditivesExplorer.class));
-                            break;
-                        case ITEM_SCAN:
-                            scan();
-                            break;
-                        case ITEM_COMPARE:
-                            startActivity(new Intent(MainActivity.this, ProductComparisonActivity.class));
-                            break;
-                        case ITEM_HISTORY:
-                            startActivity(new Intent(MainActivity.this, HistoryScanActivity.class));
-                            break;
-                        case ITEM_LOGIN:
-                            startActivityForResult(new Intent(MainActivity.this, LoginActivity
-                                    .class), LOGIN_REQUEST);
-                            break;
-                        case ITEM_ALERT:
-                            fragment = new AllergensAlertFragment();
-                            break;
-                        case ITEM_PREFERENCES:
-                            fragment = new PreferencesFragment();
-                            break;
-                        case ITEM_OFFLINE:
-                            fragment = new OfflineEditFragment();
-                            break;
-                        case ITEM_ABOUT:
-                            CustomTabActivityHelper.openCustomTab(MainActivity.this,
-                                    customTabsIntent, discoverUri, new WebViewFallback());
-                            break;
-                        case ITEM_CONTRIBUTE:
-                            CustomTabActivityHelper.openCustomTab(MainActivity.this,
-                                    customTabsIntent, contributeUri, new WebViewFallback());
-                            break;
-
-                        case ITEM_INCOMPLETE_PRODUCTS:
-
-                            /**
-                             * Search and display the products to be completed by moving to ProductBrowsingListActivity
-                             */
-                            ProductBrowsingListActivity.startActivity(this, "", SearchType.INCOMPLETE_PRODUCT);
-                            break;
-
-                        case ITEM_OBF:
-                            boolean otherOFAppInstalled = Utils.isApplicationInstalled
-                                    (MainActivity.this, BuildConfig.OFOTHERLINKAPP);
-                            if (otherOFAppInstalled) {
-                                Intent LaunchIntent = getPackageManager()
-                                        .getLaunchIntentForPackage(BuildConfig.OFOTHERLINKAPP);
-                                if (LaunchIntent != null) {
-                                    startActivity(LaunchIntent);
-                                } else {
-                                    Toast.makeText(this, R.string.app_disabled_text, Toast.LENGTH_SHORT).show();
-                                    Intent intent = new Intent();
-                                    intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-                                    Uri uri = Uri.fromParts("package", BuildConfig.OFOTHERLINKAPP, null);
-                                    intent.setData(uri);
-                                    startActivity(intent);
-                                }
-                            } else {
-                                try {
-                                    startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse
-                                            ("market://details?id=" + BuildConfig.OFOTHERLINKAPP)));
-                                } catch (ActivityNotFoundException anfe) {
-                                    startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=" +
-                                            BuildConfig.OFOTHERLINKAPP)));
-
-                                }
-                            }
-                            break;
-
-                        case ITEM_ADVANCED_SEARCH:
-                            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
-                            CustomTabsIntent customTabsIntent = builder.build();
-                            CustomTabActivityHelper.openCustomTab(this, customTabsIntent, Uri.parse(getString(R.string.advanced_search_url)), new
-                                    WebViewFallback());
-                            break;
-
-                        case ITEM_MY_CONTRIBUTIONS:
-                            myContributions();
-                            break;
-
-                        case ITEM_YOUR_LISTS:
-                            startActivity(ProductListsActivity.getIntent(this));
-                            break;
-
-                         case ITEM_LOGOUT:
-                             new MaterialDialog.Builder(MainActivity.this)
-                                     .title(R.string.confirm_logout)
-                                     .content(R.string.logout_dialog_content)
-                                     .positiveText(R.string.txtOk)
-                                     .negativeText(R.string.dialog_cancel)
-                                     .onPositive((dialog, which) -> logout())
-                                     .onNegative((dialog, which) -> Toast.makeText(getApplicationContext(), "Cancelled",
-                                             Toast.LENGTH_SHORT).show()).show();
-                             break;
-                        default:
-                            // nothing to do
-                            break;
-                    }
-
-                    if (fragment != null) {
-                        getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container, fragment).addToBackStack(null).commit();
-                    }
-
+                if (drawerItem == null) {
                     return false;
-                })
-                .withSavedInstance(savedInstanceState)
-                .withShowDrawerOnFirstLaunch(false)
-                .build();
+                }
+
+                Fragment fragment = null;
+                switch ((int) drawerItem.getIdentifier()) {
+                    case ITEM_HOME:
+                        fragment = new HomeFragment();
+                        break;
+                    case ITEM_SEARCH_BY_CODE:
+                        fragment = new FindProductFragment();
+                        break;
+                    case ITEM_CATEGORIES:
+                        startActivity(CategoryActivity.getIntent(this));
+                        break;
+
+                    case ITEM_ADDITIVES:
+                        startActivity(new Intent(this, AdditivesExplorer.class));
+                        break;
+                    case ITEM_SCAN:
+                        scan();
+                        break;
+                    case ITEM_COMPARE:
+                        startActivity(new Intent(MainActivity.this, ProductComparisonActivity.class));
+                        break;
+                    case ITEM_HISTORY:
+                        startActivity(new Intent(MainActivity.this, HistoryScanActivity.class));
+                        break;
+                    case ITEM_LOGIN:
+                        startActivityForResult(new Intent(MainActivity.this, LoginActivity
+                            .class), LOGIN_REQUEST);
+                        break;
+                    case ITEM_ALERT:
+                        fragment = new AllergensAlertFragment();
+                        break;
+                    case ITEM_PREFERENCES:
+                        fragment = new PreferencesFragment();
+                        break;
+                    case ITEM_OFFLINE:
+                        fragment = new OfflineEditFragment();
+                        break;
+                    case ITEM_ABOUT:
+                        CustomTabActivityHelper.openCustomTab(MainActivity.this,
+                            customTabsIntent, discoverUri, new WebViewFallback());
+                        break;
+                    case ITEM_CONTRIBUTE:
+                        CustomTabActivityHelper.openCustomTab(MainActivity.this,
+                            customTabsIntent, contributeUri, new WebViewFallback());
+                        break;
+
+                    case ITEM_INCOMPLETE_PRODUCTS:
+
+                        /**
+                         * Search and display the products to be completed by moving to ProductBrowsingListActivity
+                         */
+                        ProductBrowsingListActivity.startActivity(this, "", SearchType.INCOMPLETE_PRODUCT);
+                        break;
+
+                    case ITEM_OBF:
+                        boolean otherOFAppInstalled = Utils.isApplicationInstalled
+                            (MainActivity.this, BuildConfig.OFOTHERLINKAPP);
+                        if (otherOFAppInstalled) {
+                            Intent LaunchIntent = getPackageManager()
+                                .getLaunchIntentForPackage(BuildConfig.OFOTHERLINKAPP);
+                            if (LaunchIntent != null) {
+                                startActivity(LaunchIntent);
+                            } else {
+                                Toast.makeText(this, R.string.app_disabled_text, Toast.LENGTH_SHORT).show();
+                                Intent intent = new Intent();
+                                intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+                                Uri uri = Uri.fromParts("package", BuildConfig.OFOTHERLINKAPP, null);
+                                intent.setData(uri);
+                                startActivity(intent);
+                            }
+                        } else {
+                            try {
+                                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse
+                                    ("market://details?id=" + BuildConfig.OFOTHERLINKAPP)));
+                            } catch (ActivityNotFoundException anfe) {
+                                startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=" +
+                                    BuildConfig.OFOTHERLINKAPP)));
+                            }
+                        }
+                        break;
+
+                    case ITEM_ADVANCED_SEARCH:
+                        CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+                        CustomTabsIntent customTabsIntent = builder.build();
+                        CustomTabActivityHelper.openCustomTab(this, customTabsIntent, Uri.parse(getString(R.string.advanced_search_url)), new
+                            WebViewFallback());
+                        break;
+
+                    case ITEM_MY_CONTRIBUTIONS:
+                        myContributions();
+                        break;
+
+                    case ITEM_YOUR_LISTS:
+                        startActivity(ProductListsActivity.getIntent(this));
+                        break;
+
+                    case ITEM_LOGOUT:
+                        new MaterialDialog.Builder(MainActivity.this)
+                            .title(R.string.confirm_logout)
+                            .content(R.string.logout_dialog_content)
+                            .positiveText(R.string.txtOk)
+                            .negativeText(R.string.dialog_cancel)
+                            .onPositive((dialog, which) -> logout())
+                            .onNegative((dialog, which) -> Toast.makeText(getApplicationContext(), "Cancelled",
+                                Toast.LENGTH_SHORT).show()).show();
+                        break;
+                    default:
+                        // nothing to do
+                        break;
+                }
+
+                if (fragment != null) {
+                    getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container, fragment).addToBackStack(null).commit();
+                }
+
+                return false;
+            })
+            .withSavedInstance(savedInstanceState)
+            .withShowDrawerOnFirstLaunch(false)
+            .build();
 
         result.getActionBarDrawerToggle().setDrawerIndicatorEnabled(true);
 
         // Add Drawer items for the connected user
         result.addItemsAtPosition(result.getPosition(ITEM_MY_CONTRIBUTIONS), isConnected ?
-                getLogoutDrawerItem() : getLoginDrawerItem());
+            getLogoutDrawerItem() : getLoginDrawerItem());
 
         if (BuildConfig.FLAVOR.equals("obf")) {
             result.removeItem(ITEM_ALERT);
@@ -493,14 +456,13 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
             result.removeItem(ITEM_SCAN);
         }
 
-
         //if you have many different types of DrawerItems you can magically pre-cache those items
         // to get a better scroll performance
         //make sure to init the cache after the DrawerBuilder was created as this will first
         // clear the cache to make sure no old elements are in
         //RecyclerViewCacheUtil.getInstance().withCacheSize(2).init(result);
         new RecyclerViewCacheUtil<IDrawerItem>().withCacheSize(2).apply(result.getRecyclerView(),
-                result.getDrawerItems());
+            result.getDrawerItems());
 
         //only set the active selection or active profile if we do not recreate the activity
         if (savedInstanceState == null) {
@@ -512,7 +474,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         }
 
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getBaseContext
-                ());
+            ());
         if (settings.getBoolean("startScan", false)) {
             Intent cameraIntent = new Intent(MainActivity.this, ContinuousScanActivity.class);
             cameraIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
@@ -556,20 +518,19 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
 
     private void scan() {
         if (ContextCompat.checkSelfPermission(MainActivity.this, Manifest.permission.CAMERA) !=
-                PackageManager.PERMISSION_GRANTED) {
+            PackageManager.PERMISSION_GRANTED) {
             if (ActivityCompat.shouldShowRequestPermissionRationale(MainActivity.this, Manifest
-                    .permission.CAMERA)) {
+                .permission.CAMERA)) {
                 new MaterialDialog.Builder(MainActivity.this)
-                        .title(R.string.action_about)
-                        .content(R.string.permission_camera)
-                        .neutralText(R.string.txtOk)
-                        .show().setOnDismissListener(dialogInterface -> ActivityCompat.requestPermissions(MainActivity.this,
-                        new String[]{Manifest.permission.CAMERA},
-                        Utils.MY_PERMISSIONS_REQUEST_CAMERA));
-
+                    .title(R.string.action_about)
+                    .content(R.string.permission_camera)
+                    .neutralText(R.string.txtOk)
+                    .show().setOnDismissListener(dialogInterface -> ActivityCompat.requestPermissions(MainActivity.this,
+                    new String[]{Manifest.permission.CAMERA},
+                    Utils.MY_PERMISSIONS_REQUEST_CAMERA));
             } else {
                 ActivityCompat.requestPermissions(MainActivity.this, new String[]{Manifest
-                        .permission.CAMERA}, Utils.MY_PERMISSIONS_REQUEST_CAMERA);
+                    .permission.CAMERA}, Utils.MY_PERMISSIONS_REQUEST_CAMERA);
             }
         } else {
             Intent intent = new Intent(MainActivity.this, ContinuousScanActivity.class);
@@ -585,18 +546,16 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         if (isNotEmpty(userLogin1)) {
 
             ProductBrowsingListActivity.startActivity(this, userLogin1, SearchType.CONTRIBUTOR);
-
-
         } else {
             new MaterialDialog.Builder(MainActivity.this)
-                    .title(R.string.contribute)
-                    .content(R.string.contribution_without_account)
-                    .positiveText(R.string.create_account_button)
-                    .neutralText(R.string.login_button)
-                    .onPositive((dialog, which) -> CustomTabActivityHelper.openCustomTab(MainActivity.this, customTabsIntent, Uri.parse(getString(R
-                            .string.website) + "cgi/user.pl"), new WebViewFallback()))
-                    .onNeutral((dialog, which) -> startActivityForResult(new Intent(MainActivity.this, LoginActivity.class), LOGIN_REQUEST))
-                    .show();
+                .title(R.string.contribute)
+                .content(R.string.contribution_without_account)
+                .positiveText(R.string.create_account_button)
+                .neutralText(R.string.login_button)
+                .onPositive((dialog, which) -> CustomTabActivityHelper.openCustomTab(MainActivity.this, customTabsIntent, Uri.parse(getString(R
+                    .string.website) + "cgi/user.pl"), new WebViewFallback()))
+                .onNeutral((dialog, which) -> startActivityForResult(new Intent(MainActivity.this, LoginActivity.class), LOGIN_REQUEST))
+                .show();
         }
     }
 
@@ -605,13 +564,13 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         String userLogin = preferences.getString("user", null);
         String userSession = preferences.getString("user_session", null);
         userAccountUri = Uri.parse(getString(R.string.website) + "cgi/user.pl?type=edit&userid=" + userLogin + "&user_id=" + userLogin +
-                "&user_session=" + userSession);
+            "&user_session=" + userSession);
         customTabActivityHelper.mayLaunchUrl(userAccountUri, null, null);
         return new ProfileSettingDrawerItem()
-                .withName(getString(R.string.action_manage_account))
-                .withIcon(GoogleMaterial.Icon.gmd_settings)
-                .withIdentifier(ITEM_MANAGE_ACCOUNT)
-                .withSelectable(false);
+            .withName(getString(R.string.action_manage_account))
+            .withIcon(GoogleMaterial.Icon.gmd_settings)
+            .withIdentifier(ITEM_MANAGE_ACCOUNT)
+            .withSelectable(false);
     }
 
     /**
@@ -692,22 +651,18 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
             public boolean onMenuItemActionCollapse(MenuItem menuItem) {
                 FragmentManager fragmentManager = getSupportFragmentManager();
                 Fragment currentFragment = fragmentManager.findFragmentById(R.id
-                        .fragment_container);
-
+                    .fragment_container);
 
                 return true;
             }
         });
 
-
         if (getIntent().getBooleanExtra("product_search", false)) {
             searchMenuItem.expandActionView();
         }
 
-
         return true;
     }
-
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String permissions[],
@@ -716,7 +671,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         switch (requestCode) {
             case Utils.MY_PERMISSIONS_REQUEST_CAMERA: {
                 if (grantResults.length > 0 && grantResults[0] == PackageManager
-                        .PERMISSION_GRANTED) {
+                    .PERMISSION_GRANTED) {
                     Intent intent = new Intent(MainActivity.this, ContinuousScanActivity.class);
                     intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                     startActivity(intent);
@@ -727,31 +682,31 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
     }
 
     private IDrawerItem<PrimaryDrawerItem, com.mikepenz.materialdrawer.model
-            .AbstractBadgeableDrawerItem.ViewHolder> getLogoutDrawerItem() {
+        .AbstractBadgeableDrawerItem.ViewHolder> getLogoutDrawerItem() {
         return new PrimaryDrawerItem()
-                .withName(getString(R.string.logout_drawer))
-                .withIcon(GoogleMaterial.Icon.gmd_settings_power)
-                .withIdentifier(ITEM_LOGOUT)
-                .withSelectable(false);
+            .withName(getString(R.string.logout_drawer))
+            .withIcon(GoogleMaterial.Icon.gmd_settings_power)
+            .withIdentifier(ITEM_LOGOUT)
+            .withSelectable(false);
     }
 
     private IDrawerItem<PrimaryDrawerItem, com.mikepenz.materialdrawer.model
-            .AbstractBadgeableDrawerItem.ViewHolder> getLoginDrawerItem() {
+        .AbstractBadgeableDrawerItem.ViewHolder> getLoginDrawerItem() {
         return new PrimaryDrawerItem()
-                .withName(R.string.sign_in_drawer)
-                .withIcon(GoogleMaterial.Icon.gmd_account_circle)
-                .withIdentifier(ITEM_LOGIN)
-                .withSelectable(false);
+            .withName(R.string.sign_in_drawer)
+            .withIcon(GoogleMaterial.Icon.gmd_account_circle)
+            .withIdentifier(ITEM_LOGIN)
+            .withSelectable(false);
     }
 
     private IProfile<ProfileDrawerItem> getUserProfile() {
         String userLogin = getSharedPreferences("login", 0)
-                .getString("user", getResources().getString(R.string.txt_anonymous));
+            .getString("user", getResources().getString(R.string.txt_anonymous));
 
         return new ProfileDrawerItem()
-                .withName(userLogin)
-                .withIcon(R.drawable.img_home)
-                .withIdentifier(ITEM_USER);
+            .withName(userLogin)
+            .withIcon(R.drawable.img_home)
+            .withIdentifier(ITEM_USER);
     }
 
     @Override
@@ -768,7 +723,6 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
     protected void onStart() {
         super.onStart();
         customTabActivityHelper.bindCustomTabsService(this);
-
     }
 
     @Override
@@ -781,9 +735,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
     protected void onDestroy() {
         customTabActivityHelper.setConnectionCallback(null);
         super.onDestroy();
-
     }
-
 
     @Override
     protected void onNewIntent(Intent intent) {
@@ -797,7 +749,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
             String query = intent.getStringExtra(SearchManager.QUERY);
             //Saves the most recent queries and adds it to the list of suggestions
             SearchRecentSuggestions suggestions = new SearchRecentSuggestions(this,
-                    SearchSuggestionProvider.AUTHORITY, SearchSuggestionProvider.MODE);
+                SearchSuggestionProvider.AUTHORITY, SearchSuggestionProvider.MODE);
             suggestions.saveRecentQuery(query, null);
             ProductBrowsingListActivity.startActivity(this, query, SearchType.SEARCH);
             if (searchMenuItem != null) {
@@ -822,6 +774,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         changeFragment(fragment, getResources().getString(R.string.search_by_barcode_drawer), ITEM_SEARCH_BY_CODE);
     }
 
+
     /**
      * This moves the main activity to the preferences fragment.
      */
@@ -839,8 +792,8 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
     private PrimaryDrawerItem createOfflineEditDrawerItem() {
         if (numberOFSavedProducts > 0) {
             return new PrimaryDrawerItem().withName(R.string.offline_edit_drawer).withIcon(GoogleMaterial.Icon.gmd_local_airport).withIdentifier(10)
-                    .withBadge(String.valueOf(numberOFSavedProducts)).withBadgeStyle(new BadgeStyle().withTextColor(Color.WHITE).withColorRes(R
-                            .color.md_red_700));
+                .withBadge(String.valueOf(numberOFSavedProducts)).withBadgeStyle(new BadgeStyle().withTextColor(Color.WHITE).withColorRes(R
+                    .color.md_red_700));
         } else {
             return new PrimaryDrawerItem().withName(R.string.offline_edit_drawer).withIcon(GoogleMaterial.Icon.gmd_local_airport).withIdentifier(ITEM_OFFLINE);
         }
@@ -854,13 +807,13 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
     public void updateBadgeOfflineEditDrawerITem(int size) {
         positionOfOfflineBadeItem = result.getPosition(primaryDrawerItem);
         if (size > 0) {
-            primaryDrawerItem = new PrimaryDrawerItem().withName(R.string.offline_edit_drawer).withIcon(GoogleMaterial.Icon.gmd_local_airport).withIdentifier(ITEM_OFFLINE).withBadge(String.valueOf(size)).withBadgeStyle(new BadgeStyle().withTextColor(Color.WHITE).withColorRes(R.color.md_red_700));
+            primaryDrawerItem = new PrimaryDrawerItem().withName(R.string.offline_edit_drawer).withIcon(GoogleMaterial.Icon.gmd_local_airport).withIdentifier(ITEM_OFFLINE)
+                .withBadge(String.valueOf(size)).withBadgeStyle(new BadgeStyle().withTextColor(Color.WHITE).withColorRes(R.color.md_red_700));
         } else {
             primaryDrawerItem = new PrimaryDrawerItem().withName(R.string.offline_edit_drawer).withIcon(GoogleMaterial.Icon.gmd_local_airport).withIdentifier(ITEM_OFFLINE);
         }
         result.updateItemAtPosition(primaryDrawerItem, positionOfOfflineBadeItem);
     }
-
 
     @Override
     public void setItemSelected(@NavigationDrawerType Integer type) {
@@ -877,7 +830,6 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
 
             // unregister the listener
             mSensorManager.unregisterListener(mShakeDetector, mAccelerometer);
-
         }
     }
 
@@ -890,12 +842,8 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
 
             //register the listener
             mSensorManager.registerListener(mShakeDetector, mAccelerometer, SensorManager.SENSOR_DELAY_UI);
-
-
         }
-
     }
-
 
     private void handleSendImage(Intent intent) {
         Uri selectedImage = null;
@@ -968,7 +916,6 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
     private void createAlertDialog(boolean hasEditText, String barcode, ArrayList<Uri> uri) {
         AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
 
-
         LayoutInflater inflater = this.getLayoutInflater();
         View dialogView = inflater.inflate(R.layout.alert_barcode, null);
         alertDialogBuilder.setView(dialogView);
@@ -976,9 +923,9 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         final EditText barcode_edittext = dialogView.findViewById(R.id.barcode);
         final RecyclerView product_images = dialogView.findViewById(R.id.product_image);
         LinearLayoutManager layoutManager
-                = new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false);
+            = new LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false);
         product_images.setLayoutManager(layoutManager);
-        product_images.setAdapter(new PhotosAdapter( uri));
+        product_images.setAdapter(new PhotosAdapter(uri));
 
         if (hasEditText) {
             barcode_edittext.setVisibility(View.VISIBLE);
@@ -991,58 +938,55 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
 
         // set dialog message
         alertDialogBuilder
-                .setCancelable(false)
-                .setPositiveButton(R.string.txtYes, new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int id) {
-                        String temp_barcode = "";
-                        for (Uri selected : uri) {
-                            OpenFoodAPIClient api = new OpenFoodAPIClient(MainActivity.this);
-                            ProductImage image = null;
-                            ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-                            NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+            .setCancelable(false)
+            .setPositiveButton(R.string.txtYes, new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int id) {
+                    String temp_barcode = "";
+                    for (Uri selected : uri) {
+                        OpenFoodAPIClient api = new OpenFoodAPIClient(MainActivity.this);
+                        ProductImage image = null;
+                        ConnectivityManager cm = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
+                        NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
 
-                            if (hasEditText) {
+                        if (hasEditText) {
 
-                                temp_barcode = barcode_edittext.getText().toString();
-                            } else {
-                                temp_barcode = barcode;
-                            }
-
-                            if (temp_barcode.length() > 0) {
-                                dialog.cancel();
-                                if (activeNetwork != null && activeNetwork.isConnectedOrConnecting()) {
-                                    File imageFile = new File(RealPathUtil.getRealPath(MainActivity.this, selected));
-                                    image = new ProductImage(temp_barcode, OTHER, imageFile);
-                                    api.postImg(MainActivity.this, image, null);
-                                } else {
-                                    Intent intent = new Intent(MainActivity.this, AddProductActivity.class);
-                                    State st = new State();
-                                    Product pd = new Product();
-                                    pd.setCode(temp_barcode);
-                                    st.setProduct(pd);
-                                    intent.putExtra("state", st);
-                                    startActivity(intent);
-                                }
-                            } else {
-                                Toast.makeText(MainActivity.this, getString(R.string.sorry_msg), Toast.LENGTH_LONG).show();
-                            }
+                            temp_barcode = barcode_edittext.getText().toString();
+                        } else {
+                            temp_barcode = barcode;
                         }
 
-                    }
-                })
-
-                .setNegativeButton(R.string.txtNo,
-                        new DialogInterface.OnClickListener() {
-                            public void onClick(DialogInterface dialog, int id) {
-                                dialog.cancel();
+                        if (temp_barcode.length() > 0) {
+                            dialog.cancel();
+                            if (activeNetwork != null && activeNetwork.isConnectedOrConnecting()) {
+                                File imageFile = new File(RealPathUtil.getRealPath(MainActivity.this, selected));
+                                image = new ProductImage(temp_barcode, OTHER, imageFile);
+                                api.postImg(MainActivity.this, image, null);
+                            } else {
+                                Intent intent = new Intent(MainActivity.this, AddProductActivity.class);
+                                State st = new State();
+                                Product pd = new Product();
+                                pd.setCode(temp_barcode);
+                                st.setProduct(pd);
+                                intent.putExtra("state", st);
+                                startActivity(intent);
                             }
-                        });
+                        } else {
+                            Toast.makeText(MainActivity.this, getString(R.string.sorry_msg), Toast.LENGTH_LONG).show();
+                        }
+                    }
+                }
+            })
 
+            .setNegativeButton(R.string.txtNo,
+                new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int id) {
+                        dialog.cancel();
+                    }
+                });
 
         AlertDialog alertDialog = alertDialogBuilder.create();
 
         alertDialog.show();
-
     }
 
     @Override
@@ -1068,8 +1012,8 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
      * Used to navigate Fragments which are children of <code>MainActivity</code>.
      * Use this method when the <code>Fragment</code> APPEARS in the <code>Drawer</code>.
      *
-     * @param fragment   The fragment class to display.
-     * @param title      The title that should be displayed on the top toolbar.
+     * @param fragment The fragment class to display.
+     * @param title The title that should be displayed on the top toolbar.
      * @param drawerName The fragment as it appears in the drawer. See {@link NavigationDrawerListener} for the value.
      * @author ross-holloway94
      * @see <a href="https://stackoverflow.com/questions/45138446/calling-fragment-from-recyclerview-adapter">Related Stack Overflow article</a>
@@ -1085,7 +1029,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
      * Use this method when the <code>Fragment</code> DOES NOT APPEAR in the <code>Drawer</code>.
      *
      * @param fragment The fragment class to display.
-     * @param title    The title that should be displayed on the top toolbar.
+     * @param title The title that should be displayed on the top toolbar.
      * @author ross-holloway94
      * @see <a href="https://stackoverflow.com/questions/45138446/calling-fragment-from-recyclerview-adapter">Related Stack Overflow article</a>
      * @since 06/16/18
@@ -1103,11 +1047,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
             ft.commit();
         }
 
-
         Objects.requireNonNull(getSupportActionBar()).setTitle(title);
-
     }
-
-
 }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductBrowsingListActivity.java
@@ -53,7 +53,7 @@ import openfoodfacts.github.scrachx.openfood.views.listeners.RecyclerItemClickLi
 
 public class ProductBrowsingListActivity extends BaseActivity {
 
-    private static String SEARCH_INFO = "search_info";
+    public static String SEARCH_INFO = "search_info";
 
     @BindView(R.id.toolbar)
     Toolbar toolbar;

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ProductActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ProductActivity.java
@@ -311,7 +311,7 @@ public class ProductActivity extends BaseActivity implements OnRefreshListener {
     }
 
     @Override
-    protected void onNewIntent(Intent intent) {
+    public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         setIntent(intent);
         mState = (State) intent.getExtras().getSerializable("state");

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ProductActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ProductActivity.java
@@ -311,7 +311,7 @@ public class ProductActivity extends BaseActivity implements OnRefreshListener {
     }
 
     @Override
-    public void onNewIntent(Intent intent) {
+    protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         setIntent(intent);
         mState = (State) intent.getExtras().getSerializable("state");

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
@@ -54,7 +54,6 @@ import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabActivityH
 import openfoodfacts.github.scrachx.openfood.views.customtabs.CustomTabsHelper;
 import openfoodfacts.github.scrachx.openfood.views.customtabs.WebViewFallback;
 import openfoodfacts.github.scrachx.openfood.views.product.ProductActivity;
-import openfoodfacts.github.scrachx.openfood.views.product.ProductFragment;
 import pl.aprilapps.easyphotopicker.DefaultCallback;
 import pl.aprilapps.easyphotopicker.EasyImage;
 
@@ -166,7 +165,7 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         customTabActivityHelper.setConnectionCallback(this);
         customTabsIntent = CustomTabsHelper.getCustomTabsIntent(getContext(), customTabActivityHelper.getSession());
 
-        state=getStateFromActivityIntent();
+        state = getStateFromActivityIntent();
 
         presenter = new SummaryProductPresenter(product, this);
     }
@@ -258,7 +257,7 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
 
             String[] brands = product.getBrands().split(",");
             for (int i = 0; i < brands.length; i++) {
-                if(i>0){
+                if (i > 0) {
                     brandProduct.append(", ");
                 }
                 brandProduct.append(Utils.getClickableText(brands[i].trim(), "", SearchType.BRAND, getActivity(), customTabsIntent));
@@ -274,10 +273,10 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
 
             String[] embTags = product.getEmbTags().toString().replace("[", "").replace("]", "").split(", ");
             for (int i = 0; i < embTags.length; i++) {
-                if(i>0){
+                if (i > 0) {
                     embCode.append(", ");
                 }
-                String  embTag = embTags[i];
+                String embTag = embTags[i];
                 embCode.append(Utils.getClickableText(getEmbCode(embTag).trim(), getEmbUrl(embTag), SearchType.EMB, getActivity(), customTabsIntent));
             }
         } else {
@@ -370,6 +369,9 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         } else {
             scoresLayout.setVisibility(View.GONE);
         }
+        //to be sure that top of the product view is visible at start
+        nameProduct.requestFocus();
+        nameProduct.clearFocus();
     }
 
     private void refreshScoresLayout() {
@@ -384,8 +386,8 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
     }
 
     private void refreshNutriscore() {
-        int nutritionGradeResource =Utils.getImageGrade(product);
-        if (nutritionGradeResource!=Utils.NO_DRAWABLE_RESOURCE) {
+        int nutritionGradeResource = Utils.getImageGrade(product);
+        if (nutritionGradeResource != Utils.NO_DRAWABLE_RESOURCE) {
             nutriscoreImage.setVisibility(View.VISIBLE);
             nutriscoreImage.setImageResource(nutritionGradeResource);
             nutriscoreImage.setOnClickListener(view1 -> {
@@ -417,7 +419,7 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         if (environmentImpactResource != Utils.NO_DRAWABLE_RESOURCE) {
             co2Icon.setVisibility(View.VISIBLE);
             co2Icon.setImageResource(environmentImpactResource);
-        }else{
+        } else {
             co2Icon.setVisibility(View.GONE);
         }
     }
@@ -633,15 +635,15 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
 
     @Override
     public void showProductQuestion(Question question) {
-        if(Utils.isUserLoggedIn(getContext()) && question!=null && !question.isEmpty()){
+        if (Utils.isUserLoggedIn(getContext()) && question != null && !question.isEmpty()) {
             productQuestion = question;
             productQuestionText.setText(String.format("%s\n%s",
                 question.getQuestion(), question.getValue()));
             productQuestionLayout.setVisibility(View.VISIBLE);
             hasCategoryInsightQuestion = question.getInsightType().equals("category");
-        }else{
+        } else {
             productQuestionLayout.setVisibility(View.GONE);
-            productQuestion=null;
+            productQuestion = null;
         }
         refreshNutriscorePrompt();
         refreshScoresLayout();
@@ -649,7 +651,7 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
 
     @OnClick(R.id.product_question_layout)
     public void onProductQuestionClick() {
-        if(productQuestion==null && !Utils.isUserLoggedIn(getContext())){
+        if (productQuestion == null && !Utils.isUserLoggedIn(getContext())) {
             return;
         }
         new QuestionDialog(getActivity())
@@ -863,7 +865,6 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         startActivity(intent);
     }
 
-
     @OnClick(R.id.action_share_button)
     public void onShareProductButtonClick() {
         String shareUrl = " " + getString(R.string.website_product) + product.getCode();
@@ -916,7 +917,7 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
         addToListDialog.show();
         View addToListView = addToListDialog.getCustomView();
         if (addToListView != null) {
-            ProductListsDao productListsDao =ProductListsActivity.getProducListsDaoWithDefaultList(this.getContext());
+            ProductListsDao productListsDao = ProductListsActivity.getProducListsDaoWithDefaultList(this.getContext());
             List<ProductLists> productLists = productListsDao.loadAll();
 
             RecyclerView addToListRecyclerView =

--- a/app/src/screenshots/AndroidManifest.xml
+++ b/app/src/screenshots/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="openfoodfacts.github.scrachx.openfood"
+>
+    <!-- Allows changing locales for screenshots generation-->
+    <uses-permission android:name="android.permission.CHANGE_CONFIGURATION" />
+</manifest>


### PR DESCRIPTION
## Description

Configuration is set in openfoodfacts.github.scrachx.openfood.test.ScreenshotParametersProvider

To generate screenshots, possible to launch:
- TakeScreenshotIncompleteProductsTest
- TakeScreenshotMainActivityTest
- TakeScreenshotShowProductsTest

**Warn: see app\build.gradle to change the testBuildType: screenshot should selected (uncomment lines)**

![image](https://user-images.githubusercontent.com/47569605/56226155-fa192180-6072-11e9-8c46-9576caf3b196.png)


It's possible to generate all screenshot with:
`gradlew connectedOffScreenshotsAndroidTest --stacktrace --info -PtestBuildType=screenshots`

Screenshots are generated in the Phone "Pictures" folder:
![image](https://user-images.githubusercontent.com/47569605/56225967-9858b780-6072-11e9-86b1-2a5cc93eb31d.png)

Example for Brazil:
![image](https://user-images.githubusercontent.com/47569605/56225986-a0b0f280-6072-11e9-823c-d1c1700c1275.png)
