### PR TITLE
Lang pref crash

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/HomeFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/HomeFragment.java
@@ -97,7 +97,9 @@ public class HomeFragment extends NavigationBaseFragment {
     @Override
     public void onDestroy() {
         // Stop the call to server to get total product count and tagline
-        compDisp.dispose();
+        if (compDisp != null) {
+            compDisp.dispose();
+        }
         binding = null;
         super.onDestroy();
     }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/HomeFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/HomeFragment.java
@@ -64,7 +64,7 @@ public class HomeFragment extends NavigationBaseFragment {
     private static final String LOG_TAG = HomeFragment.class.getSimpleName();
     private FragmentHomeBinding binding;
     private ProductsAPI api;
-    private CompositeDisposable compDisp;
+    private final CompositeDisposable compDisp = new CompositeDisposable();
     private String taglineURL;
     private SharedPreferences sharedPrefs;
 
@@ -78,7 +78,6 @@ public class HomeFragment extends NavigationBaseFragment {
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        compDisp = new CompositeDisposable();
         binding = FragmentHomeBinding.inflate(inflater, container, false);
         return binding.getRoot();
     }
@@ -97,9 +96,7 @@ public class HomeFragment extends NavigationBaseFragment {
     @Override
     public void onDestroy() {
         // Stop the call to server to get total product count and tagline
-        if (compDisp != null) {
-            compDisp.dispose();
-        }
+        compDisp.dispose();
         binding = null;
         super.onDestroy();
     }


### PR DESCRIPTION
####  Description
Fix Null Pointer Exception on changing language preference.
Occurs when you change the language preference for the second time.
**LOGS**
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void io.reactivex.disposables.CompositeDisposable.dispose()' on a null object reference
at openfoodfacts.github.scrachx.openfood.features.HomeFragment.onDestroy(HomeFragment.java:100)
at androidx.fragment.app.Fragment.performDestroy(Fragment.java:3205)
at androidx.fragment.app.FragmentStateManager.destroy(FragmentStateManager.java:758)

#### Related issues
<!--
- Add the issue number here.
- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- If you have solved the issue completely use "Fixes #{issue_number}, example: "Fixes #123, #345".
-->

#### Related PRs
<!-- Link to all the related PRs openfoodfacts-androidapp, openfoodfacts-server, openfoodfacts-ios, etc. -->

#### Screenshots
<!-- If possible, please add relevant screenshots / GIFs -->
