### PR TITLE
Fix ssl handshake issues on android 7

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/ProductsRecyclerViewAdapter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/views/adapters/ProductsRecyclerViewAdapter.java
@@ -12,6 +12,7 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.squareup.picasso.Callback;
+import com.squareup.picasso.OkHttp3Downloader;
 import com.squareup.picasso.Picasso;
 
 import org.apache.commons.lang.StringUtils;
@@ -32,8 +33,8 @@ public class ProductsRecyclerViewAdapter extends RecyclerView.Adapter<ProductsRe
     private static final int VIEW_ITEM = 1;
     private static final int VIEW_LOAD = 0;
     private Context context;
-    private final List<Product> products;
     private final boolean isLowBatteryMode;
+    private final List<Product> products;
 
     public ProductsRecyclerViewAdapter(List<Product> items, boolean isLowBatteryMode) {
         this.products = items;
@@ -76,8 +77,9 @@ public class ProductsRecyclerViewAdapter extends RecyclerView.Adapter<ProductsRe
 
         // Load Image if isLowBatteryMode is false
         if (!isLowBatteryMode) {
-            Picasso.get()
-                .load(imageSmallUrl)
+            new Picasso.Builder(context)
+                .downloader(new OkHttp3Downloader(Utils.httpClientBuilder()))
+                .build().load(imageSmallUrl)
                 .placeholder(R.drawable.placeholder_thumb)
                 .error(R.drawable.error_image)
                 .fit()


### PR DESCRIPTION
**Description**
1. The issue was happening because of `javax.net.ssl.SSLHandshakeException`. To fix this I changed the TLS version to 1.2 since that's the maximum version our backend supports.
2. A complete report for the accepted cipher suites and protocols that we support can be checked at [ssllabs](https://www.ssllabs.com/ssltest/analyze.html?d=ssl-api.openfoodfacts.org)
3. Tested on Android versions 5.0 to 11.0 (including both)

**Closes**
https://github.com/openfoodfacts/openfoodfacts-androidapp/issues/3527