### PR TITLE
Fixed bottom panel bug

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
@@ -558,6 +558,7 @@ public class ContinuousScanActivity extends androidx.appcompat.app.AppCompatActi
     @Override
     protected void onResume() {
         super.onResume();
+        BottomNavigationListenerInstaller.selectNavigationItem(bottomNavigationView, R.id.scan_bottom_nav);
         if (bottomSheetBehavior.getState() != BottomSheetBehavior.STATE_EXPANDED) {
             barcodeView.resume();
         }
@@ -752,7 +753,6 @@ public class ContinuousScanActivity extends androidx.appcompat.app.AppCompatActi
             return false;
         });
 
-        BottomNavigationListenerInstaller.selectNavigationItem(bottomNavigationView, R.id.scan_bottom_nav);
         BottomNavigationListenerInstaller.install(bottomNavigationView, this, this);
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/HistoryScanActivity.java
@@ -142,7 +142,6 @@ public class HistoryScanActivity extends BaseActivity implements SwipeController
             swipeRefreshLayout.setRefreshing(false);
         });
 
-        BottomNavigationListenerInstaller.selectNavigationItem(bottomNavigationView, R.id.history_bottom_nav);
         BottomNavigationListenerInstaller.install(bottomNavigationView, this, this);
     }
 
@@ -508,6 +507,7 @@ public class HistoryScanActivity extends BaseActivity implements SwipeController
     @Override
     public void onResume() {
         super.onResume();
+        BottomNavigationListenerInstaller.selectNavigationItem(bottomNavigationView, R.id.history_bottom_nav);
         if (scanOnShake) {
             //unregister the listener
             mSensorManager.registerListener(mShakeDetector, mAccelerometer, SensorManager.SENSOR_DELAY_UI);

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -197,7 +197,6 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
         } else {
             fragmentManager.beginTransaction().replace(R.id.fragment_container, new HomeFragment
                 ()).commit();
-            bottomNavigationView.setSelectedItemId(R.id.home_page);
             toolbar.setTitle(APP_NAME);
         }
 
@@ -921,6 +920,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
     @Override
     public void onResume() {
         super.onResume();
+        BottomNavigationListenerInstaller.selectNavigationItem(bottomNavigationView, R.id.home_page);
 
         // change drawer menu item from "install" to "open" when navigating back from play store.
         if (Utils.isApplicationInstalled(MainActivity.this, BuildConfig.OFOTHERLINKAPP)) {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductComparisonActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductComparisonActivity.java
@@ -87,7 +87,6 @@ public class ProductComparisonActivity extends BaseActivity implements PhotoRece
             }
         });
 
-        BottomNavigationListenerInstaller.selectNavigationItem(bottomNavigationView, R.id.compare_products);
         BottomNavigationListenerInstaller.install(bottomNavigationView, this, getBaseContext());
     }
 
@@ -100,5 +99,12 @@ public class ProductComparisonActivity extends BaseActivity implements PhotoRece
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         photoReceiverHandler.onActivityResult(this,requestCode,resultCode,data);
+    }
+
+    @Override
+    public void onResume(){
+        super.onResume();
+        BottomNavigationListenerInstaller.selectNavigationItem(bottomNavigationView, R.id.compare_products);
+
     }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductListsActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductListsActivity.java
@@ -75,7 +75,6 @@ public class ProductListsActivity extends BaseActivity implements SwipeControlle
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-        BottomNavigationListenerInstaller.selectNavigationItem(bottomNavigationView, R.id.my_lists);
         BottomNavigationListenerInstaller.install(bottomNavigationView, this, getBaseContext());
         fabAdd.setCompoundDrawablesWithIntrinsicBounds(R.drawable.plus_blue, 0, 0, 0);
 
@@ -296,5 +295,12 @@ public class ProductListsActivity extends BaseActivity implements SwipeControlle
                 return false;
             }
         }
+    }
+
+    @Override
+    public void onResume(){
+        super.onResume();
+        BottomNavigationListenerInstaller.selectNavigationItem(bottomNavigationView, R.id.my_lists);
+
     }
 }


### PR DESCRIPTION
In order to fix the issue #3062 I moved the method selectNavigationItem() (which selects necessary item on the bottom panel) from onCreate to onResume method, so that it will run both on Activity creation and after the user pushes 'back' button.  And it will fix the issue, when user has highlighted "history" button while returning back to MainActivity (and all other combinations).
Tested by running OBF debug apk on Android 5.1.1, Android 9 devices.