### PR TITLE
Add right text when toggles are enabled in preferences

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1089,4 +1089,5 @@
     <string name="sign_in_or_register">Sign in or register</string>
     <string name="hunger_game_call_to_action">Help classify more %1$s</string>
     <string name="txtHomeOnline">Open Food Facts is an open database of more than %1$s food products (plus the ones you will contribute).</string>
+    <string name="enabled">Enabled</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -43,13 +43,15 @@
         <SwitchPreference
             android:defaultValue="false"
             android:key="startScan"
-            android:summary="@string/prefs_scan_startup_summary"
+            android:summaryOff="@string/prefs_scan_startup_summary"
+            android:summaryOn="Enabled"
             android:title="@string/prefs_scan_startup" />
 
         <SwitchPreference
             android:defaultValue="false"
             android:key="powerMode"
-            android:summary="@string/prefs_power_mode_summary"
+            android:summaryOn="Enabled"
+            android:summaryOff="@string/prefs_power_mode_summary"
             android:title="@string/prefs_power_mode" />
 
 
@@ -77,7 +79,8 @@
         <SwitchPreference
             android:defaultValue="false"
             android:key="disableImageLoad"
-            android:summary="@string/disable_image_loading"
+            android:summaryOn="Enabled"
+            android:summaryOff="@string/disable_image_loading"
             android:title="@string/DisableLoadTitle" />
 
     </PreferenceCategory>
@@ -110,24 +113,28 @@
         <SwitchPreference
             android:defaultValue="true"
             android:key="cropNewImage"
-            android:summary="@string/crop_new_image"
+            android:summaryOn="Enabled"
+            android:summaryOff="@string/crop_new_image"
             android:title="@string/crop_new_image_title" />
 
         <SwitchPreference
             android:defaultValue="true"
             android:key="fastAdditionMode"
-            android:summary="@string/fast_addition_mode"
+            android:summaryOn="Enabled"
+            android:summaryOff="@string/fast_addition_mode"
             android:title="@string/fast_addition_mode_title" />
 
         <SwitchPreference
             android:defaultValue="false"
             android:key="contributionTab"
-            android:summary="@string/contribution_tab_summary"
+            android:summaryOn="Enabled"
+            android:summaryOff="@string/contribution_tab_summary"
             android:title="@string/contribution_tab_title" />
         <SwitchPreference
             android:defaultValue="false"
             android:key="photoMode"
-            android:summary="@string/preference_show_all_product_photos_summary"
+            android:summaryOn="Enabled"
+            android:summaryOff="@string/preference_show_all_product_photos_summary"
             android:title="@string/preference_show_all_product_photos_title" />
 
     </PreferenceCategory>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -44,13 +44,13 @@
             android:defaultValue="false"
             android:key="startScan"
             android:summaryOff="@string/prefs_scan_startup_summary"
-            android:summaryOn="Enabled"
+            android:summaryOn="@string/enabled"
             android:title="@string/prefs_scan_startup" />
 
         <SwitchPreference
             android:defaultValue="false"
             android:key="powerMode"
-            android:summaryOn="Enabled"
+            android:summaryOn="@string/enabled"
             android:summaryOff="@string/prefs_power_mode_summary"
             android:title="@string/prefs_power_mode" />
 
@@ -79,7 +79,7 @@
         <SwitchPreference
             android:defaultValue="false"
             android:key="disableImageLoad"
-            android:summaryOn="Enabled"
+            android:summaryOn="@string/enabled"
             android:summaryOff="@string/disable_image_loading"
             android:title="@string/DisableLoadTitle" />
 
@@ -113,27 +113,27 @@
         <SwitchPreference
             android:defaultValue="true"
             android:key="cropNewImage"
-            android:summaryOn="Enabled"
+            android:summaryOn="@string/enabled"
             android:summaryOff="@string/crop_new_image"
             android:title="@string/crop_new_image_title" />
 
         <SwitchPreference
             android:defaultValue="true"
             android:key="fastAdditionMode"
-            android:summaryOn="Enabled"
+            android:summaryOn="@string/enabled"
             android:summaryOff="@string/fast_addition_mode"
             android:title="@string/fast_addition_mode_title" />
 
         <SwitchPreference
             android:defaultValue="false"
             android:key="contributionTab"
-            android:summaryOn="Enabled"
+            android:summaryOn="@string/enabled"
             android:summaryOff="@string/contribution_tab_summary"
             android:title="@string/contribution_tab_title" />
         <SwitchPreference
             android:defaultValue="false"
             android:key="photoMode"
-            android:summaryOn="Enabled"
+            android:summaryOn="@string/enabled"
             android:summaryOff="@string/preference_show_all_product_photos_summary"
             android:title="@string/preference_show_all_product_photos_title" />
 


### PR DESCRIPTION
####  Description
<!--Give a small description related to the changes you have made.-->
Add right text when toggles are enabled in preferences

#### Related issues
<!--
- Add the issue number here.
- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- If you have solved the issue completely use "Fixes #{issue_number}, example: "Fixes #123, #345".
-->

#### Related PRs
<!-- Link to all the related PRs openfoodfacts-androidapp, openfoodfacts-server, openfoodfacts-ios, etc. -->

#### Screenshots
<!-- If possible, please add relevant screenshots / GIFs -->
**Before**
![Screenshot_20201020-181135_OpenFoodFacts](https://user-images.githubusercontent.com/29518411/96668712-c125d100-1329-11eb-94aa-74b57a687f97.jpg)

**After**
![Screenshot_20201020-180929_OpenFoodFacts](https://user-images.githubusercontent.com/29518411/96668723-c7b44880-1329-11eb-8378-7fb295f8c047.jpg)

