### PR TITLE
%two_letters_code% ?

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -22,7 +22,7 @@ files:
         yi: ji
 
   - source: /app/src/obf/res/values/strings.xml
-    translation: /app/src/obf/res/values-%android_code%/%original_file_name%
+    translation: /app/src/obf/res/values-%two_letters_code%/%original_file_name%
     languages_mapping:
       two_letters_code:
         zh-CN: zh-rCN
@@ -41,7 +41,7 @@ files:
         yi: ji
 
   - source: /app/src/off/res/values/strings.xml
-    translation: /app/src/off/res/values-%android_code%/%original_file_name%
+    translation: /app/src/off/res/values-%two_letters_code%/%original_file_name%
     languages_mapping:
       two_letters_code:
         pt-BR: pt-rBR
@@ -59,7 +59,7 @@ files:
         yi: ji
 
   - source: /app/src/opff/res/values/strings.xml
-    translation: /app/src/opff/res/values-%android_code%/strings.xml
+    translation: /app/src/opff/res/values-%two_letters_code%/strings.xml
     languages_mapping:
       two_letters_code:
         zh-CN: zh-rCN
@@ -77,7 +77,7 @@ files:
         yi: ji
 
   - source: /app/src/opf/res/values/strings.xml
-    translation: /app/src/opf/res/values-%android_code%/strings.xml
+    translation: /app/src/opf/res/values-%two_letters_code%/strings.xml
     languages_mapping:
       two_letters_code:
         zh-CN: zh-rCN


### PR DESCRIPTION
- [ ] off, opf, obf and opff have not been migrated to the new system. Crowdin is complaining, so this might be a temporary fix
- [ ] main has been converted, but the old files with %two_letters_code% are still in the repository. Should I delete them ?
- [ ] Some locale don't work (Serbian, Valenciano, because they have 3 letters, or a weird structure)