### PR TITLE
Fixed ISE when fragment is not attached to activity

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ingredients/IngredientsProductFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ingredients/IngredientsProductFragment.kt
@@ -378,15 +378,14 @@ class IngredientsProductFragment : BaseFragment(), IIngredientsProductPresenter.
     }
 
     fun extractIngredients() {
-        if (isAdded) {
-            ingredientExtracted = true
-            val settings = requireActivity().getLoginPreferences()
-            if (settings.getString("user", "")!!.isEmpty()) {
-                showSignInDialog()
-            } else {
-                productState = requireProductState()
-                performOCRLauncher.launch(productState.product)
-            }
+        if (!isAdded) return
+        ingredientExtracted = true
+        val settings = requireActivity().getLoginPreferences()
+        if (settings.getString("user", "")!!.isEmpty()) {
+            showSignInDialog()
+        } else {
+            productState = requireProductState()
+            performOCRLauncher.launch(productState.product)
         }
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ingredients/IngredientsProductFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ingredients/IngredientsProductFragment.kt
@@ -378,8 +378,8 @@ class IngredientsProductFragment : BaseFragment(), IIngredientsProductPresenter.
     }
 
     fun extractIngredients() {
-        ingredientExtracted = true
         if (isAdded) {
+            ingredientExtracted = true
             val settings = requireActivity().getLoginPreferences()
             if (settings.getString("user", "")!!.isEmpty()) {
                 showSignInDialog()

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ingredients/IngredientsProductFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ingredients/IngredientsProductFragment.kt
@@ -379,12 +379,14 @@ class IngredientsProductFragment : BaseFragment(), IIngredientsProductPresenter.
 
     fun extractIngredients() {
         ingredientExtracted = true
-        val settings = requireActivity().getLoginPreferences()
-        if (settings.getString("user", "")!!.isEmpty()) {
-            showSignInDialog()
-        } else {
-            productState = requireProductState()
-            performOCRLauncher.launch(productState.product)
+        if (isAdded) {
+            val settings = requireActivity().getLoginPreferences()
+            if (settings.getString("user", "")!!.isEmpty()) {
+                showSignInDialog()
+            } else {
+                productState = requireProductState()
+                performOCRLauncher.launch(productState.product)
+            }
         }
     }
 


### PR DESCRIPTION
####  Description
Used `isAdded()` to check whether the fragment is attached to an activity.

#### Related issues
Fixes - #3743 

#### Related PRs
None

#### Screenshots