### PR TITLE
Closes #2591 Add User-Agent Header in two network requests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,6 +52,7 @@ android {
         off {
             applicationId "openfoodfacts.github.scrachx.openfood"
             resValue "string", "app_name", "OpenFoodFacts"
+            buildConfigField 'String', 'APP_NAME', '"Open Food Facts"'
             buildConfigField 'String', 'HOST', '"https://ssl-api.openfoodfacts.org"'
             buildConfigField 'String', 'OFOTHERLINKAPP', '"org.openbeautyfacts.scanner"'
             buildConfigField 'String', 'OFWEBSITE', '"https://world.openfoodfacts.org/"'
@@ -63,6 +64,7 @@ android {
         obf {
             applicationId "openfoodfacts.github.scrachx.openbeauty"
             resValue "string", "app_name", "OpenBeautyFacts"
+            buildConfigField 'String', 'APP_NAME', '"Open Beauty Facts"'
             buildConfigField 'String', 'HOST', '"https://ssl-api.openbeautyfacts.org"'
             buildConfigField 'String', 'OFOTHERLINKAPP', '"org.openfoodfacts.scanner"'
             buildConfigField 'String', 'OFWEBSITE', '"https://world.openbeautyfacts.org/"'
@@ -72,6 +74,7 @@ android {
         opff {
             applicationId "org.openpetfoodfacts.scanner"
             resValue "string", "app_name", "OpenPetFoodFacts"
+            buildConfigField 'String', 'APP_NAME', '"Open Pet Food Facts"'
             buildConfigField 'String', 'HOST', '"https://ssl-api.openpetfoodfacts.org"'
             buildConfigField 'String', 'OFOTHERLINKAPP', '"org.openfoodfacts.scanner"'
             buildConfigField 'String', 'OFWEBSITE', '"https://world.openpetfoodfacts.org/"'
@@ -81,6 +84,7 @@ android {
         opf {
             applicationId "org.openproductsfacts.scanner"
             resValue "string", "app_name", "OpenProductsFacts"
+            buildConfigField 'String', 'APP_NAME', '"Open Products Facts"'
             buildConfigField 'String', 'HOST', '"https://ssl-api.openproductsfacts.org"'
             buildConfigField 'String', 'OFOTHERLINKAPP', '"org.openfoodfacts.scanner"'
             buildConfigField 'String', 'OFWEBSITE', '"https://world.openproductsfacts.org/"'

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
@@ -153,7 +153,7 @@ public class HomeFragment extends NavigationBaseFragment implements CustomTabAct
         super.onResume();
 
         int productCount = sp.getInt("productCount", 0);
-        apiClient.getTotalProductCount(getString(R.string.app_name) + " " + Utils.getUserAgent("OTHERS"))
+        apiClient.getTotalProductCount(Utils.getUserAgent())
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(new SingleObserver<Search>() {
@@ -224,7 +224,7 @@ public class HomeFragment extends NavigationBaseFragment implements CustomTabAct
 
     private void getTagline() {
         OpenFoodAPIService openFoodAPIService = new OpenFoodAPIClient(getActivity(), "https://ssl-api.openfoodfacts.org").getAPIService();
-        Call<ArrayList<TaglineLanguageModel>> call = openFoodAPIService.getTagline(getString(R.string.app_name) + " " + Utils.getUserAgent("OTHERS"));
+        Call<ArrayList<TaglineLanguageModel>> call = openFoodAPIService.getTagline(Utils.getUserAgent());
         call.enqueue(new Callback<ArrayList<TaglineLanguageModel>>() {
             @Override
             public void onResponse(Call<ArrayList<TaglineLanguageModel>> call, Response<ArrayList<TaglineLanguageModel>> response) {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
@@ -153,7 +153,7 @@ public class HomeFragment extends NavigationBaseFragment implements CustomTabAct
         super.onResume();
 
         int productCount = sp.getInt("productCount", 0);
-        apiClient.getTotalProductCount()
+        apiClient.getTotalProductCount(getString(R.string.app_name) + " " + Utils.getUserAgent("OTHERS"))
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
             .subscribe(new SingleObserver<Search>() {
@@ -224,7 +224,7 @@ public class HomeFragment extends NavigationBaseFragment implements CustomTabAct
 
     private void getTagline() {
         OpenFoodAPIService openFoodAPIService = new OpenFoodAPIClient(getActivity(), "https://ssl-api.openfoodfacts.org").getAPIService();
-        Call<ArrayList<TaglineLanguageModel>> call = openFoodAPIService.getTagline();
+        Call<ArrayList<TaglineLanguageModel>> call = openFoodAPIService.getTagline(getString(R.string.app_name) + " " + Utils.getUserAgent("OTHERS"));
         call.enqueue(new Callback<ArrayList<TaglineLanguageModel>>() {
             @Override
             public void onResponse(Call<ArrayList<TaglineLanguageModel>> call, Response<ArrayList<TaglineLanguageModel>> response) {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIService.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/OpenFoodAPIService.java
@@ -336,12 +336,12 @@ public interface OpenFoodAPIService {
      * This method gives the # of products on Open Food Facts
      */
     @GET("/1.json?fields=null")
-    Single<Search> getTotalProductCount();
+    Single<Search> getTotalProductCount(@Header("User-Agent") String header);
     /**
      * This method gives the news in all languages
      */
     @GET("/files/tagline/tagline-"+ BuildConfig.FLAVOR+".json")
-    Call<ArrayList<TaglineLanguageModel>> getTagline();
+    Call<ArrayList<TaglineLanguageModel>> getTagline(@Header("User-Agent") String header);
     /**
      * This method gives the image fields of a product
      */

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
@@ -787,13 +787,12 @@ public class Utils {
      * @return Returns the header to be put in network call
      */
     public static String getUserAgent(String type) {
-        final String prefix = "Official Android App ";
-        if (type.equals(HEADER_USER_AGENT_SCAN)) {
-            return prefix + BuildConfig.VERSION_NAME + " " + HEADER_USER_AGENT_SCAN;
-        } else if (type.equals(HEADER_USER_AGENT_SEARCH)) {
-            return prefix + BuildConfig.VERSION_NAME + " " + HEADER_USER_AGENT_SEARCH;
-        }
-        return prefix + BuildConfig.VERSION_NAME;
+        return getUserAgent() + " " + type;
+    }
+
+    public static String getUserAgent() {
+        final String prefix = " Official Android App ";
+        return BuildConfig.APP_NAME + prefix + BuildConfig.VERSION_NAME;
     }
 
      /*

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Utils.java
@@ -46,6 +46,7 @@ import okhttp3.OkHttpClient;
 import okhttp3.TlsVersion;
 import okhttp3.logging.HttpLoggingInterceptor;
 import openfoodfacts.github.scrachx.openfood.R;
+import openfoodfacts.github.scrachx.openfood.BuildConfig;
 import openfoodfacts.github.scrachx.openfood.jobs.SavedProductUploadJob;
 import openfoodfacts.github.scrachx.openfood.models.DaoSession;
 import openfoodfacts.github.scrachx.openfood.models.Product;


### PR DESCRIPTION
## Description
- Send User-Agent Header **Open Food Facts Official Android App 3.2.2** in the /tagline-xx.json and /1.json?fields=null GET requests.
- add `import openfoodfacts.github.scrachx.openfood.BuildConfig;` to `Utils.java` to use the correct BuildConfig, currently it was using the package `com.firebase.jobdispatcher` which was not desired and returned incorrect VersionName.
- Make User-Agent Header uniform throughout the app. They will look like:
`"<APP_NAME> Official Android App <VERSION> <TYPE>"`
`<Type>` is optional and the currently used values are `Scan` and `Search`.
All the User-Agent headers sent via the app would be of the above type only.
(Added a screenshot in a comment for reference)

## Related issues and discussion
fixes #2591 
 
 ## Screen-shots, if any
![image](https://user-images.githubusercontent.com/10832531/66274717-1322c280-e89f-11e9-8391-971f20aa1126.png)

 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines.
