### PR TITLE
Revert "Fixes #2671: Updated compile and target SDK versions of the app"

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,7 +14,7 @@ def obtainTestBuildType() {
 }
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 27
     buildToolsVersion '28.0.3'
 
 
@@ -24,7 +24,7 @@ android {
     defaultConfig {
         applicationId "openfoodfacts.github.scrachx.openfood"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 27
         versionCode 316
         versionName "3.1.6"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Reverts openfoodfacts/openfoodfacts-androidapp#2672
some used libraries like materialdrawer are not compatible with this new version