### PR TITLE
Ignore additional fields in Robotoff random question endpoint

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/Question.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/Question.java
@@ -1,11 +1,13 @@
 package openfoodfacts.github.scrachx.openfood.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.commons.lang.StringUtils;
 
 import java.io.Serializable;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Question implements Serializable {
 
     private static final long serialVersionUID = 1L;


### PR DESCRIPTION
## Description

Adding a new field in robotoff /questions/random endpoint make the call fail due to serialization issues.