### PR TITLE
Remove token which was public

### DIFF
--- a/sentry.properties
+++ b/sentry.properties
@@ -1,4 +1,3 @@
 defaults.project=openfoodfacts-android
 defaults.org=openfoodfacts
-auth.token=4664a0f9a08e4b2facef49f778b82321993e7e8b0783439fa81f7741b36249b3
 #defaults.url=//TODO:


### PR DESCRIPTION
commited sentry token has been invalidated and is now loaded from ~/.sentryclirc on builder’s machine