### PR TITLE
Fix Changelog.kt in release build

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/changelog/Changelog.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/changelog/Changelog.kt
@@ -1,14 +1,15 @@
 package openfoodfacts.github.scrachx.openfood.features.changelog
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.io.Serializable
 
 data class Changelog(
-        @JsonProperty("changelog") val versions: List<Version>,
-) {
-    data class Version(
-            @JsonProperty("date") var date: String,
-            @JsonProperty("code") var code: Long,
-            @JsonProperty("name") var name: String,
-            @JsonProperty("items") var items: List<String>,
-    )
-}
+        @JsonProperty("changelog") val versions: List<ChangelogVersion>,
+) : Serializable
+
+data class ChangelogVersion(
+        @JsonProperty("date") val date: String,
+        @JsonProperty("code") val code: Long,
+        @JsonProperty("name") val name: String,
+        @JsonProperty("items") val items: List<String>,
+) : Serializable


### PR DESCRIPTION
####  Description
I'm not able to build release build locally, so this is attempt to fix the issue. The main problem is the proguard obfuscates  these classes and jakson parser we cannot parse them in release build.

#### Related issues
#2870 