### PR TITLE
Force the usage of Ubuntu Trusty in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: android
 
 jdk: oraclejdk8
 
+# Currently Travis doesn't have a Ubuntu Xenial image for "language: android"
+# If the distribution is omitted it falls back to Ubuntu Precise instead of Trusty, making the build unstable
+dist: trusty
+
 env:
   global:
     - ABI=x86_64


### PR DESCRIPTION
## Description

Travis have been [gradually migrating](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment) users to Ubuntu Xenial, which doesn't currently support `language: android`. This caused the Travis worker to fallback to Ubuntu Precise instead of Trusty, breaking all our builds.

This PR fixes the issue by forcing Travis to use Ubuntu Trusty.
