### PR TITLE
Show reload taxonomies option in preferences if local data is empty

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -12,6 +12,9 @@
     <option name="FORMATTER_TAGS_ENABLED" value="true" />
     <option name="WRAP_COMMENTS" value="true" />
     <option name="SOFT_MARGINS" value="160" />
+    <AndroidXmlCodeStyleSettings>
+      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
+    </AndroidXmlCodeStyleSettings>
     <JavaCodeStyleSettings>
       <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
         <value>

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/ProductRepository.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/ProductRepository.java
@@ -199,7 +199,7 @@ public class ProductRepository implements IProductRepository {
      *
      * @return The list of countries.
      */
-    public Single<List<Country>> relodCountriesFromServer() {
+    public Single<List<Country>> reloadCountriesFromServer() {
         return getTaxonomyData(Taxonomy.COUNTRY, true, false, countryDao);
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoadTaxonomiesService.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoadTaxonomiesService.java
@@ -25,7 +25,7 @@ public class LoadTaxonomiesService extends IntentService {
     private ResultReceiver receiver;
     private Disposable disposable;
     public static final int STATUS_RUNNING = 0;
-    private static final int STATUS_FINISHED = 1;
+    public static final int STATUS_FINISHED = 1;
     public static final int STATUS_ERROR = 2;
 
     public LoadTaxonomiesService() {
@@ -45,7 +45,6 @@ public class LoadTaxonomiesService extends IntentService {
     }
 
     private void doTask() {
-
         final Consumer<Throwable> throwableConsumer = this::handleError;
         showLoading();
         List<SingleSource<?>> syncObservables = new ArrayList<>();
@@ -55,7 +54,7 @@ public class LoadTaxonomiesService extends IntentService {
         syncObservables.add(productRepository.reloadIngredientsFromServer().subscribeOn(Schedulers.io()));
         syncObservables.add(productRepository.reloadAnalysisTagConfigsFromServer().subscribeOn(Schedulers.io()));
         syncObservables.add(productRepository.reloadAnalysisTagsFromServer().subscribeOn(Schedulers.io()));
-        syncObservables.add(productRepository.relodCountriesFromServer().subscribeOn(Schedulers.io()));
+        syncObservables.add(productRepository.reloadCountriesFromServer().subscribeOn(Schedulers.io()));
         syncObservables.add(productRepository.reloadAdditivesFromServer().subscribeOn(Schedulers.io()));
         syncObservables.add(productRepository.reloadCategoriesFromServer().subscribeOn(Schedulers.io()));
 

--- a/app/src/main/res/drawable/ic_cloud_download_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_cloud_download_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19.35,10.04C18.67,6.59 15.64,4 12,4 9.11,4 6.6,5.64 5.35,8.04 2.34,8.36 0,10.91 0,14c0,3.31 2.69,6 6,6h13c2.76,0 5,-2.24 5,-5 0,-2.64 -2.05,-4.78 -4.65,-4.96zM17,13l-5,5 -5,-5h3V9h4v4h3z"/>
+</vector>

--- a/app/src/main/res/layout/loading.xml
+++ b/app/src/main/res/layout/loading.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ProgressBar xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/progressBar"
+    android:layout_width="@dimen/small_loading_size"
+    android:layout_height="@dimen/small_loading_size"
+    android:layout_centerInParent="true"
+    android:layout_gravity="center" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -64,4 +64,6 @@
 
     <dimen name="scan_summary_peek_large">198dp</dimen>
     <dimen name="scan_summary_peek_small">120dp</dimen>
+
+    <dimen name="small_loading_size">24dp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -664,7 +664,7 @@
 
     <string name="Terms">Terms</string>
     <string name="TermsOfUse">Terms and Privacy</string>
-    
+
     <string name="translate_url" translatable="false">https://translate.openfoodfacts.org/</string>
     <string name="donation_url">https://donate.openfoodfacts.org</string>
     <!--Just replace "world" by "fr", "de"… translate the "terms-of-use" with the hyphens -->
@@ -1013,4 +1013,7 @@
     <string name="compare_saturated_fat">Saturated fat</string>
     <string name="compare_fat">Fat</string>
     <string name="compare_quantity">Quantity :</string>
+
+    <string name="load_ingredient_detection_data">Load ingredient detection data</string>
+    <string name="load_ingredient_detection_data_summary">No ingredient detection data has been found, try to load it from server</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     dependencies {
 
 
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Fixes #2941

Signed-off-by: Rares Petrescu <petrescu.rares@gmail.com>

## Description

- Display "Load ingredient detection data" if there is no analysis tag config stored in local db.
   If user selects it, it will reload the taxonomies using the LoadTaxonomiesService.

- gradle ++