### PR TITLE
Fixes #2977: Tweaked the CommonBottomListener

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/listeners/BottomNavigationListenerInstaller.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/listeners/BottomNavigationListenerInstaller.java
@@ -6,6 +6,8 @@ import android.content.Context;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import android.util.Log;
 
+import androidx.fragment.app.FragmentActivity;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -65,7 +67,7 @@ public class BottomNavigationListenerInstaller {
             Log.i(BottomNavigationListenerInstaller.class.getSimpleName(),"install",e);
         }
 
-        bottomNavigationView.setOnNavigationItemSelectedListener(new CommonBottomListener(activity, context));
+        bottomNavigationView.setOnNavigationItemSelectedListener(new CommonBottomListener((FragmentActivity) activity, context));
     }
 
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/listeners/CommonBottomListener.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/listeners/CommonBottomListener.java
@@ -9,17 +9,22 @@ import androidx.annotation.NonNull;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
 import android.view.MenuItem;
 import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+
 import openfoodfacts.github.scrachx.openfood.R;
+import openfoodfacts.github.scrachx.openfood.fragments.HomeFragment;
 import openfoodfacts.github.scrachx.openfood.utils.Utils;
 import openfoodfacts.github.scrachx.openfood.views.*;
 
 public class CommonBottomListener implements BottomNavigationView.OnNavigationItemSelectedListener {
-    private final Activity activity;
-    private final Context context;
+    private FragmentActivity activity;
+    private  Context context;
 
-    CommonBottomListener(Activity activity, Context context) {
+    CommonBottomListener(FragmentActivity activity, Context context) {
         this.activity = activity;
         this.context = context;
     }
@@ -65,6 +70,7 @@ public class CommonBottomListener implements BottomNavigationView.OnNavigationIt
             case R.id.home_page:
             case R.id.home:
                 if(isCurrentActivity(WelcomeActivity.class)||isCurrentActivity(MainActivity.class)){
+                    activity.getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container,new HomeFragment()).addToBackStack(null).commit();
                     break;
                 }
                 activity.startActivity((createIntent( MainActivity.class)));


### PR DESCRIPTION
Fixed the homeButton not functioning bug.

##  Description
1. Even if the current Activity is MainActivity still we can have different Fragments on top of it,
therefore whenever the home button is clicked now it is getting swapped with HomeFragment.
2. Used `FragmentActivity` instead of `Activity` to use `getSupportFragmentManager()` instead of deprecated `getFragmentManager()`.

## Related issues and discussion
Fixes #2977
 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [ ] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
