### PR TITLE
Remove Sentry gradle plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,20 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-buildscript {
-    repositories {
-        mavenCentral()
-        jcenter()
-        google()
-        maven("https://jitpack.io")
-    }
-}
 plugins {
     id("com.android.application")
     id("de.timfreiheit.resourceplaceholders.plugin")
     id("org.greenrobot.greendao")
-    id("io.sentry.android.gradle")
     id("kotlin-android")
     id("kotlin-parcelize")
     id("kotlin-kapt")
@@ -207,22 +197,18 @@ dependencies {
     androidTestImplementation("tools.fastlane:screengrab:1.2.0")
 
     resourcePlaceholders { files = listOf("xml/shortcuts.xml") }
-
 }
-
 
 android {
     compileSdkVersion(30)
 
     testBuildType = obtainTestBuildType()
 
-
     buildFeatures {
         dataBinding = true
     }
 
     flavorDimensions("versionCode", "platform")
-
 
     defaultConfig {
         applicationId = "openfoodfacts.github.scrachx.openfood"
@@ -238,7 +224,6 @@ android {
         ndk.abiFilters("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
 
         multiDexEnabled = true
-        // jackOptions.enabled = true
     }
 
     signingConfigs {
@@ -343,7 +328,6 @@ android {
         }
     }
 
-
     dexOptions {
         preDexLibraries = false
         javaMaxHeapSize = "4g"
@@ -381,7 +365,6 @@ android {
         // avoid "Method ... not mocked."
         unitTests.isReturnDefaultValues = true
         execution = "ANDROIDX_TEST_ORCHESTRATOR"
-
     }
 }
 
@@ -392,9 +375,3 @@ kapt {
 }
 
 greendao { schemaVersion(22) }
-
-
-
-
-
-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,8 +37,6 @@ buildscript {
 
         classpath("com.google.dagger:hilt-android-gradle-plugin:$hiltVersion")
 
-
-        classpath("io.sentry:sentry-android-gradle-plugin:1.7.36")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -69,20 +69,19 @@ lane :release do
         skip_upload_screenshots: true
     )
 
+    FLAVOR = SharedValues::GRADLE_FLAVOR + SharedValues::GRADLE_BUILD_TYPE
+    sentry_upload_proguard(
+      org_slug: 'openfoodfacts',
+      project_slug: 'openfoodfacts-android',
+      android_manifest_path: './app/build/intermediates/merged_manifests/' + FLAVOR + '/out/AndroidManifest.xml'
+      mapping_path: './app/build/outputs/mapping/' + FLAVOR + '/mapping.txt',
+    )
+
     sentry_create_release(
         org_slug: 'openfoodfacts',
         project_slug: 'openfoodfacts-android',
         version: PACKAGE_NAME + '@' + versionName + '+' + versionCode,
         finalize: false # Release will be finalized by the "finalize_sentry" lane, when the version is in production
-    )
-
-    FLAVOR = SharedValues::GRADLE_FLAVOR + SharedValues::GRADLE_BUILD_TYPE
-    sentry_upload_proguard(
-      auth_token: ENV['SENTRY_AUTH_TOKEN'],
-      org_slug: 'openfoodfacts',
-      project_slug: 'openfoodfacts-android',
-      android_manifest_path: './app/build/intermediates/merged_manifests/' + FLAVOR + '/out/AndroidManifest.xml'
-      mapping_path: './app/build/outputs/mapping/' + FLAVOR + '/mapping.txt',
     )
 
     sentry_set_commits(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -69,12 +69,20 @@ lane :release do
         skip_upload_screenshots: true
     )
 
-
     sentry_create_release(
         org_slug: 'openfoodfacts',
         project_slug: 'openfoodfacts-android',
         version: PACKAGE_NAME + '@' + versionName + '+' + versionCode,
         finalize: false # Release will be finalized by the "finalize_sentry" lane, when the version is in production
+    )
+
+    FLAVOR = SharedValues::GRADLE_FLAVOR + SharedValues::GRADLE_BUILD_TYPE
+    sentry_upload_proguard(
+      auth_token: ENV['SENTRY_AUTH_TOKEN'],
+      org_slug: 'openfoodfacts',
+      project_slug: 'openfoodfacts-android',
+      android_manifest_path: './app/build/intermediates/merged_manifests/' + FLAVOR + '/out/AndroidManifest.xml'
+      mapping_path: './app/build/outputs/mapping/' + FLAVOR + '/mapping.txt',
     )
 
     sentry_set_commits(


### PR DESCRIPTION
####  Description
Remove Sentry gradle plugin because we upload mapping with CLI.
https://docs.sentry.io/platforms/android/proguard/

#### Related issues
#3830 