### PR TITLE
Load invalid barcodes locally and ignore them when scanned

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -147,7 +147,7 @@ buildscript {
 apply plugin: 'org.greenrobot.greendao'
 
 greendao {
-    schemaVersion 15
+    schemaVersion 16
 }
 android {
     // Other settings

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/DatabaseHelper.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/DatabaseHelper.java
@@ -145,6 +145,10 @@ public class DatabaseHelper extends DaoMaster.OpenHelper {
                 AnalysisTagConfigDao.createTable(db, true);
                 break;
             }
+            case 16: {
+                InvalidBarcodeDao.createTable(db, true);
+                break;
+            }
         }
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/InvalidBarcode.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/InvalidBarcode.java
@@ -1,0 +1,37 @@
+package openfoodfacts.github.scrachx.openfood.models;
+
+import org.greenrobot.greendao.annotation.Entity;
+import org.greenrobot.greendao.annotation.Id;
+import org.greenrobot.greendao.annotation.Index;
+
+import java.io.Serializable;
+import org.greenrobot.greendao.annotation.Generated;
+
+@Entity(indexes = {
+    @Index(value = "barcode", unique = true)
+})
+
+public class InvalidBarcode implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    private String barcode;
+
+    @Generated(hash = 1699276588)
+    public InvalidBarcode(String barcode) {
+        this.barcode = barcode;
+    }
+
+    @Generated(hash = 1875151970)
+    public InvalidBarcode() {
+    }
+
+    public String getBarcode() {
+        return barcode;
+    }
+
+    public void setBarcode(String barcode) {
+        this.barcode = barcode;
+    }
+}

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/ProductApiService.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/ProductApiService.java
@@ -4,6 +4,8 @@ package openfoodfacts.github.scrachx.openfood.network;
  * Created by Lobster on 03.03.18.
  */
 
+import java.util.List;
+
 import io.reactivex.Single;
 import openfoodfacts.github.scrachx.openfood.models.*;
 import retrofit2.http.GET;
@@ -22,6 +24,7 @@ public interface ProductApiService {
     String ANALYSIS_TAG_JSON = "data/taxonomies/ingredients_analysis.json";
     String ANALYSIS_TAG_CONFIG_JSON = "files/app/ingredients-analysis.json";
     String TAGS_JSON = "data/taxonomies/packager-codes.json";
+    String INVALID_BARCODES_JSON = "data/invalid-barcodes.json";
 
     @GET(LABELS_JSON)
     Single<LabelsWrapper> getLabels();
@@ -43,6 +46,9 @@ public interface ProductApiService {
 
     @GET(TAGS_JSON)
     Single<TagsWrapper> getTags();
+
+    @GET(INVALID_BARCODES_JSON)
+    Single<List<String>> getInvalidBarcodes();
 
     @GET("data/taxonomies/vitamins.json")
     Single<CategoriesWrapper> getVitamins();

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/ProductRepository.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/ProductRepository.java
@@ -383,11 +383,12 @@ public class ProductRepository implements IProductRepository {
     }
 
     /**
-     * Invalid Barcodess saving to local database
+     * Invalid Barcodess saving to local database. Will clear all previous invalid barcodes stored before.
      *
      * @param invalidBarcodes The list of invalidBarcodes to be saved.
      */
     private void saveInvalidBarcodes(List<InvalidBarcode> invalidBarcodes) {
+        invalidBarcodeDao.deleteAll();
         invalidBarcodeDao.insertOrReplaceInTx(invalidBarcodes);
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/Taxonomy.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/Taxonomy.java
@@ -60,6 +60,12 @@ public enum Taxonomy {
         public Single<List<Tag>> load(ProductRepository repository, long lastModifiedDate) {
             return repository.loadTags(lastModifiedDate);
         }
+    },
+    INVALID_BARCODES(ProductApiService.INVALID_BARCODES_JSON) {
+        @Override
+        public Single<List<InvalidBarcode>> load(ProductRepository repository, long lastModifiedDate) {
+            return repository.loadInvalidBarcodes(lastModifiedDate);
+        }
     };
     public final String jsonUrl;
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
@@ -65,6 +65,8 @@ import openfoodfacts.github.scrachx.openfood.models.AllergenHelper;
 import openfoodfacts.github.scrachx.openfood.models.AllergenName;
 import openfoodfacts.github.scrachx.openfood.models.AnalysisTagConfig;
 import openfoodfacts.github.scrachx.openfood.models.HistoryProductDao;
+import openfoodfacts.github.scrachx.openfood.models.InvalidBarcode;
+import openfoodfacts.github.scrachx.openfood.models.InvalidBarcodeDao;
 import openfoodfacts.github.scrachx.openfood.models.OfflineSavedProduct;
 import openfoodfacts.github.scrachx.openfood.models.OfflineSavedProductDao;
 import openfoodfacts.github.scrachx.openfood.models.Product;
@@ -89,6 +91,7 @@ public class ContinuousScanActivity extends androidx.appcompat.app.AppCompatActi
     private static final int ADD_PRODUCT_ACTIVITY_REQUEST_CODE = 1;
     private static final int LOGIN_ACTIVITY_REQUEST_CODE = 2;
     private HistoryProductDao mHistoryProductDao;
+    private InvalidBarcodeDao mInvalidBarcodeDao;
     @BindView(R.id.quick_view)
     LinearLayout quickView;
     @BindView(R.id.barcode_scanner)
@@ -160,10 +163,17 @@ public class ContinuousScanActivity extends androidx.appcompat.app.AppCompatActi
         @Override
         public void barcodeResult(BarcodeResult result) {
             handler.removeCallbacks(runnable);
-            if (result.getText() == null || result.getText().equals(lastText)) {
+            if (result.getText() == null || result.getText().isEmpty() || result.getText().equals(lastText)) {
                 // Prevent duplicate scans
                 return;
             }
+            InvalidBarcode invalidBarcode = mInvalidBarcodeDao.queryBuilder()
+                .where(InvalidBarcodeDao.Properties.Barcode.eq(result.getText())).unique();
+            if (invalidBarcode != null) {
+                // scanned barcode is in the list of invalid barcodes, do nothing
+                return;
+            }
+
             if (mRing) {
                 beepManager.playBeepSound();
             }
@@ -674,6 +684,7 @@ public class ContinuousScanActivity extends androidx.appcompat.app.AppCompatActi
         });
 
         mHistoryProductDao = Utils.getAppDaoSession(ContinuousScanActivity.this).getHistoryProductDao();
+        mInvalidBarcodeDao = Utils.getAppDaoSession(ContinuousScanActivity.this).getInvalidBarcodeDao();
         mOfflineSavedProductDao = Utils.getAppDaoSession(ContinuousScanActivity.this).getOfflineSavedProductDao();
 
         sp = getSharedPreferences("camera", 0);

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoadTaxonomiesService.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoadTaxonomiesService.java
@@ -50,6 +50,7 @@ public class LoadTaxonomiesService extends IntentService {
         List<SingleSource<?>> syncObservables = new ArrayList<>();
         syncObservables.add(productRepository.reloadLabelsFromServer().subscribeOn(Schedulers.io()));
         syncObservables.add(productRepository.reloadTagsFromServer().subscribeOn(Schedulers.io()));
+        syncObservables.add(productRepository.reloadInvalidBarcodesFromServer().subscribeOn(Schedulers.io()));
         syncObservables.add(productRepository.reloadAllergensFromServer().subscribeOn(Schedulers.io()));
         syncObservables.add(productRepository.reloadIngredientsFromServer().subscribeOn(Schedulers.io()));
         syncObservables.add(productRepository.reloadAnalysisTagConfigsFromServer().subscribeOn(Schedulers.io()));

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/splash/SplashPresenter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/splash/SplashPresenter.java
@@ -38,6 +38,7 @@ public class SplashPresenter implements ISplashPresenter.Actions {
     public void refreshData() {
         activateDownload(Taxonomy.CATEGORY);
         activateDownload(Taxonomy.TAGS);
+        activateDownload(Taxonomy.INVALID_BARCODES);
         activateDownload(Taxonomy.ADDITIVE, OFFApplication.OFF, OFFApplication.OBF);
         activateDownload(Taxonomy.COUNTRY, OFFApplication.OFF, OFFApplication.OBF);
         activateDownload(Taxonomy.LABEL, OFFApplication.OFF, OFFApplication.OBF);


### PR DESCRIPTION
Load all invalid barcodes the same way taxonomies are loaded, insert them into local db. When scanning a barcode, query the invalid barcodes db, and if found, ignore the scan.

Fix #2629
