### PR TITLE
Do not show the CHANGELOG translation prompt in English

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/changelog/ChangelogDialog.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/changelog/ChangelogDialog.kt
@@ -9,6 +9,7 @@ import android.view.WindowManager
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.pm.PackageInfoCompat
+import androidx.core.view.isVisible
 import androidx.fragment.app.DialogFragment
 import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -21,6 +22,7 @@ import openfoodfacts.github.scrachx.openfood.customtabs.CustomTabActivityHelper
 import openfoodfacts.github.scrachx.openfood.customtabs.CustomTabsHelper
 import openfoodfacts.github.scrachx.openfood.customtabs.WebViewFallback
 import openfoodfacts.github.scrachx.openfood.utils.LocaleHelper.getLocaleFromContext
+import java.util.Locale
 
 class ChangelogDialog : DialogFragment(R.layout.fragment_changelog) {
 
@@ -86,9 +88,14 @@ class ChangelogDialog : DialogFragment(R.layout.fragment_changelog) {
     }
 
     private fun setupTranslationHelpLabel() {
-        val language = getLocaleFromContext(context).displayLanguage
-        translationHelpLabel.text = getString(R.string.changelog_translation_help, language)
-        translationHelpLabel.setOnClickListener { openDailyFoodFacts() }
+        val locale = getLocaleFromContext(context)
+        if (locale.language.startsWith(Locale.ENGLISH.language)) {
+            translationHelpLabel.isVisible = false
+        } else {
+            translationHelpLabel.isVisible = true
+            translationHelpLabel.text = getString(R.string.changelog_translation_help, locale.displayLanguage)
+            translationHelpLabel.setOnClickListener { openDailyFoodFacts() }
+        }
     }
 
     private fun applyWindowTweaks() {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/changelog/ChangelogDialog.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/changelog/ChangelogDialog.kt
@@ -92,8 +92,8 @@ class ChangelogDialog : DialogFragment(R.layout.fragment_changelog) {
         if (locale.language.startsWith(Locale.ENGLISH.language)) {
             translationHelpLabel.isVisible = false
         } else {
-            translationHelpLabel.isVisible = true
             translationHelpLabel.text = getString(R.string.changelog_translation_help, locale.displayLanguage)
+            translationHelpLabel.isVisible = true
             translationHelpLabel.setOnClickListener { openDailyFoodFacts() }
         }
     }

--- a/app/src/main/res/layout/fragment_changelog.xml
+++ b/app/src/main/res/layout/fragment_changelog.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical">
 
     <TextView
@@ -32,10 +32,12 @@
         android:clickable="true"
         android:focusable="true"
         android:gravity="center"
-        tools:text="@string/changelog_translation_help"
         android:textColor="?android:textColorLink"
         android:textSize="@dimen/font_normal"
-        android:textStyle="normal" />
+        android:textStyle="normal"
+        android:visibility="gone"
+        tools:text="@string/changelog_translation_help"
+        tools:visibility="visible" />
 
     <Button
         android:id="@+id/changelog_button_close"


### PR DESCRIPTION
####  Description
Do not show the CHANGELOG translation prompt in English.

#### Related issues
Fix #3859 

#### Screenshots
![Screenshot_1614510066](https://user-images.githubusercontent.com/1501831/109416246-135cba00-79ce-11eb-80e4-93b2ecda0d60.png)

![Screenshot_1614510081](https://user-images.githubusercontent.com/1501831/109416247-148de700-79ce-11eb-8dc8-31172d8b30fd.png)
