### PR TITLE
Refactored the redundant setup of the bottom navigation

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AllergensAlertFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AllergensAlertFragment.java
@@ -91,7 +91,6 @@ public class AllergensAlertFragment extends NavigationBaseFragment {
         mDataObserver = new DataObserver();
         bottomNavigationView  = view.findViewById((R.id.bottom_navigation));
         BottomNavigationListenerInstaller.selectNavigationItem(bottomNavigationView, 0);
-        BottomNavigationListenerInstaller.install(bottomNavigationView,getActivity(),getContext());
         productRepository.getAllergensByEnabledAndLanguageCode(true, Locale.getDefault().getLanguage());
 
         final String language = LocaleHelper.getLanguage(getContext());

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/FindProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/FindProductFragment.java
@@ -58,7 +58,6 @@ public class FindProductFragment extends NavigationBaseFragment {
         }
 
         BottomNavigationListenerInstaller.selectNavigationItem(bottomNavigationView, 0);
-        BottomNavigationListenerInstaller.install(bottomNavigationView, getActivity(), getContext());
     }
 
     @OnClick(R.id.buttonBarcode)

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/HomeFragment.java
@@ -71,7 +71,6 @@ public class HomeFragment extends NavigationBaseFragment implements CustomTabAct
         checkUserCredentials();
         sp = PreferenceManager.getDefaultSharedPreferences(getContext());
         BottomNavigationListenerInstaller.selectNavigationItem(bottomNavigationView, R.id.home_page);
-        BottomNavigationListenerInstaller.install(bottomNavigationView, getActivity(), getContext());
     }
 
     @Override

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/OfflineEditFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/OfflineEditFragment.java
@@ -114,7 +114,6 @@ public class OfflineEditFragment extends NavigationBaseFragment implements SaveL
         DividerItemDecoration dividerItemDecoration = new DividerItemDecoration(mRecyclerView.getContext(),
             DividerItemDecoration.VERTICAL);
         mRecyclerView.addItemDecoration(dividerItemDecoration);
-        BottomNavigationListenerInstaller.install(bottomNavigationView, getActivity(), getContext());
     }
 
     @OnClick(R.id.message_dismiss_icon)


### PR DESCRIPTION
Refactored the codebase to remove the redundant setup code for bottom navigation

##  Description
1. Refactored the redundant setup of the bottom navigation for the fragments which are accesible only by the MainActivity as their Fragment activity .

## Related issues and discussion
Fixes #2991
 
 ## Checklist
 
Make sure you've done all the following (You can delete the checklist before submitting)
 - [x] Apply the `AndroidStyle.xml` style template to your code in Android Studio.
 - [x] Code is well documented
 - [ ] Include unit tests for new functionality
 - [x] All user-visible strings are made translatable
 - [x] Code passes Travis builds in your branch
 - [x] If you have multiple commits please combine them into one commit by squashing them.
 - [x] Read and understood the contribution guidelines .
