### PR TITLE
Fixes #2660: Fixed Keyboard inaccessible widget lint warnings

### DIFF
--- a/app/src/main/res/layout/fragment_contributors.xml
+++ b/app/src/main/res/layout/fragment_contributors.xml
@@ -43,7 +43,8 @@
                         android:clickable="true"
                         android:gravity="center"
                         android:padding="@dimen/spacing_small"
-                        android:textColorLink="@color/light_blue_A700" />
+                        android:textColorLink="@color/light_blue_A700"
+                        android:focusable="true" />
 
                     <TextView
                         android:id="@+id/last_editor"
@@ -57,7 +58,8 @@
                         android:clickable="true"
                         android:gravity="center"
                         android:padding="@dimen/spacing_small"
-                        android:textColorLink="@color/light_blue_A700" />
+                        android:textColorLink="@color/light_blue_A700"
+                        android:focusable="true" />
 
                     <TextView
                         android:id="@+id/other_editors"
@@ -71,7 +73,8 @@
                         android:clickable="true"
                         android:gravity="center"
                         android:padding="@dimen/spacing_small"
-                        android:textColorLink="@color/light_blue_A700" />
+                        android:textColorLink="@color/light_blue_A700"
+                        android:focusable="true" />
 
                 </LinearLayout>
 
@@ -97,7 +100,8 @@
                     android:clickable="true"
                     android:gravity="center"
                     android:padding="@dimen/spacing_small"
-                    android:textColorLink="@color/light_blue_A700" />
+                    android:textColorLink="@color/light_blue_A700"
+                    android:focusable="true" />
 
             </android.support.v7.widget.CardView>
         </LinearLayout>

--- a/app/src/main/res/layout/fragment_nutrition_product.xml
+++ b/app/src/main/res/layout/fragment_nutrition_product.xml
@@ -75,7 +75,8 @@
                     android:layout_marginRight="@dimen/spacing_normal"
                     android:layout_marginBottom="@dimen/spacing_tiny"
                     android:clickable="true"
-                    android:gravity="center" />
+                    android:gravity="center"
+                    android:focusable="true" />
 
                 <TextView
                     android:id="@+id/nutriscoreLink"


### PR DESCRIPTION
## Description

Fixed Keyboard inaccessible widget lint warnings by adding a focusable attribute. A widget that is declared to be clickable but not declared to be focusable is not accessible via the keyboard. 

## Related issues and discussion
Fixes #2660  