### PR TITLE
Feat packing values on environment tab

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/environment/EnvironmentProductFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/environment/EnvironmentProductFragment.kt
@@ -89,6 +89,15 @@ class EnvironmentProductFragment : BaseFragment() {
             binding.environmentInfoCv.visibility = View.GONE
         }
 
+        val packaging = product.packaging
+        if (!packaging.isNullOrEmpty()) {
+            binding.packagingText.text = bold(getString(R.string.packaging_environmentTab))
+            binding.packagingText.append(" ")
+            binding.packagingText.append(packaging.split(',').toString().removeSurrounding("[","]") )
+        } else {
+            binding.packagingCv.visibility = View.GONE
+        }
+
         val recyclingInstructionsToDiscard = product.recyclingInstructionsToDiscard
         if (!recyclingInstructionsToDiscard.isNullOrEmpty()) {
             binding.recyclingInstructionToDiscard.text = bold("Recycling instructions - To discard: ")

--- a/app/src/main/res/layout/fragment_environment_product.xml
+++ b/app/src/main/res/layout/fragment_environment_product.xml
@@ -80,9 +80,7 @@
                     android:id="@+id/carbon_footprint_cv"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
                     android:layout_marginTop="16dp"
-                    android:layout_marginEnd="16dp"
                     app:cardElevation="4dp">
 
                     <TextView
@@ -103,9 +101,7 @@
                     android:id="@+id/environment_info_cv"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
                     android:layout_marginTop="16dp"
-                    android:layout_marginEnd="16dp"
                     app:cardElevation="4dp">
 
                     <TextView
@@ -126,9 +122,7 @@
                     android:id="@+id/packaging_cv"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
                     android:layout_marginTop="16dp"
-                    android:layout_marginEnd="16dp"
                     app:cardElevation="4dp">
 
                     <TextView
@@ -149,9 +143,7 @@
                     android:id="@+id/recycling_instructions_discard_cv"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
                     android:layout_marginTop="16dp"
-                    android:layout_marginEnd="16dp"
                     app:cardElevation="4dp">
 
                     <TextView
@@ -172,9 +164,7 @@
                     android:id="@+id/recycling_instructions_recycle_cv"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="16dp"
                     android:layout_marginTop="16dp"
-                    android:layout_marginEnd="16dp"
                     app:cardElevation="4dp">
 
                     <TextView

--- a/app/src/main/res/layout/fragment_environment_product.xml
+++ b/app/src/main/res/layout/fragment_environment_product.xml
@@ -123,6 +123,29 @@
                 </androidx.cardview.widget.CardView>
 
                 <androidx.cardview.widget.CardView
+                    android:id="@+id/packaging_cv"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginTop="16dp"
+                    android:layout_marginEnd="16dp"
+                    app:cardElevation="4dp">
+
+                    <TextView
+                        android:id="@+id/packaging_text"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="@dimen/spacing_normal"
+                        android:layout_marginTop="@dimen/spacing_tiny"
+                        android:layout_marginRight="@dimen/spacing_normal"
+                        android:layout_marginBottom="@dimen/spacing_tiny"
+                        android:padding="@dimen/spacing_small"
+                        android:textIsSelectable="true"
+                        android:textSize="@dimen/font_normal" />
+
+                </androidx.cardview.widget.CardView>
+
+                <androidx.cardview.widget.CardView
                     android:id="@+id/recycling_instructions_discard_cv"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -574,6 +574,7 @@
     <string name="logout_drawer">Logout</string>
     <string name="contribution_without_account">You can sign-in or create an Open Food Facts account to keep your contributions</string>
     <string name="textCarbonFootprint">Carbon footprint / CO2 emissions: </string>
+    <string name="packaging_environmentTab">Packaging :</string>
     <string name="action_search">Search</string>
     <string name="search_hint">Search a product</string>
     <string name="number_of_results">Number of results: </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -574,7 +574,7 @@
     <string name="logout_drawer">Logout</string>
     <string name="contribution_without_account">You can sign-in or create an Open Food Facts account to keep your contributions</string>
     <string name="textCarbonFootprint">Carbon footprint / CO2 emissions: </string>
-    <string name="packaging_environmentTab">Packaging :</string>
+    <string name="packaging_environmentTab">Packaging:</string>
     <string name="action_search">Search</string>
     <string name="search_hint">Search a product</string>
     <string name="number_of_results">Number of results: </string>


### PR DESCRIPTION
####  Description
Added the packaging card view to display packaging values. ( ```25c483b```)
 Made the environment tab card view layout as the rest of the application. (```54dbc0a```)
<!--Give a small description related to the changes you have made.-->

#### Related issues
<!--
- Add the issue number here.
- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- If you have solved the issue completely use "Fixes #{issue_number}, example: "Fixes #123, #345".
-->
Fixes #3608 

<!-- Link to all the related PRs openfoodfacts-androidapp, openfoodfacts-server, openfoodfacts-ios, etc. -->


#### Screenshots
With ```25c483b```
![image](https://user-images.githubusercontent.com/71206228/105077624-c8888200-5ab2-11eb-9b3c-b2619fb998e2.png)

With ```54dbc0a```
![image](https://user-images.githubusercontent.com/71206228/105077607-c0c8dd80-5ab2-11eb-8b2c-f14c02f49d5a.png)



<!-- If possible, please add relevant screenshots / GIFs -->
