### PR TITLE
Fixes #2687: Resolved inconvertible types between two objects while comparing

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductNutritionFactsFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductNutritionFactsFragment.java
@@ -828,7 +828,7 @@ public class AddProductNutritionFactsFragment extends BaseFragment implements Ph
     }
 
     private ValueState checkCarbohydrate(CustomValidatingEditTextView editText, float value) {
-        if (!carbohydrate.getEntryName().equals(editText)) {
+        if (!carbohydrate.getEntryName().equals(editText.toString())) {
             return ValueState.NOT_TESTED;
         }
         ValueState res = checkAsGram(editText, value);

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/ContributorsFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/ContributorsFragment.java
@@ -92,7 +92,7 @@ public class ContributorsFragment extends BaseFragment {
             otherEditorsText.setVisibility(View.INVISIBLE);
         }
 
-        if (!product.getStatesTags().equals("")) {
+        if (!product.getStatesTags().toString().equals("")) {
 
             statesText.setMovementMethod(LinkMovementMethod.getInstance());
             statesText.setText("");


### PR DESCRIPTION
## Description

Resolved inconvertible types between two objects while comparing with `.equals()`.
## Related issues and discussion
Fixes #2687  