### PR TITLE
Untested 64 bit support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,6 +29,7 @@ android {
         versionName "3.2.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
+        ndk.abiFilters 'armeabi-v7a','arm64-v8a','x86','x86_64'
     }
 
     buildTypes {


### PR DESCRIPTION
For any version released after August 1, 2019, we'll have to be 64-bit compatible
https://developer.android.com/distribute/best-practices/develop/64-bit

This tries to add 64-bit support, without checking whether we're actually compatible