### PR TITLE
Fixed btnAlignment issue in Additive cards

### DIFF
--- a/app/src/main/res/layout/fragment_product_attribute_details.xml
+++ b/app/src/main/res/layout/fragment_product_attribute_details.xml
@@ -83,9 +83,8 @@
                 android:layout_height="wrap_content"
                 android:layout_below="@id/exposureEvalTable"
                 android:layout_marginBottom="@dimen/spacing_small"
-                android:gravity="center_horizontal"
+                android:gravity="center"
                 android:weightSum="100">
-
 
                 <Button
                     android:id="@+id/wikipediaButton"


### PR DESCRIPTION
####  Description
Changed the gravity of linearLayout to **center** from **center-horizontal**.
#### Related issues
Fixed issue #3673 

#### Related PRs
None of the PRs are related to this.

#### Screenshots
![Untitled](https://user-images.githubusercontent.com/65870389/104293070-9770e600-54e3-11eb-832e-bed0abd9d6ba.png)

