### PR TITLE
For #4218: Remove top to bottom constraint.

### DIFF
--- a/app/src/main/res/layout/activity_product_browsing_list.xml
+++ b/app/src/main/res/layout/activity_product_browsing_list.xml
@@ -181,6 +181,5 @@
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/linearLayout" />
+        app:layout_constraintStart_toStartOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
####  Description
This allows navigation_bottom to stay on the bottom of parent.
instead of being positioned before the product list is loaded.

#### Related issues
- #4218
