### PR TITLE
chore(stats): Matomo integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -134,8 +134,9 @@ dependencies {
     // UI Component : Chips Input
     implementation("com.hootsuite.android:nachos:1.2.0")
 
-    // Crash analytics
+    // Analytics
     implementation("io.sentry:sentry-android:2.2.2")
+    implementation("org.matomo.sdk:tracker:4.1.2")
 
     // Unit Testing
     testImplementation("junit:junit:4.13")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
         <meta-data
             android:name="io.sentry.session-tracking.enable"
             android:value="true" />
+        <meta-data android:name="io.sentry.auto-init" android:value="false" />
 
         <!-- 18:9 aspect ratio support -->
         <meta-data

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductIngredientsFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductIngredientsFragment.java
@@ -59,6 +59,9 @@ import openfoodfacts.github.scrachx.openfood.models.DaoSession;
 import openfoodfacts.github.scrachx.openfood.models.OfflineSavedProduct;
 import openfoodfacts.github.scrachx.openfood.models.Product;
 import openfoodfacts.github.scrachx.openfood.network.ApiFields;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsEvent;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsService;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsView;
 import openfoodfacts.github.scrachx.openfood.utils.EditTextUtils;
 import openfoodfacts.github.scrachx.openfood.utils.FileDownloader;
 import openfoodfacts.github.scrachx.openfood.utils.FileUtils;
@@ -100,6 +103,12 @@ public class AddProductIngredientsFragment extends BaseFragment {
     }
 
     @Override
+    public void onResume() {
+        super.onResume();
+        AnalyticsService.getInstance().trackView(AnalyticsView.PRODUCT_EDIT_INGREDIENTS);
+    }
+
+    @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         photoReceiverHandler = new PhotoReceiverHandler(newPhotoFile -> {
@@ -112,6 +121,7 @@ public class AddProductIngredientsFragment extends BaseFragment {
             if (activity instanceof AddProductActivity) {
                 ((AddProductActivity) activity).addToPhotoMap(image, 1);
             }
+            AnalyticsService.getInstance().trackEvent(AnalyticsEvent.ProductIngredientsPictureEdited(code));
             hideImageProgress(false, getString(R.string.image_uploaded_successfully));
         });
         binding.btnExtractIngredients.setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_compare_arrows_black_18dp, 0, 0, 0);

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductNutritionFactsFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductNutritionFactsFragment.java
@@ -72,6 +72,8 @@ import openfoodfacts.github.scrachx.openfood.models.OfflineSavedProduct;
 import openfoodfacts.github.scrachx.openfood.models.Product;
 import openfoodfacts.github.scrachx.openfood.models.Units;
 import openfoodfacts.github.scrachx.openfood.network.ApiFields;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsService;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsView;
 import openfoodfacts.github.scrachx.openfood.utils.CustomValidatingEditTextView;
 import openfoodfacts.github.scrachx.openfood.utils.EditTextUtils;
 import openfoodfacts.github.scrachx.openfood.utils.FileDownloader;
@@ -130,6 +132,12 @@ public class AddProductNutritionFactsFragment extends BaseFragment {
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         binding = FragmentAddProductNutritionFactsBinding.inflate(inflater);
         return binding.getRoot();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        AnalyticsService.getInstance().trackView(AnalyticsView.PRODUCT_EDIT_NUTRITION_FACTS);
     }
 
     @Override

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AddProductOverviewFragment.java
@@ -85,6 +85,8 @@ import openfoodfacts.github.scrachx.openfood.models.TagDao;
 import openfoodfacts.github.scrachx.openfood.network.ApiFields;
 import openfoodfacts.github.scrachx.openfood.network.CommonApiManager;
 import openfoodfacts.github.scrachx.openfood.network.services.ProductsAPI;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsService;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsView;
 import openfoodfacts.github.scrachx.openfood.utils.EditTextUtils;
 import openfoodfacts.github.scrachx.openfood.utils.FileDownloader;
 import openfoodfacts.github.scrachx.openfood.utils.LocaleHelper;
@@ -131,6 +133,12 @@ public class AddProductOverviewFragment extends BaseFragment {
                              Bundle savedInstanceState) {
         binding = FragmentAddProductOverviewBinding.inflate(inflater);
         return binding.getRoot();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        AnalyticsService.getInstance().trackView(AnalyticsView.PRODUCT_EDIT_OVERVIEW);
     }
 
     @Override

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AllergensAlertFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AllergensAlertFragment.java
@@ -52,6 +52,8 @@ import openfoodfacts.github.scrachx.openfood.R;
 import openfoodfacts.github.scrachx.openfood.databinding.FragmentAlertAllergensBinding;
 import openfoodfacts.github.scrachx.openfood.models.AllergenName;
 import openfoodfacts.github.scrachx.openfood.repositories.ProductRepository;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsEvent;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsService;
 import openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener.NavigationDrawerType;
 import openfoodfacts.github.scrachx.openfood.views.adapters.AllergensAdapter;
 
@@ -167,6 +169,7 @@ public class AllergensAlertFragment extends NavigationBaseFragment {
                             mAllergensEnabled.add(allergens.get(position));
                             mAdapter.notifyItemInserted(mAllergensEnabled.size() - 1);
                             binding.allergensRecycle.scrollToPosition(mAdapter.getItemCount() - 1);
+                            AnalyticsService.getInstance().trackEvent(AnalyticsEvent.AllergenAlertCreated(allergens.get(position).getAllergenTag()));
                         })
                         .show();
                 }, Throwable::printStackTrace));

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AnalyticsUsageBottomSheetDialogFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/AnalyticsUsageBottomSheetDialogFragment.java
@@ -1,0 +1,44 @@
+package openfoodfacts.github.scrachx.openfood.fragments;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.databinding.DataBindingUtil;
+import androidx.preference.PreferenceManager;
+
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
+
+import openfoodfacts.github.scrachx.openfood.R;
+import openfoodfacts.github.scrachx.openfood.databinding.FragmentAnalyticsUsageBottomSheetBinding;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsService;
+import openfoodfacts.github.scrachx.openfood.views.OFFApplication;
+
+public class AnalyticsUsageBottomSheetDialogFragment extends BottomSheetDialogFragment {
+    public AnalyticsUsageBottomSheetDialogFragment() {
+        setCancelable(false);
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+
+        FragmentAnalyticsUsageBottomSheetBinding binding = DataBindingUtil.inflate(inflater, R.layout.fragment_analytics_usage_bottom_sheet, container, false);
+
+        binding.grantButton.setOnClickListener(view -> {
+            PreferenceManager.getDefaultSharedPreferences(OFFApplication.getInstance()).edit().putBoolean("privacyAnalyticsReporting", true).apply();
+            AnalyticsService.getInstance().onAnalyticsEnabledToggled(true);
+            dismiss();
+        });
+        binding.declineButton.setOnClickListener(view -> {
+            PreferenceManager.getDefaultSharedPreferences(OFFApplication.getInstance()).edit().putBoolean("privacyAnalyticsReporting", false).apply();
+            AnalyticsService.getInstance().onAnalyticsEnabledToggled(false);
+            dismiss();
+        });
+
+        return binding.getRoot();
+    }
+}

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
@@ -44,6 +44,7 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceScreen;
+import androidx.preference.SwitchPreference;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkInfo;
 import androidx.work.WorkManager;
@@ -82,6 +83,7 @@ import openfoodfacts.github.scrachx.openfood.models.AnalysisTagNameDao;
 import openfoodfacts.github.scrachx.openfood.models.CountryName;
 import openfoodfacts.github.scrachx.openfood.models.CountryNameDao;
 import openfoodfacts.github.scrachx.openfood.models.DaoSession;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsService;
 import openfoodfacts.github.scrachx.openfood.utils.INavigationItem;
 import openfoodfacts.github.scrachx.openfood.utils.JsonUtils;
 import openfoodfacts.github.scrachx.openfood.utils.LocaleHelper;
@@ -263,10 +265,19 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements INa
             return true;
         });
 
-        CheckBoxPreference photoPreference = findPreference("photoMode");
+        SwitchPreference photoPreference = findPreference("photoMode");
         if (AppFlavors.isFlavors(AppFlavors.OPF)) {
             photoPreference.setVisible(false);
         }
+
+        SwitchPreference analyticsReportingPreference = findPreference("privacyAnalyticsReporting");
+        analyticsReportingPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                AnalyticsService.getInstance().onAnalyticsEnabledToggled(newValue == Boolean.TRUE);
+                return true;
+            }
+        });
 
         // Preference to show version name
         Preference versionPref = findPreference("Version");

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/fragments/PreferencesFragment.java
@@ -83,6 +83,7 @@ import openfoodfacts.github.scrachx.openfood.models.AnalysisTagNameDao;
 import openfoodfacts.github.scrachx.openfood.models.CountryName;
 import openfoodfacts.github.scrachx.openfood.models.CountryNameDao;
 import openfoodfacts.github.scrachx.openfood.models.DaoSession;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsEvent;
 import openfoodfacts.github.scrachx.openfood.utils.AnalyticsService;
 import openfoodfacts.github.scrachx.openfood.utils.INavigationItem;
 import openfoodfacts.github.scrachx.openfood.utils.JsonUtils;
@@ -346,6 +347,17 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements INa
                 preference.setSummaryOn(null);
                 preference.setSummaryOff(null);
                 preference.setTitle(getString(R.string.display_analysis_tag_status, config.getTypeName().toLowerCase()));
+                preference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                    @Override
+                    public boolean onPreferenceChange(Preference preference, Object newValue) {
+                        if (newValue == Boolean.TRUE) {
+                            AnalyticsEvent.IngredientAnalysisEnabled(config.getType()).track();
+                        } else {
+                            AnalyticsEvent.IngredientAnalysisDisabled(config.getType()).track();
+                        }
+                        return true;
+                    }
+                });
                 displayCategory.addPreference(preference);
             }
         }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsEvent.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsEvent.java
@@ -49,26 +49,19 @@ public class AnalyticsEvent {
         return new AnalyticsEvent("user-account", "logout", null, null);
     }
 
+    public static AnalyticsEvent RobotoffLoginPrompt() {
+        return new AnalyticsEvent("user-account", "login-prompt", "robotoff", null);
+    }
+
+    public static AnalyticsEvent RobotoffLoggedInAfterPrompt() {
+        return new AnalyticsEvent("user-account", "logged-in-after-prompt", "robotoff", null);
+    }
+
     public static AnalyticsEvent ShoppingListCreated() {
         return new AnalyticsEvent("shopping-lists", "created", null, null);
     }
 
     public static AnalyticsEvent ShoppingListExported() {
         return new AnalyticsEvent("shopping-lists", "exported", null, null);
-    }
-
-    public static AnalyticsEvent RobotoffSeen() {
-        return new AnalyticsEvent("robotoff", "seen", null, null);
-    }
-    public static AnalyticsEvent RobotoffAnsweredPositive() {
-        return new AnalyticsEvent("robotoff", "answered", "positive", null);
-    }
-
-    public static AnalyticsEvent RobotoffAnsweredNegative() {
-        return new AnalyticsEvent("robotoff", "answered", "negative", null);
-    }
-
-    public static AnalyticsEvent RobotoffAnsweredAmbiguous() {
-        return new AnalyticsEvent("robotoff", "answered", "ambiguous", null);
     }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsEvent.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsEvent.java
@@ -1,0 +1,74 @@
+package openfoodfacts.github.scrachx.openfood.utils;
+
+public class AnalyticsEvent {
+    public String category;
+    public String action;
+    public String name;
+    public Float value;
+
+    private AnalyticsEvent(String category, String action, String name, Float value) {
+        this.category = category;
+        this.action = action;
+        this.name = name;
+        this.value = value;
+    }
+
+    public void track() {
+        AnalyticsService.getInstance().trackEvent(this);
+    }
+
+    public static AnalyticsEvent ScannedBarcode(String barcode) {
+        return new AnalyticsEvent("scanner", "scanned", barcode, null);
+    }
+
+    public static AnalyticsEvent ScannedBarcodeResultExpanded(String barcode) {
+        return new AnalyticsEvent("scanner", "result-expanded", barcode, null);
+    }
+
+    public static AnalyticsEvent AllergenAlertCreated(String allergenCode) {
+        return new AnalyticsEvent("allergen-alerts", "created", allergenCode, null);
+    }
+
+    public static AnalyticsEvent ProductCreated(String barcode) {
+        return new AnalyticsEvent("products", "created", barcode, null);
+    }
+
+    public static AnalyticsEvent ProductEdited(String barcode) {
+        return new AnalyticsEvent("products", "edited", barcode, null);
+    }
+
+    public static AnalyticsEvent ProductIngredientsPictureEdited(String barcode) {
+        return new AnalyticsEvent("products", "edited-ingredients-picture", barcode, null);
+    }
+
+    public static AnalyticsEvent UserLogin() {
+        return new AnalyticsEvent("user-account", "login", null, null);
+    }
+
+    public static AnalyticsEvent UserLogout() {
+        return new AnalyticsEvent("user-account", "logout", null, null);
+    }
+
+    public static AnalyticsEvent ShoppingListCreated() {
+        return new AnalyticsEvent("shopping-lists", "created", null, null);
+    }
+
+    public static AnalyticsEvent ShoppingListExported() {
+        return new AnalyticsEvent("shopping-lists", "exported", null, null);
+    }
+
+    public static AnalyticsEvent RobotoffSeen() {
+        return new AnalyticsEvent("robotoff", "seen", null, null);
+    }
+    public static AnalyticsEvent RobotoffAnsweredPositive() {
+        return new AnalyticsEvent("robotoff", "answered", "positive", null);
+    }
+
+    public static AnalyticsEvent RobotoffAnsweredNegative() {
+        return new AnalyticsEvent("robotoff", "answered", "negative", null);
+    }
+
+    public static AnalyticsEvent RobotoffAnsweredAmbiguous() {
+        return new AnalyticsEvent("robotoff", "answered", "ambiguous", null);
+    }
+}

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsEvent.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsEvent.java
@@ -64,4 +64,12 @@ public class AnalyticsEvent {
     public static AnalyticsEvent ShoppingListExported() {
         return new AnalyticsEvent("shopping-lists", "exported", null, null);
     }
+
+    public static AnalyticsEvent IngredientAnalysisEnabled(String name) {
+        return new AnalyticsEvent("ingredient-analysis", "enabled", name, null);
+    }
+
+    public static AnalyticsEvent IngredientAnalysisDisabled(String name) {
+        return new AnalyticsEvent("ingredient-analysis", "disabled", name, null);
+    }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsEvent.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsEvent.java
@@ -72,4 +72,12 @@ public class AnalyticsEvent {
     public static AnalyticsEvent IngredientAnalysisDisabled(String name) {
         return new AnalyticsEvent("ingredient-analysis", "disabled", name, null);
     }
+
+    public static AnalyticsEvent AddProductToComparison(String barcode) {
+        return new AnalyticsEvent("products", "compare-add", barcode, null);
+    }
+
+    public static AnalyticsEvent CompareProducts(int count) {
+        return new AnalyticsEvent("products", "compare-multiple", null, (float) count);
+    }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsService.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsService.java
@@ -1,5 +1,6 @@
 package openfoodfacts.github.scrachx.openfood.utils;
 
+import androidx.fragment.app.FragmentManager;
 import androidx.preference.PreferenceManager;
 
 import org.matomo.sdk.Matomo;
@@ -10,6 +11,7 @@ import org.matomo.sdk.extra.TrackHelper;
 import io.sentry.android.core.SentryAndroid;
 import io.sentry.core.Sentry;
 import openfoodfacts.github.scrachx.openfood.BuildConfig;
+import openfoodfacts.github.scrachx.openfood.fragments.AnalyticsUsageBottomSheetDialogFragment;
 import openfoodfacts.github.scrachx.openfood.views.OFFApplication;
 
 public class AnalyticsService {
@@ -66,6 +68,15 @@ public class AnalyticsService {
             .name(event.name)
             .value(event.value)
             .with(tracker);
+    }
+
+    public void showAnalyticsBottomSheetIfNeeded(FragmentManager childFragmentManager) {
+        if (PreferenceManager.getDefaultSharedPreferences(OFFApplication.getInstance()).contains("privacyAnalyticsReporting")) {
+            //key already exists, do not show
+            return;
+        }
+        AnalyticsUsageBottomSheetDialogFragment bottomSheet = new AnalyticsUsageBottomSheetDialogFragment();
+        bottomSheet.show(childFragmentManager, "AnalyticsUsageBottomSheetDialogFragment");
     }
 
     private static boolean isAnalyticsEnabled() {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsService.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsService.java
@@ -1,12 +1,30 @@
 package openfoodfacts.github.scrachx.openfood.utils;
 
+import androidx.preference.PreferenceManager;
+
+import org.matomo.sdk.Matomo;
+import org.matomo.sdk.Tracker;
+import org.matomo.sdk.TrackerBuilder;
+import org.matomo.sdk.extra.TrackHelper;
+
+import io.sentry.android.core.SentryAndroid;
 import io.sentry.core.Sentry;
 import openfoodfacts.github.scrachx.openfood.BuildConfig;
+import openfoodfacts.github.scrachx.openfood.views.OFFApplication;
 
 public class AnalyticsService {
     private static AnalyticsService instance;
+    private Tracker tracker;
+    private boolean isCrashReportingEnabled;
 
     private AnalyticsService() {
+        // isCrashReportingEnabled is not dynamic, as sentry can not be enabled / disabled, so it takes the value at startup, and changes will only be taken into account after an app restart
+        isCrashReportingEnabled = PreferenceManager.getDefaultSharedPreferences(OFFApplication.getInstance()).getBoolean("privacyCrashReports", true);
+
+        //TODO: pass matomo url and id from properties, with different values depending on flavor
+        tracker = TrackerBuilder.createDefault("https://example.com/piwik.php", 1)
+            .build(Matomo.getInstance(OFFApplication.getInstance()));
+        tracker.setOptOut(!AnalyticsService.isAnalyticsEnabled());
     }
 
     public static synchronized AnalyticsService getInstance() {
@@ -17,14 +35,44 @@ public class AnalyticsService {
     }
 
     public void init() {
-        Sentry.configureScope(scope -> scope.setTag("flavor", BuildConfig.FLAVOR));
+        if (isCrashReportingEnabled) {
+            SentryAndroid.init(OFFApplication.getInstance());
+            Sentry.configureScope(scope -> scope.setTag("flavor", BuildConfig.FLAVOR));
+        }
+        TrackHelper.track().download().with(tracker);
     }
 
     public void log(String key, String value) {
-        Sentry.setTag(key, value);
+        if (isCrashReportingEnabled) {
+            Sentry.setTag(key, value);
+        }
     }
 
     public void record(Exception exception) {
-        Sentry.captureException(exception);
+        if (isCrashReportingEnabled) {
+            Sentry.captureException(exception);
+        }
+    }
+
+    public void trackView(AnalyticsView view) {
+        TrackHelper.track()
+            .screen(view.path)
+            .with(tracker);
+    }
+
+    public void trackEvent(AnalyticsEvent event) {
+        TrackHelper.track()
+            .event(event.category, event.action)
+            .name(event.name)
+            .value(event.value)
+            .with(tracker);
+    }
+
+    private static boolean isAnalyticsEnabled() {
+        return PreferenceManager.getDefaultSharedPreferences(OFFApplication.getInstance()).getBoolean("privacyAnalyticsReporting", false);
+    }
+
+    public void onAnalyticsEnabledToggled(boolean enabled) {
+        tracker.setOptOut(!enabled);
     }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsView.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/AnalyticsView.java
@@ -1,0 +1,13 @@
+package openfoodfacts.github.scrachx.openfood.utils;
+
+public enum AnalyticsView {
+    SCANNER("scanner"),
+    PRODUCT_EDIT_OVERVIEW("products/edit/overview"),
+    PRODUCT_EDIT_INGREDIENTS("products/edit/ingredients"),
+    PRODUCT_EDIT_NUTRITION_FACTS("products/edit/nutrition_facts");
+    public String path;
+
+    AnalyticsView(String path) {
+        this.path = path;
+    }
+}

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/AddProductActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/AddProductActivity.java
@@ -65,6 +65,8 @@ import openfoodfacts.github.scrachx.openfood.models.ToUploadProductDao;
 import openfoodfacts.github.scrachx.openfood.network.ApiFields;
 import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient;
 import openfoodfacts.github.scrachx.openfood.network.services.ProductsAPI;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsEvent;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsService;
 import openfoodfacts.github.scrachx.openfood.utils.OfflineProductService;
 import openfoodfacts.github.scrachx.openfood.utils.Utils;
 import openfoodfacts.github.scrachx.openfood.views.adapters.ProductFragmentPagerAdapter;
@@ -386,6 +388,12 @@ public class AddProductActivity extends AppCompatActivity {
             .show();
 
         Utils.hideKeyboard(this);
+
+        if (editingMode) {
+            AnalyticsService.getInstance().trackEvent(AnalyticsEvent.ProductEdited(productDetails.get("code")));
+        } else {
+            AnalyticsService.getInstance().trackEvent(AnalyticsEvent.ProductCreated(productDetails.get("code")));
+        }
 
         Intent intent = new Intent();
         setResult(RESULT_OK, intent);

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
@@ -279,6 +279,7 @@ public class ContinuousScanActivity extends AppCompatActivity {
                         if (productsToCompare.contains(product)) {
                             intent.putExtra("product_already_exists", true);
                         } else {
+                            AnalyticsEvent.AddProductToComparison(product.getCode()).track();
                             productsToCompare.add(product);
                         }
                         intent.putExtra(INTENT_KEY_PRODUCTS_TO_COMPARE, productsToCompare);

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ContinuousScanActivity.java
@@ -88,6 +88,9 @@ import openfoodfacts.github.scrachx.openfood.models.State;
 import openfoodfacts.github.scrachx.openfood.models.eventbus.ProductNeedsRefreshEvent;
 import openfoodfacts.github.scrachx.openfood.network.ApiFields;
 import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsEvent;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsService;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsView;
 import openfoodfacts.github.scrachx.openfood.utils.LocaleHelper;
 import openfoodfacts.github.scrachx.openfood.utils.OfflineProductService;
 import openfoodfacts.github.scrachx.openfood.utils.ProductUtils;
@@ -177,6 +180,7 @@ public class ContinuousScanActivity extends AppCompatActivity {
             lastBarcode = result.getText();
             if (!(isFinishing())) {
                 setShownProduct(lastBarcode);
+                AnalyticsService.getInstance().trackEvent(AnalyticsEvent.ScannedBarcode(lastBarcode));
             }
         }
 
@@ -598,6 +602,7 @@ public class ContinuousScanActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
+        AnalyticsService.getInstance().trackView(AnalyticsView.SCANNER);
         BottomNavigationListenerInstaller.selectNavigationItem(binding.bottomNavigation.bottomNavigation, R.id.scan_bottom_nav);
         if (bottomSheetBehavior.getState() != BottomSheetBehavior.STATE_EXPANDED) {
             binding.barcodeScanner.resume();
@@ -696,6 +701,9 @@ public class ContinuousScanActivity extends AppCompatActivity {
                 } else {
                     bottomSheetBehavior.setPeekHeight(peekLarge);
                     bottomSheet.getLayoutParams().height = ViewGroup.LayoutParams.MATCH_PARENT;
+                }
+                if (newState == BottomSheetBehavior.STATE_EXPANDED) {
+                    AnalyticsService.getInstance().trackEvent(AnalyticsEvent.ScannedBarcodeResultExpanded(lastBarcode));
                 }
                 bottomSheet.requestLayout();
             }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoginActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/LoginActivity.java
@@ -49,6 +49,7 @@ import openfoodfacts.github.scrachx.openfood.customtabs.CustomTabsHelper;
 import openfoodfacts.github.scrachx.openfood.customtabs.WebViewFallback;
 import openfoodfacts.github.scrachx.openfood.databinding.ActivityLoginBinding;
 import openfoodfacts.github.scrachx.openfood.network.services.ProductsAPI;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsEvent;
 import openfoodfacts.github.scrachx.openfood.utils.ShakeDetector;
 import openfoodfacts.github.scrachx.openfood.utils.Utils;
 import retrofit2.Retrofit;
@@ -226,6 +227,8 @@ public class LoginActivity extends BaseActivity {
 
                 binding.txtInfoLogin.setTextColor(getResources().getColor(R.color.green_500));
                 binding.txtInfoLogin.setText(R.string.txtInfoLoginOk);
+
+                AnalyticsEvent.UserLogin().track();
 
                 setResult(RESULT_OK, new Intent());
                 finish();

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -113,6 +113,7 @@ import openfoodfacts.github.scrachx.openfood.models.Product;
 import openfoodfacts.github.scrachx.openfood.models.State;
 import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient;
 import openfoodfacts.github.scrachx.openfood.utils.AnalyticsEvent;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsService;
 import openfoodfacts.github.scrachx.openfood.utils.LocaleHelper;
 import openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener;
 import openfoodfacts.github.scrachx.openfood.utils.RealPathUtil;
@@ -871,6 +872,8 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
     public void onResume() {
         super.onResume();
         BottomNavigationListenerInstaller.selectNavigationItem(binding.bottomNavigationInclude.bottomNavigation, R.id.home_page);
+
+        AnalyticsService.getInstance().showAnalyticsBottomSheetIfNeeded(getSupportFragmentManager());
 
         // change drawer menu item from "install" to "open" when navigating back from play store.
         if (Utils.isApplicationInstalled(MainActivity.this, BuildConfig.OFOTHERLINKAPP)) {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/MainActivity.java
@@ -112,6 +112,7 @@ import openfoodfacts.github.scrachx.openfood.jobs.OfflineProductWorker;
 import openfoodfacts.github.scrachx.openfood.models.Product;
 import openfoodfacts.github.scrachx.openfood.models.State;
 import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsEvent;
 import openfoodfacts.github.scrachx.openfood.utils.LocaleHelper;
 import openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener;
 import openfoodfacts.github.scrachx.openfood.utils.RealPathUtil;
@@ -596,6 +597,7 @@ public class MainActivity extends BaseActivity implements CustomTabActivityHelpe
     private void logout() {
         getSharedPreferences("login", MODE_PRIVATE).edit().clear().apply();
         updateConnectedState();
+        AnalyticsEvent.UserLogout().track();
     }
 
     @Override

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductComparisonActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductComparisonActivity.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import openfoodfacts.github.scrachx.openfood.R;
 import openfoodfacts.github.scrachx.openfood.databinding.ActivityProductComparisonBinding;
 import openfoodfacts.github.scrachx.openfood.models.Product;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsEvent;
 import openfoodfacts.github.scrachx.openfood.utils.PhotoReceiverHandler;
 import openfoodfacts.github.scrachx.openfood.utils.Utils;
 import openfoodfacts.github.scrachx.openfood.views.adapters.ProductComparisonAdapter;
@@ -58,6 +59,10 @@ public class ProductComparisonActivity extends BaseActivity {
 
         productComparisonAdapter = new ProductComparisonAdapter(products, this);
         binding.productComparisonRv.setAdapter(productComparisonAdapter);
+
+        if (products.size() > 1) {
+            AnalyticsEvent.CompareProducts(products.size()).track();
+        }
 
         binding.productComparisonButton.setOnClickListener(v -> {
             if (Utils.isHardwareCameraInstalled(ProductComparisonActivity.this)) {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductListsActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/ProductListsActivity.java
@@ -57,6 +57,8 @@ import openfoodfacts.github.scrachx.openfood.models.ProductLists;
 import openfoodfacts.github.scrachx.openfood.models.ProductListsDao;
 import openfoodfacts.github.scrachx.openfood.models.YourListedProduct;
 import openfoodfacts.github.scrachx.openfood.models.YourListedProductDao;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsEvent;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsService;
 import openfoodfacts.github.scrachx.openfood.utils.SwipeController;
 import openfoodfacts.github.scrachx.openfood.utils.SwipeControllerActions;
 import openfoodfacts.github.scrachx.openfood.utils.Utils;
@@ -159,6 +161,7 @@ public class ProductListsActivity extends BaseActivity implements SwipeControlle
                     dialog.dismiss();
                     return;
                 }
+                AnalyticsService.getInstance().trackEvent(AnalyticsEvent.ShoppingListCreated());
                 final String listName = inputEditText.getText().toString();
                 ProductLists productList = new ProductLists(listName, productToAdd != null ? 1 : 0);
                 productLists.add(productList);

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/YourListedProductsActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/YourListedProductsActivity.java
@@ -53,6 +53,8 @@ import openfoodfacts.github.scrachx.openfood.models.ProductLists;
 import openfoodfacts.github.scrachx.openfood.models.ProductListsDao;
 import openfoodfacts.github.scrachx.openfood.models.YourListedProduct;
 import openfoodfacts.github.scrachx.openfood.models.YourListedProductDao;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsEvent;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsService;
 import openfoodfacts.github.scrachx.openfood.utils.FileUtils;
 import openfoodfacts.github.scrachx.openfood.utils.LocaleHelper;
 import openfoodfacts.github.scrachx.openfood.utils.SwipeController;
@@ -216,6 +218,7 @@ public class YourListedProductsActivity extends BaseActivity implements SwipeCon
                     }
                 } else {
                     exportCSV();
+                    AnalyticsService.getInstance().trackEvent(AnalyticsEvent.ShoppingListExported());
                 }
                 return true;
             case R.id.action_sort_listed_products:

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
@@ -548,7 +548,6 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
     @Override
     public void showProductQuestion(Question question) {
         if (question != null && !question.isEmpty()) {
-            AnalyticsEvent.RobotoffSeen().track();
             productQuestion = question;
             binding.productQuestionText.setText(String.format("%s%n%s",
                 question.getQuestion(), question.getValue()));
@@ -576,21 +575,18 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
                 @Override
                 public void onPositiveFeedback(QuestionDialog dialog) {
                     //init POST request
-                    AnalyticsEvent.RobotoffAnsweredPositive().track();
                     sendProductInsights(productQuestion.getInsightId(), AnnotationAnswer.POSITIVE);
                     dialog.dismiss();
                 }
 
                 @Override
                 public void onNegativeFeedback(QuestionDialog dialog) {
-                    AnalyticsEvent.RobotoffAnsweredNegative().track();
                     sendProductInsights(productQuestion.getInsightId(), AnnotationAnswer.NEGATIVE);
                     dialog.dismiss();
                 }
 
                 @Override
                 public void onAmbiguityFeedback(QuestionDialog dialog) {
-                    AnalyticsEvent.RobotoffAnsweredAmbiguous().track();
                     sendProductInsights(productQuestion.getInsightId(), AnnotationAnswer.AMBIGUITY);
                     dialog.dismiss();
                 }
@@ -605,6 +601,7 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
 
     public void sendProductInsights(String insightId, AnnotationAnswer annotation) {
         if (!Utils.isUserLoggedIn(requireActivity())) {
+            AnalyticsEvent.RobotoffLoginPrompt().track();
             new MaterialDialog.Builder(requireActivity())
                 .title(getString(R.string.sign_in_to_answer))
                 .positiveText(getString(R.string.sign_in_or_register))
@@ -612,6 +609,7 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
                     registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
                         result -> {
                             if (result.getResultCode() == Activity.RESULT_OK) {
+                                AnalyticsEvent.RobotoffLoggedInAfterPrompt().track();
                                 dialog.dismiss();
                                 processInsight(insightId, annotation);
                             }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/summary/SummaryProductFragment.java
@@ -84,6 +84,7 @@ import openfoodfacts.github.scrachx.openfood.models.Tag;
 import openfoodfacts.github.scrachx.openfood.models.TagDao;
 import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient;
 import openfoodfacts.github.scrachx.openfood.network.WikiDataApiClient;
+import openfoodfacts.github.scrachx.openfood.utils.AnalyticsEvent;
 import openfoodfacts.github.scrachx.openfood.utils.BottomScreenCommon;
 import openfoodfacts.github.scrachx.openfood.utils.FragmentUtils;
 import openfoodfacts.github.scrachx.openfood.utils.ImageUploadListener;
@@ -547,6 +548,7 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
     @Override
     public void showProductQuestion(Question question) {
         if (question != null && !question.isEmpty()) {
+            AnalyticsEvent.RobotoffSeen().track();
             productQuestion = question;
             binding.productQuestionText.setText(String.format("%s%n%s",
                 question.getQuestion(), question.getValue()));
@@ -574,18 +576,21 @@ public class SummaryProductFragment extends BaseFragment implements CustomTabAct
                 @Override
                 public void onPositiveFeedback(QuestionDialog dialog) {
                     //init POST request
+                    AnalyticsEvent.RobotoffAnsweredPositive().track();
                     sendProductInsights(productQuestion.getInsightId(), AnnotationAnswer.POSITIVE);
                     dialog.dismiss();
                 }
 
                 @Override
                 public void onNegativeFeedback(QuestionDialog dialog) {
+                    AnalyticsEvent.RobotoffAnsweredNegative().track();
                     sendProductInsights(productQuestion.getInsightId(), AnnotationAnswer.NEGATIVE);
                     dialog.dismiss();
                 }
 
                 @Override
                 public void onAmbiguityFeedback(QuestionDialog dialog) {
+                    AnalyticsEvent.RobotoffAnsweredAmbiguous().track();
                     sendProductInsights(productQuestion.getInsightId(), AnnotationAnswer.AMBIGUITY);
                     dialog.dismiss();
                 }

--- a/app/src/main/res/layout/fragment_analytics_usage_bottom_sheet.xml
+++ b/app/src/main/res/layout/fragment_analytics_usage_bottom_sheet.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:weightSum="1">
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/title"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    android:text="@string/preference_analytics_bottom_sheet_title"
+                    android:textAlignment="center"
+                    android:textAppearance="@style/Base.TextAppearance.AppCompat.Medium"
+                    android:textStyle="bold"
+                    android:gravity="center_horizontal" />
+
+                <TextView
+                    android:id="@+id/message"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="16dp"
+                    android:text="@string/preference_analytics_bottom_sheet_description"
+                    android:textAppearance="@style/Base.TextAppearance.AppCompat.Small" />
+
+            </LinearLayout>
+        </ScrollView>
+
+        <Button
+            android:id="@+id/grant_button"
+            style="@style/Base.Widget.AppCompat.Button.Borderless"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_weight="2"
+            android:text="@string/preference_analytics_bottom_sheet_grant_button"
+            android:textColor="@color/colorPrimary"
+            android:textStyle="bold" />
+
+        <Button
+            android:id="@+id/decline_button"
+            style="@style/Base.Widget.AppCompat.Button.Borderless"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_weight="2"
+            android:text="@string/preference_analytics_bottom_sheet_decline_button"
+            android:textColor="@color/gray" />
+
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -726,6 +726,12 @@
     <string name="preference_header_network">Network</string>
     <string name="preference_header_about" translatable="false">@string/action_about</string>
     <string name="preference_header_contributing">Contributing</string>
+    <string name="preference_header_privacy">Privacy</string>
+
+    <string name="preference_crash_title">Crash reporting</string>
+    <string name="preference_crash_summary">When enabled, crash reports will be sent to the Open Food Facts server automatically, so that we can fix bugs and improve the app.</string>
+    <string name="preference_analytics_title">Send anonymous data</string>
+    <string name="preference_analytics_summary">When enabled, some anonymous information regarding app usage will be sent to the Open Food Facts servers, so that we can understand how and how much features are used in order to improve them.</string>
 
     <string name="scan_first_string">Your viewed product history will be listed here.\nThis history is for your eyes only and is stored locally.</string>
     <string name="log_in">Login</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -732,6 +732,10 @@
     <string name="preference_crash_summary">When enabled, crash reports will be sent to the Open Food Facts server automatically, so that we can fix bugs and improve the app.</string>
     <string name="preference_analytics_title">Send anonymous data</string>
     <string name="preference_analytics_summary">When enabled, some anonymous information regarding app usage will be sent to the Open Food Facts servers, so that we can understand how and how much features are used in order to improve them.</string>
+    <string name="preference_analytics_bottom_sheet_title">Send anonymous data</string>
+    <string name="preference_analytics_bottom_sheet_description">Help improve Open Food Facts by letting us know how you use it. Data collected is anonymous. This option can be disabled at any time in the settings section.</string>
+    <string name="preference_analytics_bottom_sheet_grant_button">Grant</string>
+    <string name="preference_analytics_bottom_sheet_decline_button">Decline</string>
 
     <string name="scan_first_string">Your viewed product history will be listed here.\nThis history is for your eyes only and is stored locally.</string>
     <string name="log_in">Login</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -139,6 +139,26 @@
 
     <PreferenceCategory
         android:summary=""
+        android:title="@string/preference_header_privacy">
+
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="privacyCrashReports"
+            android:summaryOn="@string/preference_crash_summary"
+            android:summaryOff="@string/preference_crash_summary"
+            android:title="@string/preference_crash_title" />
+
+        <SwitchPreference
+            android:defaultValue="false"
+            android:key="privacyAnalyticsReporting"
+            android:summaryOn="@string/preference_analytics_summary"
+            android:summaryOff="@string/preference_analytics_summary"
+            android:title="@string/preference_analytics_title" />
+
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:summary=""
         android:title="@string/preference_header_about">
 
         <Preference


### PR DESCRIPTION
**Type of Changes:** New feature

⚠️ Nothing is operational yet, as we don't have the Matomo server for now.

### TODO List:
- [x] ask the user at first open if he agreed to be tracked (default to false) (TODO)
- [x] in the preferences screen, allow to enable / disable tracking
- [x] in the preferences screen, allow disabling crash reporting


### Proposed changes
Integrates anonymous Matomo analytics tracking

**Views tracked:**
- scanner view
- products/edit/overview
- products/edit/ingredients
- products/edit/nutrition_facts

**Events tracked:**
- scanner scanned (with barcode as event name)
- scanner result card swiped up (with barcode as event name)
- allergen alert added (with allergen tag as event name)
- ingredient-analysis
  - enabled (with name of ingredient analysis)
  - disabled (with name of ingredient analysis)
- user-account
  - login
  - logout
  - login prompt (name: robotoff)
  - logged-in-after-prompt (name: robotoff)
- products :
  - created (with barcode as event name)
  - edited (with barcode as event name)
  - edited-ingredients-picture (added a product’s ingredients picture) (with barcode as event name)
  - compare-multiple : multiple products are being compared (triggered if products count > 1 with products count in event value)
  - compare-add : a product has been added for comparison
- shopping lists :
  - created
  - exported

### Screenshots
![Screenshot_20200805-150506](https://user-images.githubusercontent.com/920265/89418188-0590d000-d730-11ea-8715-12d13909528b.jpg)

![Screenshot_1595668051](https://user-images.githubusercontent.com/920265/88455741-37747d80-ce78-11ea-8527-2dda1c2cc9c2.png)
