### PR TITLE
Fixes #2844: Hiding the product card on pressing the scan button

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
@@ -811,4 +811,10 @@ public class ContinuousScanActivity extends androidx.appcompat.app.AppCompatActi
             return null;
         }
     }
+
+    public void collapseBottomSheet(){
+        if(bottomSheetBehavior!=null){
+            bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+        }
+    }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/listeners/CommonBottomListener.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/listeners/CommonBottomListener.java
@@ -33,6 +33,7 @@ public class CommonBottomListener implements BottomNavigationView.OnNavigationIt
         switch (item.getItemId()) {
             case R.id.scan_bottom_nav:
                 if(isCurrentActivity(ContinuousScanActivity.class)){
+                    ((ContinuousScanActivity)activity).collapseBottomSheet();
                     break;
                 }
                 if (Utils.isHardwareCameraInstalled(context)) {


### PR DESCRIPTION

## Description
In the barcode scanning activity if the product card/ bottom sheet is visible on the screen, it should hide if the scan button is pressed for the next scan.

#fixes {2844}
 
 ## Screen-shots, if any
 