### PR TITLE
Feat : #2963 - Add onboarding tooltip on first use for image editing

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/TipBox.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/TipBox.java
@@ -47,7 +47,12 @@ public class TipBox extends LinearLayout {
         int marginStart = attributes.getDimensionPixelSize(R.styleable.TipBox_arrowMarginStart, 0);
         int marginEnd = attributes.getDimensionPixelSize(R.styleable.TipBox_arrowMarginEnd, 0);
         int arrowAlignment = attributes.getInt(R.styleable.TipBox_arrowAlignment, Gravity.START);
+        boolean canDisplayImmediately = attributes.getBoolean(R.styleable.TipBox_shouldDisplayImmediately, false);
         setArrowAlignment(arrowAlignment, marginStart, marginEnd);
+        int toolTipTextColor = attributes.getColor(R.styleable.TipBox_textColor, getResources().getColor(R.color.md_black_1000));
+        int toolTipBackgroundColor = attributes.getColor(R.styleable.TipBox_backgroundColor,
+            getResources().getColor(R.color.brand_light_blue));
+        attributes.recycle();
 
         // gone by default
         setVisibility(View.GONE);
@@ -58,13 +63,10 @@ public class TipBox extends LinearLayout {
 
         prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
         //Tooltip should be shown the first time the actual content is available
-        boolean canDisplayImmediately = attributes.getBoolean(R.styleable.TipBox_shouldDisplayImmediately, false);
-        tipMessage.setTextColor(attributes.getColor(R.styleable.TipBox_textColor, getResources().getColor(R.color.md_black_1000)));
-        int toolTipColor = attributes.getColor(R.styleable.TipBox_backgroundColor,
-            getResources().getColor(R.color.brand_light_blue));
-        findViewById(R.id.tipBoxContainer).setBackgroundColor(toolTipColor);
-        arrow.setColorFilter(toolTipColor);
-        attributes.recycle();
+
+        tipMessage.setTextColor(toolTipTextColor);
+        findViewById(R.id.tipBoxContainer).setBackgroundColor(toolTipBackgroundColor);
+        arrow.setColorFilter(toolTipBackgroundColor);
         if (canDisplayImmediately) {
             loadToolTip();
         }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/TipBox.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/TipBox.java
@@ -49,8 +49,6 @@ public class TipBox extends LinearLayout {
         int arrowAlignment = attributes.getInt(R.styleable.TipBox_arrowAlignment, Gravity.START);
         setArrowAlignment(arrowAlignment, marginStart, marginEnd);
 
-        attributes.recycle();
-
         // gone by default
         setVisibility(View.GONE);
         findViewById(R.id.gotItBtn).setOnClickListener(v -> {
@@ -59,21 +57,17 @@ public class TipBox extends LinearLayout {
         });
 
         prefs = PreferenceManager.getDefaultSharedPreferences(getContext());
-        boolean show = prefs.getBoolean(identifier, true);
-        if (!show) {
-            return;
+        //Tooltip should be shown the first time the actual content is available
+        boolean canDisplayImmediately = attributes.getBoolean(R.styleable.TipBox_shouldDisplayImmediately, false);
+        tipMessage.setTextColor(attributes.getColor(R.styleable.TipBox_textColor, getResources().getColor(R.color.md_black_1000)));
+        int toolTipColor = attributes.getColor(R.styleable.TipBox_backgroundColor,
+            getResources().getColor(R.color.brand_light_blue));
+        findViewById(R.id.tipBoxContainer).setBackgroundColor(toolTipColor);
+        arrow.setColorFilter(toolTipColor);
+        attributes.recycle();
+        if (canDisplayImmediately) {
+            loadToolTip();
         }
-
-        getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
-            @Override
-            public boolean onPreDraw() {
-                Handler handler = new Handler();
-                handler.postDelayed(TipBox.this::show, 500);
-
-                getViewTreeObserver().removeOnPreDrawListener(this);
-                return true;
-            }
-        });
     }
 
     public void setIdentifier(String identifier) {
@@ -159,6 +153,23 @@ public class TipBox extends LinearLayout {
         // Collapse speed of 1dp/ms
         anim.setDuration((int) (initialHeight / getContext().getResources().getDisplayMetrics().density));
         startAnimation(anim);
+    }
+
+    public void loadToolTip() {
+        boolean show = prefs.getBoolean(identifier, true);
+        if (!show) {
+            return;
+        }
+        getViewTreeObserver().addOnPreDrawListener(new ViewTreeObserver.OnPreDrawListener() {
+            @Override
+            public boolean onPreDraw() {
+                Handler handler = new Handler();
+                handler.postDelayed(TipBox.this::show, 500);
+
+                getViewTreeObserver().removeOnPreDrawListener(this);
+                return true;
+            }
+        });
     }
 
     public void hide() {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/product/ingredients/IngredientsProductFragment.java
@@ -196,6 +196,8 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
         presenter.loadAdditives();
 
         if (isNotBlank(product.getImageIngredientsUrl(langCode))) {
+            binding.ingredientImagetipBox.setTipMessage(getString(R.string.onboarding_hint_msg, getString(R.string.ingredient_image_edit_tip)));
+            binding.ingredientImagetipBox.loadToolTip();
             binding.addPhotoLabel.setVisibility(View.GONE);
             binding.changeIngImg.setVisibility(View.VISIBLE);
 

--- a/app/src/main/res/layout/fragment_ingredients_product.xml
+++ b/app/src/main/res/layout/fragment_ingredients_product.xml
@@ -27,15 +27,29 @@
                 android:orientation="vertical"
                 android:paddingBottom="@dimen/nav_bar_height">
 
+                <openfoodfacts.github.scrachx.openfood.views.TipBox
+                    android:id="@+id/ingredientImagetipBox"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/activity_vertical_margin"
+                    app:arrowAlignment="center"
+                    app:arrowMarginStart="0dp"
+                    app:shouldDisplayImmediately="false"
+                    app:backgroundColor="@android:color/holo_green_light"
+                    app:textColor="@android:color/white"
+                    android:visibility="gone"
+                    app:identifier="ingredient_image_tip_box"
+                    app:message="@string/ingredient_image_edit_tip" />
+
                 <ImageButton
                     android:id="@+id/imageViewIngredients"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
                     android:layout_marginLeft="@dimen/spacing_normal"
-                    android:layout_marginTop="@dimen/activity_vertical_margin"
                     android:layout_marginRight="@dimen/spacing_normal"
                     android:adjustViewBounds="true"
+                    android:layout_marginTop="@dimen/spacing_tiny"
                     android:background="?android:selectableItemBackground"
                     android:maxHeight="120dp"
                     android:scaleType="fitCenter"

--- a/app/src/main/res/layout/fragment_summary_product.xml
+++ b/app/src/main/res/layout/fragment_summary_product.xml
@@ -257,6 +257,7 @@
                         android:layout_height="wrap_content"
                         app:arrowAlignment="start"
                         app:arrowMarginStart="0dp"
+                        app:shouldDisplayImmediately="true"
                         app:identifier="ingredient_analysis_tip_box"
                         app:message="@string/ingredient_analysis_tip" />
 

--- a/app/src/main/res/layout/tip_box.xml
+++ b/app/src/main/res/layout/tip_box.xml
@@ -9,6 +9,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:id="@+id/tipBoxContainer"
         android:background="@color/brand_light_blue"
         android:gravity="center"
         android:orientation="horizontal"
@@ -38,8 +39,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:scaleType="fitXY"
-        android:tint="@color/brand_light_blue"
         app:srcCompat="@drawable/ic_tip_box_down_arrow"
-        tools:ignore="ContentDescription" />
+        tools:ignore="ContentDescription"
+        app:tint="@color/brand_light_blue" />
 
 </LinearLayout>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -35,6 +35,9 @@
         <attr name="animate" format="boolean" />
         <attr name="message" format="string" />
         <attr name="identifier" format="string" />
+        <attr name="shouldDisplayImmediately" format="boolean"/>
+        <attr name="backgroundColor" format="color"/>
+        <attr name="textColor" format="color"/>
         <attr name="arrowMarginStart" format="dimension" />
         <attr name="arrowMarginEnd" format="dimension" />
         <attr name="arrowAlignment" format="string">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1040,6 +1040,8 @@
     <string name="tip_message">TIP: %1$s </string>
     <string name="ingredient_analysis_tip">Click on the icons below to learn more about the product and to select what information you are interested in.</string>
     <string name="got_it">Got it!</string>
+    <string name="onboarding_hint_msg">Hint: %s </string>
+    <string name="ingredient_image_edit_tip">Tap on the image to zoom it, change it, crop it, rotate it and more…</string>
     <string name="ingredients_in_this_product_are">Ingredients in this product are %1$s.</string>
     <string name="ingredients_in_this_product">Ingredients in this product that are %1$s:</string>
     <string name="display_analysis_tag_status">Display %1$s status</string>


### PR DESCRIPTION
*Display tool tip for ingredients image
*Load it the first time only when the image is available. The tooltip will not be shown if the user first taps on an ingredient which has no image associated
*Added customization to the tooltip to configure background and text color