### PR TITLE
Fixes #2671: Updated compile and target SDK versions of the app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ def obtainTestBuildType() {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     buildToolsVersion '28.0.3'
 
 
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId "openfoodfacts.github.scrachx.openfood"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 316
         versionName "3.1.6"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Description

Updated compile and target SDK versions ( from 27 to 28 ) of the app in the build. gradle file to make use of the latest features.

## Related issues and discussion
Fixes #2671 
