### PR TITLE
When adding a photo from the picture manager, the app redirects to an empty Scan window #3180

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/FullScreenActivityOpener.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/FullScreenActivityOpener.java
@@ -9,6 +9,8 @@ import android.widget.Toast;
 
 import androidx.core.app.ActivityOptionsCompat;
 import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentTransaction;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -48,6 +50,9 @@ public class FullScreenActivityOpener {
             ActivityOptionsCompat options = ActivityOptionsCompat.
                 makeSceneTransitionAnimation(fragment.getActivity(), mImageFront, fragment.getActivity().getString(R.string.product_transition));
             fragment.startActivityForResult(intent, ProductImageManagementActivity.REQUEST_EDIT_IMAGE, options.toBundle());
+            fragment.getActivity().finish();
+            fragment.getActivity().getSupportFragmentManager().beginTransaction().replace(R.id.fragment_container,
+                fragment).addToBackStack("product").commit();
         } else {
             fragment.startActivityForResult(intent, ProductImageManagementActivity.REQUEST_EDIT_IMAGE);
         }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductImageManagementActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductImageManagementActivity.java
@@ -17,6 +17,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
+import androidx.fragment.app.FragmentManager;
 
 import com.github.chrisbanes.photoview.PhotoViewAttacher;
 import com.squareup.picasso.Callback;
@@ -451,6 +452,8 @@ public class ProductImageManagementActivity extends BaseActivity implements Phot
     }
 
     void onExit() {
+        FragmentManager fm = getSupportFragmentManager();
+        fm.popBackStack("product",0);
         finish();
     }
 


### PR DESCRIPTION
some ideas on fixing issue https://github.com/openfoodfacts/openfoodfacts-androidapp/issues/3180
The fact that the productimagemanagementactivity started by summaryproductfragment, ingredientproductfragment, and nutrition fragment in FullscreenActivityOpener.java might be related to the fact that these fragments are not added to the backstack. So when the user calls finish in productimagemanagementactivity, the activity ends and redirects to the previous screen (works in history but not in scan).
Some ideas on fixing the issue: add the current fragment to the backstack so when user finishes he can call popBackStack upon exit (still doesn't work properly).