### PR TITLE
Fix bug with spinner for vitamin_a in ProductEditNutritionFactsFragment

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/app/AnalyticsService.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/app/AnalyticsService.kt
@@ -10,5 +10,5 @@ object AnalyticsService {
 
     fun setTag(key: String, value: String) = Sentry.setTag(key, value)
 
-    fun record(exception: Exception) = Sentry.captureException(exception)
+    fun record(exception: Throwable) = Sentry.captureException(exception)
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/ProductEditNutritionFactsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/ProductEditNutritionFactsFragment.kt
@@ -154,7 +154,7 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
             it.addValidListener()
             it.checkValue()
         }
-        (requireActivity() as? ProductEditActivity)?.initialValues?.let { values ->
+        (activity as? ProductEditActivity)?.initialValues?.let { values ->
             addAllFieldsToMap(values)
         }
     }
@@ -716,7 +716,7 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
                 modSpinner.setSelection(modSelectedIndex)
             }
         } catch (t: Throwable) {
-            AnalyticsService.record(Throwable("Can't find weight units for nutriment: $nutrientShortName", t))
+            AnalyticsService.record(IllegalStateException("Can't find weight units for nutriment: $nutrientShortName", t))
             closeScreenWithAlert()
         }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/ProductEditNutritionFactsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/ProductEditNutritionFactsFragment.kt
@@ -692,19 +692,27 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
         editText.imeOptions = EditorInfo.IME_ACTION_DONE
         editText.requestFocus()
         if (preFillValues) {
-            editText.setText(value)
+            value?.takeIf { it != "0" }?.let { editText.setText(value) }
         }
 
         // Setup unit spinner
         val unitSpinner = rowView.findViewById<Spinner>(R.id.spinner_unit)
         val modSpinner = rowView.findViewById<Spinner>(R.id.spinner_mod)
-        if (Nutriments.PH == nutrientShortName) {
-            unitSpinner.visibility = View.INVISIBLE
-        } else if (Nutriments.STARCH == nutrientShortName) {
-            val arrayAdapter = ArrayAdapter(requireActivity(), android.R.layout.simple_spinner_item, requireActivity().resources.getStringArray(R.array.weights_array))
-            arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
-            unitSpinner.adapter = arrayAdapter
-            starchEditText = editText
+        when (nutrientShortName) {
+            Nutriments.PH -> {
+                unitSpinner.visibility = View.INVISIBLE
+            }
+            Nutriments.STARCH -> {
+                val arrayAdapter = ArrayAdapter(requireActivity(), android.R.layout.simple_spinner_item, requireActivity().resources.getStringArray(R.array.weights_array))
+                arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+                unitSpinner.adapter = arrayAdapter
+                starchEditText = editText
+            }
+            Nutriments.VITAMIN_A -> {
+                val arrayAdapter = ArrayAdapter(requireActivity(), android.R.layout.simple_spinner_item, requireActivity().resources.getStringArray(R.array.weight_all_units))
+                arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+                unitSpinner.adapter = arrayAdapter
+            }
         }
         if (preFillValues) {
             unitSpinner.setSelection(unitSelectedIndex)

--- a/app/src/main/res/layout/fragment_add_product_nutrition_facts.xml
+++ b/app/src/main/res/layout/fragment_add_product_nutrition_facts.xml
@@ -843,13 +843,11 @@
                     app:layout_constraintStart_toStartOf="@+id/spinner_sodium_unit"
                     app:layout_constraintTop_toTopOf="@id/alcohol_til" />
 
-                <TableLayout
+                <LinearLayout
                     android:id="@+id/table_layout"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal"
-                    android:shrinkColumns="0"
-                    android:stretchColumns="0"
+                    android:orientation="vertical"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/alcohol_til" />


### PR DESCRIPTION
####  Description
Found a bug for "vitamin_a" nutrinion in ProductEditNutritionFactsFragment.kt when we try to add row
```
2021-02-08 19:01:00.312 869-869/openfoodfacts.github.scrachx.openfood.debug E/AndroidRuntime: FATAL EXCEPTION: main
    Process: openfoodfacts.github.scrachx.openfood.debug, PID: 869
    java.lang.ArrayIndexOutOfBoundsException: length=3; index=4
        at java.util.Arrays$ArrayList.get(Arrays.java:3769)
        at android.widget.ArrayAdapter.getItem(ArrayAdapter.java:393)
        at android.widget.ArrayAdapter.createViewFromResource(ArrayAdapter.java:449)
        at android.widget.ArrayAdapter.getView(ArrayAdapter.java:415)
        at android.widget.Spinner.makeView(Spinner.java:712)
        at android.widget.Spinner.layout(Spinner.java:660)
        at android.widget.Spinner.onLayout(Spinner.java:622)
```


#### Related issues
not found

#### Related PRs
not found

#### Screenshots
|![Screenshot_1613045536](https://user-images.githubusercontent.com/1501831/107635135-b4800c80-6c7b-11eb-9a48-c4448134d3bc.png)


