### PR TITLE
Finalize Sentry release (to mark it as live)

### DIFF
--- a/.github/workflows/android-release-sentry.yml
+++ b/.github/workflows/android-release-sentry.yml
@@ -1,0 +1,41 @@
+name: Finalize Sentry release
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  finalize-sentry-release:
+    name: Finalize Sentry release
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Decrypt api json file
+        run: cd ./fastlane/envfiles && ./decrypt_secrets.sh
+        env:
+          API_JSON_FILE_DECRYPTKEY: ${{ secrets.API_JSON_FILE_DECRYPTKEY }}
+          STORE_JKS_DECRYPTKEY: ${{ secrets.STORE_JKS_DECRYPTKEY }}
+
+      - name: Set up Ruby 2.6
+        uses: actions/setup-ruby@v1.1.2
+        with:
+          ruby-version: 2.6.x
+
+      - name: Install sentry-cli
+        run: curl -sL https://sentry.io/get-cli/ | bash
+
+      - name: Install Dependencies
+        run: gem install bundler && bundle install
+
+      - name: Run Fastlane finalize_sentry lane
+        run: bundle exec fastlane finalize_sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          CI_RELEASE: true
+          SIGN_STORE_PATH: ../fastlane/envfiles/keystore.jks
+          SIGN_STORE_PASSWORD: ${{ secrets.SIGN_STORE_PASSWORD }}
+          SIGN_KEY_ALIAS: ${{ secrets.SIGN_KEY_ALIAS }}
+          SIGN_KEY_PASSWORD: ${{ secrets.SIGN_KEY_PASSWORD }}
+

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -59,7 +59,7 @@ lane :release do
         org_slug: 'openfoodfacts',
         project_slug: 'openfoodfacts-android',
         version: PACKAGE_NAME + '@' + versionName + '+' + versionCode,
-        finalize: false # Release will be finalized by the "daily" lane, when the version is in production
+        finalize: false # Release will be finalized by the "finalize_sentry" lane, when the version is in production
     )
 
     sentry_set_commits(
@@ -72,13 +72,13 @@ lane :release do
 end
 
 desc 'Check the version currently in production and mark it as "finalized"'
-lane :daily do
+lane :finalize_sentry do
     PACKAGE_NAME = CredentialsManager::AppfileConfig.try_fetch_value(:package_name)
     versionName = google_play_track_version_name(track: 'production')
     versionCode = google_play_track_version_codes(track: 'production').max
     sentry_finalize_release(
         org_slug: 'openfoodfacts',
         project_slug: 'openfoodfacts-android',
-        version: versionName + '+' + versionCode
+        version: PACKAGE_NAME + '@' + versionName + '+' + versionCode,
     )
 end


### PR DESCRIPTION
Just realized that we create releases in Sentry every time the `fastlane release` is ran (which is good), but we never finalize them. (finalizing a release on Sentry is especially for journaling and issue management, like "fixed in next release", full details here: https://docs.sentry.io/product/cli/releases/#:~:text=Finalizing%20a%20release%20means%20that,sorting%20releases%20in%20the%20UI)

The new github action workflow is a cron performed every day, launch the `fastlane finalize_sentry` script, which get the latest version currently in the production lane and mark it as finalized in sentry. This way, once a build is promoted to "production" in google play, it is marked as "finalized" maximum 24h later.