### PR TITLE
Made the day and night strings untranslatable

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -984,8 +984,8 @@
 
     <!-- Application theme settings -->
     <string name="follow_system">Follow system</string>
-    <string name="day">Day</string>
-    <string name="night">Night</string>
+    <string name="day" translatable="false">Day</string>
+    <string name="night" translatable="false">Night</string>
     <string name="required_for_ecoscore">(Required to calculate the Eco-Score)</string>
     <string name="hint_origin">Examples: USA, France, Italy</string>
     <string name="report_email_chooser_title">Send a report email</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -127,7 +127,7 @@
     </string-array>
 
     <!-- Application theme settings -->
-    <string-array name="application_theme_entries">
+    <string-array name="application_theme_entries" translatable="false">
         <item>@string/follow_system</item>
         <item>@string/day</item>
         <item>@string/night</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -984,8 +984,8 @@
 
     <!-- Application theme settings -->
     <string name="follow_system">Follow system</string>
-    <string name="day" translatable="false">Day</string>
-    <string name="night" translatable="false">Night</string>
+    <string name="day">Day</string>
+    <string name="night">Night</string>
     <string name="required_for_ecoscore">(Required to calculate the Eco-Score)</string>
     <string name="hint_origin">Examples: USA, France, Italy</string>
     <string name="report_email_chooser_title">Send a report email</string>


### PR DESCRIPTION
####  Description
Made `@string/day` and `@string/night` untranslatable.

#### Related issues
Fixes #3837 