### PR TITLE
For #4260: Replace PreferenceChangeListener with PreferenceClickListener.

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/preferences/PreferencesFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/preferences/PreferencesFragment.kt
@@ -195,7 +195,7 @@ class PreferencesFragment : PreferenceFragmentCompat(), INavigationItem {
         }
 
         requirePreference<Preference>(getString(R.string.pref_contact_us_key)) {
-            setOnPreferenceChangeListener { _, _ ->
+            setOnPreferenceClickListener {
                 try {
                     startActivity(Intent(Intent.ACTION_SENDTO).apply {
                         data = getString(R.string.off_mail).toUri()
@@ -209,7 +209,7 @@ class PreferencesFragment : PreferenceFragmentCompat(), INavigationItem {
         }
 
         requirePreference<Preference>(getString(R.string.pref_rate_us_key)) {
-            setOnPreferenceChangeListener { _, _ ->
+            setOnPreferenceClickListener {
                 try {
                     startActivity(
                         Intent(


### PR DESCRIPTION

####  Description
<!--Give a small description related to the changes you have made.-->
PreferenceChangeListener does not fire for preferences that do not change value. 

#### Related issues
- #4260.

