### PR TITLE
fix#3001 error messages are shown using built-in methods

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/FindProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/FindProductFragment.java
@@ -61,16 +61,16 @@ public class FindProductFragment extends NavigationBaseFragment {
     protected void onSearchBarcodeProduct() {
         Utils.hideKeyboard(getActivity());
         if (mBarCodeText.getText().toString().isEmpty()) {
-            displayToast(getResources().getString(R.string.txtBarcodeRequire));
+            mBarCodeText.setError(getResources().getString(R.string.txtBarcodeRequire));
         } else {
             String barcodeText = mBarCodeText.getText().toString();
             if (barcodeText.length() <= 2 && !ProductUtils.DEBUG_BARCODE.equals(barcodeText)) {
-                displayToast(getResources().getString(R.string.txtBarcodeNotValid));
+                mBarCodeText.setError(getResources().getString(R.string.txtBarcodeNotValid));
             } else {
                 if (ProductUtils.isBarcodeValid(barcodeText)) {
                     api.getProduct(mBarCodeText.getText().toString(), getActivity());
                 } else {
-                    displayToast(getResources().getString(R.string.txtBarcodeNotValid));
+                    mBarCodeText.setError(getResources().getString(R.string.txtBarcodeNotValid));
                 }
             }
         }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/FindProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/FindProductFragment.java
@@ -1,11 +1,6 @@
 package openfoodfacts.github.scrachx.openfood.fragments;
 
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import com.google.android.material.bottomnavigation.BottomNavigationView;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,6 +8,16 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+
+import org.apache.commons.lang.StringUtils;
+
 import butterknife.BindView;
 import butterknife.OnClick;
 import openfoodfacts.github.scrachx.openfood.R;
@@ -21,7 +26,6 @@ import openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener.Navi
 import openfoodfacts.github.scrachx.openfood.utils.ProductUtils;
 import openfoodfacts.github.scrachx.openfood.utils.Utils;
 import openfoodfacts.github.scrachx.openfood.views.listeners.BottomNavigationListenerInstaller;
-import org.apache.commons.lang.StringUtils;
 
 import static openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener.ITEM_SEARCH_BY_CODE;
 
@@ -60,19 +64,23 @@ public class FindProductFragment extends NavigationBaseFragment {
     @OnClick(R.id.buttonBarcode)
     protected void onSearchBarcodeProduct() {
         Utils.hideKeyboard(getActivity());
-        if (mBarCodeText.getText().toString().isEmpty()) {
+
+        final String barCodeTxt = mBarCodeText.getText().toString();
+        if (barCodeTxt.isEmpty()) {
             mBarCodeText.setError(getResources().getString(R.string.txtBarcodeRequire));
+            return;
+        }
+
+        if (barCodeTxt.length() <= 2 && !ProductUtils.DEBUG_BARCODE.equals(barCodeTxt)) {
+            mBarCodeText.setError(getResources().getString(R.string.txtBarcodeNotValid));
+            return;
+        }
+
+        if (!ProductUtils.isBarcodeValid(barCodeTxt)) {
+            mBarCodeText.setError(getResources().getString(R.string.txtBarcodeNotValid));
         } else {
-            String barcodeText = mBarCodeText.getText().toString();
-            if (barcodeText.length() <= 2 && !ProductUtils.DEBUG_BARCODE.equals(barcodeText)) {
-                mBarCodeText.setError(getResources().getString(R.string.txtBarcodeNotValid));
-            } else {
-                if (ProductUtils.isBarcodeValid(barcodeText)) {
-                    api.getProduct(mBarCodeText.getText().toString(), getActivity());
-                } else {
-                    mBarCodeText.setError(getResources().getString(R.string.txtBarcodeNotValid));
-                }
-            }
+
+            api.getProduct(barCodeTxt, getActivity());
         }
     }
 
@@ -95,6 +103,7 @@ public class FindProductFragment extends NavigationBaseFragment {
         mToast.show();
     }
 
+    @Override
     public void onResume() {
         super.onResume();
         final ActionBar supportActionBar = ((AppCompatActivity) getActivity()).getSupportActionBar();


### PR DESCRIPTION
## Description

The error messages are now shown using buit-in methods.

fixes #3001 
 
 ## Screen-shots
![WhatsApp Image 2020-01-20 at 10 07 09 PM](https://user-images.githubusercontent.com/46667021/72744243-2f8b0680-3bd3-11ea-9206-68d7c316347b.jpeg)

 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [x] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
