### PR TITLE
Fixed grey food scores displayed for cosmetics

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/adapters/ProductsRecyclerViewAdapter.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/adapters/ProductsRecyclerViewAdapter.kt
@@ -10,7 +10,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
-import openfoodfacts.github.scrachx.openfood.BuildConfig
+import openfoodfacts.github.scrachx.openfood.AppFlavors
 import openfoodfacts.github.scrachx.openfood.R
 import openfoodfacts.github.scrachx.openfood.models.Product
 import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient.Companion.getLocaleProductNameField
@@ -81,7 +81,7 @@ class ProductsRecyclerViewAdapter(
         // Set product description
         holder.productDetails.text = product?.getProductBrandsQuantityDetails()
 
-        if(BuildConfig.FLAVOR == "off") {
+        if (AppFlavors.isFlavors(AppFlavors.OFF)) {
             // Set nutriscore icon
             val nutriRes = product.getNutriScoreResource()
             holder.productNutriscore.setImageResource(nutriRes)

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/adapters/ProductsRecyclerViewAdapter.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/adapters/ProductsRecyclerViewAdapter.kt
@@ -10,6 +10,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
+import openfoodfacts.github.scrachx.openfood.BuildConfig
 import openfoodfacts.github.scrachx.openfood.R
 import openfoodfacts.github.scrachx.openfood.models.Product
 import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient.Companion.getLocaleProductNameField
@@ -80,23 +81,22 @@ class ProductsRecyclerViewAdapter(
         // Set product description
         holder.productDetails.text = product?.getProductBrandsQuantityDetails()
 
-        // Set nutriscore icon
-        val nutriRes = product.getNutriScoreResource()
-        holder.productNutriscore.setImageResource(nutriRes)
-        holder.productNutriscore.visibility = View.VISIBLE
+        if(BuildConfig.FLAVOR == "off") {
+            // Set nutriscore icon
+            val nutriRes = product.getNutriScoreResource()
+            holder.productNutriscore.setImageResource(nutriRes)
+            holder.productNutriscore.visibility = View.VISIBLE
 
+            // Set nova icon
+            val novaRes = product.getNovaGroupResource()
+            holder.productNova.setImageResource(novaRes)
+            holder.productNova.visibility = View.VISIBLE
 
-        // Set nova icon
-        val novaRes = product.getNovaGroupResource()
-        holder.productNova.setImageResource(novaRes)
-        holder.productNova.visibility = View.VISIBLE
-
-
-        // Set ecoscore icon
-        val ecoRes = product.getEcoscoreResource()
-        holder.productEcoscore.setImageResource(ecoRes)
-        holder.productEcoscore.visibility = View.VISIBLE
-
+            // Set ecoscore icon
+            val ecoRes = product.getEcoscoreResource()
+            holder.productEcoscore.setImageResource(ecoRes)
+            holder.productEcoscore.visibility = View.VISIBLE
+        }
     }
 
     fun getProduct(position: Int) = products[position]


### PR DESCRIPTION
####  Description
Added a _if_ block to check the build flavor. If the build flavor is  **"off"** then only the food scores are visible. 

#### Related issues
Fixes #3741

#### Related PRs
None

#### Screenshots
![img](https://user-images.githubusercontent.com/65870389/104779093-7a1e6f00-57a4-11eb-990e-ade4011ae5a0.jpg)
