### PR TITLE
Remove distributionSha256Sum from gradle-wrapper.properties

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
-#Tue Oct 13 15:31:53 CEST 2020
+#Sat Oct 17 01:48:10 IST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
-distributionSha256Sum=23e7d37e9bb4f8dabb8a3ea7fdee9dd0428b9b1a71d298aefd65b11dccea220f


### PR DESCRIPTION
**Description**
1. We get the below error after cloning and syncing the project, this happens because we had `distributionSha256Sum` present, since the sha256 can be different for different os versions like Window, Darwin or Linux then Android Studio throws an error.
2. We also got a query on slack for the same. The slack thread can be viewed [here](https://openfoodfacts.slack.com/archives/C02KVRT2C/p1602744257092500).
3. Android Studio itself suggests to remove distributionSha256Sum and sync the project.
4. Related issue https://github.com/gradle/gradle/issues/9361

**Screenshot**
![image (1)](https://user-images.githubusercontent.com/10832531/96306429-499c2d00-101d-11eb-846a-30495c59f627.png)

