### PR TITLE
fix #1328 - use android theme instead of app theme

### DIFF
--- a/app/src/main/res/layout/activity_full_screen_image.xml
+++ b/app/src/main/res/layout/activity_full_screen_image.xml
@@ -10,7 +10,7 @@
             android:layout_height="wrap_content"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+            android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
             android:elevation="4dp"
             android:id="@+id/toolbar"/>
     <Spinner

--- a/app/src/main/res/layout/activity_product.xml
+++ b/app/src/main/res/layout/activity_product.xml
@@ -16,9 +16,9 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
+            android:theme="@style/Black_Back_Arrow"
             app:layout_scrollFlags="scroll|enterAlways"
-            app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-            app:theme="@style/Black_Back_Arrow"/>
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tabs"

--- a/app/src/main/res/layout/activity_product_images_list.xml
+++ b/app/src/main/res/layout/activity_product_images_list.xml
@@ -9,9 +9,9 @@
     <androidx.appcompat.widget.Toolbar
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
             android:elevation="4dp"
             android:id="@+id/toolbar"/>
 

--- a/app/src/main/res/layout/activity_zoom_image.xml
+++ b/app/src/main/res/layout/activity_zoom_image.xml
@@ -8,9 +8,9 @@
     <androidx.appcompat.widget.Toolbar
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
             android:elevation="4dp"
             android:id="@+id/toolbar"/>
 

--- a/app/src/main/res/layout/calculate_details.xml
+++ b/app/src/main/res/layout/calculate_details.xml
@@ -18,9 +18,9 @@
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
+            android:theme="@style/Black_Back_Arrow"
             app:layout_scrollFlags="scroll|enterAlways"
-            app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-            app:theme="@style/Black_Back_Arrow" />
+            app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
 
     </com.google.android.material.appbar.AppBarLayout>
 


### PR DESCRIPTION
## Description

`app.theme` is deprecated, hence `android:theme` is used.

fixes #1328