### PR TITLE
Fix #2574: Can't install both OpenFoodFacts and OpenBeautyFacts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,7 @@
             android:value="2.1" />
         
         <provider
-            android:authorities="openfoodfacts.github.scrachx.openfood.utils.SearchSuggestionProvider"
+            android:authorities="${applicationId}.utils.SearchSuggestionProvider"
             android:name=".utils.SearchSuggestionProvider" />
 
         <activity

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/SearchSuggestionProvider.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/SearchSuggestionProvider.java
@@ -1,9 +1,10 @@
 package openfoodfacts.github.scrachx.openfood.utils;
 
 import android.content.SearchRecentSuggestionsProvider;
+import openfoodfacts.github.scrachx.openfood.BuildConfig;
 
 public class SearchSuggestionProvider extends SearchRecentSuggestionsProvider {
-    public final static String AUTHORITY = "openfoodfacts.github.scrachx.openfood.utils.SearchSuggestionProvider";
+    public final static String AUTHORITY = BuildConfig.APPLICATION_ID+".utils.SearchSuggestionProvider";
     public final static int MODE = DATABASE_MODE_QUERIES;
 
     public SearchSuggestionProvider() {


### PR DESCRIPTION
Use variable ( in SearchSuggestionProvider.java file and AndroidManifest.xml ) to define search authority.

 ## Screen-shot
 
![image](https://user-images.githubusercontent.com/47569605/56882927-747b7580-6a65-11e9-8077-9b92a84950fa.png)

