### PR TITLE
Fix crash caused by ISE on the 3 screens

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/MainActivity.java
@@ -162,8 +162,8 @@ public class MainActivity extends BaseActivity implements NavigationDrawerListen
     private CompositeDisposable disp;
     ActivityResultLauncher<Void> loginActivityResultLauncher = registerForActivityResult(
         new LoginActivity.LoginContract(),
-        (ActivityResultCallback<Boolean>) result -> {
-            if (result){
+        (ActivityResultCallback<Boolean>) isLoggedIn -> {
+            if (isLoggedIn) {
                 updateConnectedState();
             }
         });

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/MainActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/MainActivity.java
@@ -42,6 +42,8 @@ import android.widget.EditText;
 import android.widget.SearchView;
 import android.widget.Toast;
 
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
@@ -158,6 +160,13 @@ public class MainActivity extends BaseActivity implements NavigationDrawerListen
     private String barcode;
     private PrefManager prefManager;
     private CompositeDisposable disp;
+    ActivityResultLauncher<Void> loginActivityResultLauncher = registerForActivityResult(
+        new LoginActivity.LoginContract(),
+        (ActivityResultCallback<Boolean>) result -> {
+            if (result){
+                updateConnectedState();
+            }
+        });
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -334,11 +343,7 @@ public class MainActivity extends BaseActivity implements NavigationDrawerListen
                         break;
 
                     case ITEM_LOGIN:
-                        registerForActivityResult(new LoginActivity.LoginContract(), isLoggedIn -> {
-                            if (isLoggedIn) {
-                                updateConnectedState();
-                            }
-                        }).launch(null);
+                        loginActivityResultLauncher.launch(null);
                         break;
 
                     case ITEM_ALERT:

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ingredients/IngredientsProductFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ingredients/IngredientsProductFragment.java
@@ -32,6 +32,10 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.browser.customtabs.CustomTabsIntent;
@@ -107,6 +111,22 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
      **/
     private boolean isLowBatteryMode = false;
     private PhotoReceiverHandler photoReceiverHandler;
+    ActivityResultLauncher<Product> productActivityResultLauncher = registerForActivityResult(
+        new ProductEditActivity.EditProductSendUpdatedImg(),
+        (ActivityResultCallback<Boolean>) result -> {
+            if (result) {
+                onRefresh();
+            }
+        });
+    ActivityResultLauncher<Void> loginActivityResultLauncher = registerForActivityResult(
+        new LoginActivity.LoginContract(),
+        (ActivityResultCallback<Boolean>) result -> {
+            ProductEditActivity.start(getContext(),
+                activityProductState,
+                sendUpdatedIngredientsImage,
+                extractIngredients);
+        });
+
 
     @Override
     public void onAttach(@NonNull Context context) {
@@ -425,11 +445,7 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
             } else {
                 activityProductState = FragmentUtils.getStateFromArguments(this);
                 if (activityProductState != null) {
-                    registerForActivityResult(new ProductEditActivity.EditProductSendUpdatedImg(), result -> {
-                        if (result) {
-                            onRefresh();
-                        }
-                    }).launch(activityProductState.getProduct());
+                    productActivityResultLauncher.launch(activityProductState.getProduct());
                 }
             }
         }
@@ -499,11 +515,7 @@ public class IngredientsProductFragment extends BaseFragment implements IIngredi
             .positiveText(R.string.txtSignIn)
             .negativeText(R.string.dialog_cancel)
             .onPositive((dialog, which) -> {
-                registerForActivityResult(new LoginActivity.LoginContract(), isLoggedIn ->
-                    ProductEditActivity.start(getContext(),
-                        activityProductState,
-                        sendUpdatedIngredientsImage,
-                        extractIngredients)).launch(null);
+                loginActivityResultLauncher.launch(null);
                 dialog.dismiss();
             })
             .onNegative((dialog, which) -> dialog.dismiss())

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/scan/ContinuousScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/scan/ContinuousScanActivity.java
@@ -34,6 +34,9 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.activity.result.ActivityResult;
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -159,6 +162,11 @@ public class ContinuousScanActivity extends AppCompatActivity {
     private SummaryProductPresenter summaryProductPresenter;
     private Disposable hintBarcodeDisp;
     private CompositeDisposable commonDisp;
+    ActivityResultLauncher<Intent> productActivityResultLauncher = registerForActivityResult(
+        new ActivityResultContracts.StartActivityForResult(),
+        (ActivityResultCallback<ActivityResult>) result -> {
+            setShownProduct(lastBarcode);
+        });
 
     /**
      * Used by screenshot tests.
@@ -491,11 +499,7 @@ public class ContinuousScanActivity extends AppCompatActivity {
     private void navigateToProductAddition(Product product) {
         Intent intent = new Intent(ContinuousScanActivity.this, ProductEditActivity.class);
         intent.putExtra(ProductEditActivity.KEY_EDIT_PRODUCT, product);
-        registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
-            if (result.getResultCode() == RESULT_OK) {
-                setShownProduct(lastBarcode);
-            }
-        }).launch(intent);
+        productActivityResultLauncher.launch(intent);
     }
 
     private void showAllViews() {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/scan/ContinuousScanActivity.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/scan/ContinuousScanActivity.java
@@ -165,7 +165,9 @@ public class ContinuousScanActivity extends AppCompatActivity {
     ActivityResultLauncher<Intent> productActivityResultLauncher = registerForActivityResult(
         new ActivityResultContracts.StartActivityForResult(),
         (ActivityResultCallback<ActivityResult>) result -> {
-            setShownProduct(lastBarcode);
+            if (result.getResultCode() == RESULT_OK) {
+                setShownProduct(lastBarcode);
+            }
         });
 
     /**


### PR DESCRIPTION
####  Description
startActivityForResult() was depreciated. The replacement for that was recently done in the code but not implemented correctly causing ISE.
Documentation : https://developer.android.com/training/basics/intents/result

#### Related issues
Closes #3559 
<!--
- Add the issue number here.
- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- If you have solved the issue completely use "Fixes #{issue_number}, example: "Fixes #123, #345".
-->

#### Related PRs
<!-- Link to all the related PRs openfoodfacts-androidapp, openfoodfacts-server, openfoodfacts-ios, etc. -->

#### Screenshots
<!-- If possible, please add relevant screenshots / GIFs -->
