### PR TITLE
Crash at Advanced Search Resolved

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/search/ProductSearchActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/search/ProductSearchActivity.kt
@@ -163,12 +163,12 @@ class ProductSearchActivity : BaseActivity() {
                 mSearchInfo = SearchInfo.emptySearchInfo()
                 mSearchInfo.searchTitle = paths[4]
                 mSearchInfo.searchQuery = paths[4]
-                mSearchInfo.searchType = SearchType.fromUrl(paths[3])!!
                 if (paths[3] == "cgi" && paths[4].contains("search.pl")) {
                     mSearchInfo.searchTitle = data.getQueryParameter("search_terms") ?: ""
                     mSearchInfo.searchQuery = data.getQueryParameter("search_terms") ?: ""
                     mSearchInfo.searchType = SearchType.SEARCH
-                }
+                } else
+                    mSearchInfo.searchType = SearchType.fromUrl(paths[3])!!
             } else {
                 Log.i(javaClass.simpleName, "No data was passed in with URL. Exiting.")
                 finish()


### PR DESCRIPTION
####  Description
Fixed the issue of app crashing on trying to open Advanced Search from sidebar (then open with  OpenFoodFacts). There was a NullPointerException causing the crash. I fixed that by moving a line to else block.

#### Related issues
Fixes the issue #3610 

#### Related PRs
None of the PR are related to this one.

#### Screenshots
After Resolving

![Resolved](https://user-images.githubusercontent.com/65870389/101931076-f7335300-3bfe-11eb-82bb-4b83a40c1e40.gif)
