### PR TITLE
Fix permission denied issue on clicking manage account

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoginActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoginActivity.java
@@ -203,9 +203,9 @@ public class LoginActivity extends BaseActivity implements CustomTabActivityHelp
                 } else {
                     // store the user session id (user_session and user_id)
                     for (HttpCookie httpCookie : HttpCookie.parse(response.headers().get("set-cookie"))) {
-                        if (httpCookie.getDomain().equals(".openbeautyfacts.org") && httpCookie.getPath().equals("/")) {
+                        //Example format of set-cookie: session=user_session&S0MeR@nD0MSECRETk3Y&user_id&testuser; domain=.openfoodfacts.org; path=/
+                        if (BuildConfig.HOST.contains(httpCookie.getDomain()) && httpCookie.getPath().equals("/")) {
                             String[] cookieValues = httpCookie.getValue().split("&");
-                            //why ?
                             for (int i = 0; i < cookieValues.length; i++) {
                                 editor.putString(cookieValues[i], cookieValues[++i]);
                             }


### PR DESCRIPTION
## Description
Currently only `.openbeautyfacts.org` domain was checked in the code thus the `user_session` cookie was not set in the app after successful login for any flavor except OBF. Changed the logic to check for `BuildConfig.HOST` which makes it possible to save the `user_session` cookies for all the flavors now.

## Related issues and discussion
#Fixes #1965 
 
 ## Screen-shots, if any
 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [ ] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [ ] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines.
