### PR TITLE
FIX: Image selection from the image manager does not work anymore #3839 (View parameter made nullable)

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/ImagesManageActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/ImagesManageActivity.kt
@@ -97,7 +97,7 @@ class ImagesManageActivity : BaseActivity() {
         binding.btnEditImage.setOnClickListener { onStartEditExistingImage() }
 
         binding.comboLanguages.onItemSelectedListener = object : OnItemSelectedListener {
-            override fun onItemSelected(parent: AdapterView<*>?, view: View, position: Int, id: Long) =
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) =
                     onLanguageChanged()
 
             override fun onNothingSelected(parent: AdapterView<*>?) = Unit // Do nothing


### PR DESCRIPTION
####  Description
NPE fixed
<!--Give a small description related to the changes you have made.-->

#### Related issues
<!--
- Add the issue number here.
- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- If you have solved the issue completely use "Fixes #{issue_number}, example: "Fixes #123, #345".
-->
Fixes #3839 

#### Related PRs
<!-- Link to all the related PRs openfoodfacts-androidapp, openfoodfacts-server, openfoodfacts-ios, etc. -->

#### Screenshots
<!-- If possible, please add relevant screenshots / GIFs -->
