### PR TITLE
Use open_other_flavor_drawer instead of open_food_drawer

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -395,7 +395,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         if (BuildConfig.FLAVOR.equals("obf")) {
             result.removeItem(ITEM_ALERT);
             result.removeItem(ITEM_ADDITIVES);
-            result.updateName(ITEM_OBF, new StringHolder(getString(R.string.open_food_drawer)));
+            result.updateName(ITEM_OBF, new StringHolder(getString(R.string.open_other_flavor_drawer)));
         }
 
         if (BuildConfig.FLAVOR.equals("opff")) {


### PR DESCRIPTION
## Description

Build is currently broken as open_food_drawer was removed from the default local (although it still exists in many others). It seems the last commit on the MainActivity class intended to use open_other_flavor_drawer instead.

## Related issues and discussion
Left a message on slack regarding this. Feel free to close the pull request if this is not the appropriate fix.
 
 ## Screen-shots, if any
 
 ## Checklist
 
