### PR TITLE
Fix #2613

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIClient.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIClient.java
@@ -167,6 +167,10 @@ public class OpenFoodAPIClient {
                 }
 
                 final State s = response.body();
+                if(s==null){
+                    Toast.makeText(activity,R.string.something_went_wrong,Toast.LENGTH_LONG).show();
+                    return;
+                }
                 if (s.getStatus() == 0) {
                     if (activity != null) {
                         productNotFoundDialogBuilder(activity, barcode)


### PR DESCRIPTION
Fix NullPointerException with OpenFoodAPIClient class.
The response from OFF could be empty ( no state): in this case, a toast message is displayed to the user.