### PR TITLE
Re-enabled additives detection for Open Beauty Facts

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -405,7 +405,6 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
 
         if (BuildConfig.FLAVOR.equals("obf")) {
             result.removeItem(ITEM_ALERT);
-            result.removeItem(ITEM_ADDITIVES);
             result.updateName(ITEM_OBF, new StringHolder(getString(R.string.open_food_drawer)));
         }
 


### PR DESCRIPTION
## Description
Enables "additives" for build variant obf

#fixes #1659
## Screen-shots
![Screenshot_20190517_132039](https://user-images.githubusercontent.com/34261945/57912386-c9ade880-78a7-11e9-8f47-906f9bb74691.png)

 