### PR TITLE
Don't set product URL edit field hint twice

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
@@ -241,8 +241,6 @@ public class AddProductOverviewFragment extends BaseFragment {
             Toast.makeText(activity, R.string.error_adding_product_details, Toast.LENGTH_SHORT).show();
             activity.finish();
         }
-        link.setHint(Html.fromHtml("<small><small>" +
-            getString(R.string.hint_product_URL) + "</small></small>"));
         initializeChips();
         loadAutoSuggestions();
         if (getActivity() instanceof AddProductActivity && ((AddProductActivity) getActivity()).getInitialValues() != null) {


### PR DESCRIPTION
## Description

During product edition, the hint of the product URL was present twice, which resulted in a text overlay (see screenshots).

 ## Screen-shots, if any
 
Before:
![Screenshot_20190423-132238_OpenFoodFacts](https://user-images.githubusercontent.com/9609923/56578266-84aad500-65cd-11e9-9b11-d07555fa9913.png)
After:
![Screenshot_1556019792](https://user-images.githubusercontent.com/9609923/56578553-34804280-65ce-11e9-8ffb-aedb6b56d37c.png)
![Screenshot_1556019813](https://user-images.githubusercontent.com/9609923/56578556-364a0600-65ce-11e9-96a2-6210c86dc75e.png)

 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [ ] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [ ] Code is well documented
 - [ ] Include unit tests for new functionality
 - [ ] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch
 - [ ] If you have multiple commits please combine them into one commit by squashing them.
 - [ ] Read and understood the contribution guidelines .
