### PR TITLE
FEAT: confirmation added when setting a photo from the photos tab

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/photos/ProductPhotosAdapter.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/photos/ProductPhotosAdapter.kt
@@ -108,6 +108,9 @@ class ProductPhotosAdapter(
                 R.id.set_front_image -> product.getImageStringKey(ProductImageField.FRONT)
                 else -> product.getImageStringKey(ProductImageField.OTHER)
             }
+            if (snackView == null) Toast.makeText(context, context.getString(R.string.changes_saved), Toast.LENGTH_SHORT).show()
+            else Snackbar.make(snackView, R.string.changes_saved, Snackbar.LENGTH_SHORT).show()
+
             openFoodAPIClient.editImage(product.code, imgMap)
                     .subscribe { response -> displaySetImageName(response) }
                     .addTo(disp)


### PR DESCRIPTION
####  Description
Added a toast to let user know the image is set
<!--Give a small description related to the changes you have made.-->

#### Related issues
<!--
- Add the issue number here.
- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- If you have solved the issue completely use "Fixes #{issue_number}, example: "Fixes #123, #345".
-->
Fixes #3832 

<!-- Link to all the related PRs openfoodfacts-androidapp, openfoodfacts-server, openfoodfacts-ios, etc. -->

#### Screenshots
<!-- If possible, please add relevant screenshots / GIFs -->
![image](https://user-images.githubusercontent.com/71206228/110181616-3655f680-7e32-11eb-8519-3e977034e9f2.png)
