### PR TITLE
Add day/night mode switch in settings

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/PreferencesFragment.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/PreferencesFragment.java
@@ -34,6 +34,7 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatDelegate;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.fragment.app.FragmentActivity;
 import androidx.preference.CheckBoxPreference;
@@ -145,6 +146,25 @@ public class PreferencesFragment extends PreferenceFragmentCompat implements INa
                 configuration.setLocale(LocaleHelper.getLocale((String) locale));
                 activity.recreate();
             }
+            return true;
+        });
+
+        ListPreference applicationThemePreference = requirePreference("applicationThemePreference");
+
+        String[] applicationThemeEntries = getResources().getStringArray(R.array.application_theme_entries);
+
+        applicationThemePreference.setEntries(R.array.application_theme_entries);
+        applicationThemePreference.setEntryValues(R.array.application_theme_entries);
+
+        applicationThemePreference.setOnPreferenceChangeListener((preference, value) -> {
+            if (value.equals(applicationThemeEntries[1])) {
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
+            } else if (value.equals(applicationThemeEntries[2])) {
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
+            } else {
+                AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM);
+            }
+
             return true;
         });
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,13 @@
         <item>&gt;</item>
     </string-array>
 
+    <!-- Application theme settings -->
+    <string-array name="application_theme_entries">
+        <item>@string/follow_system</item>
+        <item>@string/day</item>
+        <item>@string/night</item>
+    </string-array>
+
     <!-- nutrients list
     do not change the order of the array as the items are paired with the String array
     PARAMS_OTHER_NUTRIENTS present in AddProductNutritionFactsFragment-->
@@ -1101,4 +1108,9 @@
     <string name="hunger_game_call_to_action">Help classify more %1$s</string>
     <string name="txtHomeOnline">Open Food Facts is an open database of more than %1$s food products (plus the ones you will contribute).</string>
     <string name="enabled">Enabled</string>
+
+    <!-- Application theme settings -->
+    <string name="follow_system">Follow system</string>
+    <string name="day">Day</string>
+    <string name="night">Night</string>
 </resources>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -14,6 +14,13 @@
             app:useSimpleSummaryProvider="true" />
 
         <ListPreference
+            android:defaultValue="@string/follow_system"
+            android:dialogTitle="Change application theme"
+            android:key="applicationThemePreference"
+            android:title="Application theme"
+            app:useSimpleSummaryProvider="true" />
+
+        <ListPreference
             android:defaultValue="@string/kcal"
             android:dialogTitle="@string/energy_pref_title"
             android:key="energyUnitPreference"


### PR DESCRIPTION


####  Description
<!--Give a small description related to the changes you have made.-->
This change adds a settings to the preferences page that allows the user set the day/night mode application theme preferences


#### Related issues
<!--
- Add the issue number here.
- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- If you have solved the issue completely use "Fixes #{issue_number}, example: "Fixes #123, #345".
-->
Closes https://github.com/openfoodfacts/openfoodfacts-androidapp/issues/3478
#### Related PRs
<!-- Link to all the related PRs openfoodfacts-androidapp, openfoodfacts-server, openfoodfacts-ios, etc. -->

#### Screenshots
<!-- If possible, please add relevant screenshots / GIFs -->
![Screenshot_1606007989](https://user-images.githubusercontent.com/18437312/99891344-4245f000-2c69-11eb-9855-6d182f7c337c.png)
![Screenshot_1606007999](https://user-images.githubusercontent.com/18437312/99891345-440fb380-2c69-11eb-8ff3-2e17c5b2576e.png)
