### PR TITLE
Fix #2485: Show "Add more photos" in product addition simple mode

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
@@ -265,7 +265,6 @@ public class AddProductOverviewFragment extends BaseFragment {
         periodsAfterOpeningParent.setVisibility(visibility);
         changeVisibilityManufacturingSectionTo(visibility);
         changePurchasingSectionVisibilityTo(visibility);
-        otherImage.setVisibility(visibility);
         greyLine2.setVisibility(visibility);
         greyLine3.setVisibility(visibility);
         greyLine4.setVisibility(visibility);


### PR DESCRIPTION
Fix #2485: Show "Add more photos" in product addition simple mode

let the field "Take more photos" be always visible

![image](https://user-images.githubusercontent.com/47569605/56590487-7e295700-65e7-11e9-881c-62fc74917d4a.png)

