### PR TITLE
Extract ingredients button is looking odd

### DIFF
--- a/app/src/main/res/drawable/ic_compare_arrows_black_18dp.xml
+++ b/app/src/main/res/drawable/ic_compare_arrows_black_18dp.xml
@@ -1,5 +1,5 @@
-<vector android:height="18dp" android:tint="#37474F"
+<vector android:height="18dp"
     android:viewportHeight="24.0" android:viewportWidth="24.0"
     android:width="18dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M9.01,14L2,14v2h7.01v3L13,15l-3.99,-4v3zM14.99,13v-3L22,10L22,8h-7.01L14.99,5L11,9l3.99,4z"/>
+    <path android:fillColor="@color/blue_500" android:pathData="M9.01,14L2,14v2h7.01v3L13,15l-3.99,-4v3zM14.99,13v-3L22,10L22,8h-7.01L14.99,5L11,9l3.99,4z"/>
 </vector>

--- a/app/src/main/res/layout/fragment_add_product_ingredients.xml
+++ b/app/src/main/res/layout/fragment_add_product_ingredients.xml
@@ -140,7 +140,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="40dp"
                 android:text="@string/extract_ingredients"
-                android:textColor="@color/md_black_1000"
                 android:visibility="gone"
                 style="@style/BorderButton"
                 app:layout_constraintBottom_toBottomOf="@id/ingredients_list"


### PR DESCRIPTION
## Description

Extract ingredients button text is in black color whereas all other button texts are in blue colour 
 ## Screen-shots, if any
 before changes:
![Screenshot_20190912-213826](https://user-images.githubusercontent.com/43813438/64859883-1b456480-d649-11e9-88fe-3c072c3fdbfd.png)
after changes:
![Screenshot_20190912-225758](https://user-images.githubusercontent.com/43813438/64859902-28faea00-d649-11e9-879c-abe71aba47b3.png)

 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
