### PR TITLE
Fastlane beta script now uses the version indicated in the branch name

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,11 +16,10 @@ lane :release do
     PACKAGE_NAME = CredentialsManager::AppfileConfig.try_fetch_value(:package_name)
     gradle_file = "./app/build.gradle.kts"
 
-    localVersionName = android_get_version_name(gradle_file: gradle_file)
-    UI.important "Local is v#{localVersionName}"
+    #fetch versionName from current release branch name
+    versionName = version_to_use_from_git_branch(gitBranch: git_branch).to_s
+    UI.important "Using versionName #{versionName}"
 
-    #fetch versionName from playstore and bump minor if needed
-    versionName = play_store_version_to_upload_to(minimumVersionName: localVersionName).to_s
     #fetch versionCode from playstore and bump it
     versionCode = play_store_version_code_to_upload_to().to_s
 

--- a/fastlane/utils.rb
+++ b/fastlane/utils.rb
@@ -31,3 +31,13 @@ def play_store_version_to_upload_to(minimumVersionName: '0.0.1')
     }
     return versionParsed.to_s
 end
+
+def version_to_use_from_git_branch(gitBranch:)
+    if gitBranch =~ /release\/[0-9]+\.[0-9]+\.[0-9]+/
+        gitBranchVersion = gitBranch.split('release/')[1]
+        gitBranchVersionParsed = Versionomy.parse(gitBranchVersion)
+        puts "Using version name #{gitBranchVersionParsed} (from current branch name #{gitBranch})"
+        return gitBranchVersionParsed
+    end
+    FastlaneCore::UI.user_error!("ERROR: we are not on a release/x.y.z branch, no version could be inferred.")
+end


### PR DESCRIPTION
For example, if pushing on the release/3.4.1 branch, then the internal build will use the version 3.4.1.

PR Description
Proposed changes

before, the "fastlane release" script would push a build on the play store internal using the latest version used in the play store. 
This leads to problems when code is pushed on two different "release/xxx" branches (as a push on release/4.3 would trigger a build with version 4.3.1 if any already exists).
Now, the script use the version specified in the name branch, so a push on release/4.3 will trigger a build with the version set to 4.3