### PR TITLE
Fix DB closed crash at startup

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/OFFApplication.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/OFFApplication.java
@@ -64,10 +64,9 @@ public class OFFApplication extends MultiDexApplication {
         } else {
             nameDB = "open_beauty_facts";
         }
-        Database db;
-        try (DatabaseHelper helper = new DatabaseHelper(this, nameDB)) {
-            db = helper.getWritableDb();
-        }
+        
+        DatabaseHelper helper = new DatabaseHelper(this, nameDB);
+        Database db = helper.getWritableDb();
         daoSession = new DaoMaster(db).newSession();
 
         // DEBUG


### PR DESCRIPTION
App crash at startup : 

```
attempt to re-open an already-closed object: SQLiteDatabase: /data/user/0/openfoodfacts.github.scrachx.openfood/databases/open_food_facts
        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3303)
```

Crash was caused by the try with resource insatntiation on the DB helper. 

https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html says that an object implementing Closeable created in a try with resource instation will be closed at the end of the try block, and our DatabaseHelper does implements AutoCloseable, so it is closed right after begin created, therefore the db is closed and never accessible from the app.