### PR TITLE
ref: extract product open functionality to own class

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/compare/ProductCompareActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/compare/ProductCompareActivity.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.rx2.await
 import openfoodfacts.github.scrachx.openfood.R
 import openfoodfacts.github.scrachx.openfood.databinding.ActivityProductComparisonBinding
 import openfoodfacts.github.scrachx.openfood.features.compare.ProductCompareViewModel.SideEffect
+import openfoodfacts.github.scrachx.openfood.features.product.view.ProductViewActivityStarter
 import openfoodfacts.github.scrachx.openfood.features.shared.BaseActivity
 import openfoodfacts.github.scrachx.openfood.features.simplescan.SimpleScanActivityContract
 import openfoodfacts.github.scrachx.openfood.images.ProductImage
@@ -32,6 +33,7 @@ import openfoodfacts.github.scrachx.openfood.listeners.CommonBottomListenerInsta
 import openfoodfacts.github.scrachx.openfood.listeners.CommonBottomListenerInstaller.selectNavigationItem
 import openfoodfacts.github.scrachx.openfood.models.Product
 import openfoodfacts.github.scrachx.openfood.models.ProductImageField
+import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient
 import openfoodfacts.github.scrachx.openfood.utils.*
 import java.util.*
 import javax.inject.Inject
@@ -40,10 +42,16 @@ import javax.inject.Inject
 class ProductCompareActivity : BaseActivity() {
 
     @Inject
+    lateinit var client: OpenFoodAPIClient
+
+    @Inject
     lateinit var picasso: Picasso
 
     @Inject
     lateinit var sharedPreferences: SharedPreferences
+
+    @Inject
+    lateinit var productViewActivityStarter: ProductViewActivityStarter
 
     private lateinit var binding: ActivityProductComparisonBinding
     private lateinit var photoReceiverHandler: PhotoReceiverHandler
@@ -140,7 +148,7 @@ class ProductCompareActivity : BaseActivity() {
 
             fullProductClickListener = {
                 val barcode = it.code
-                openProduct(barcode)
+                productViewActivityStarter.openProduct(barcode, this@ProductCompareActivity)
             }
         }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/ProductEditActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/ProductEditActivity.kt
@@ -77,6 +77,9 @@ class ProductEditActivity : BaseActivity() {
     private val binding get() = _binding!!
 
     @Inject
+    lateinit var client: OpenFoodAPIClient
+
+    @Inject
     lateinit var offlineService: OfflineProductService
 
     @Inject

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/overview/EditOverviewFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/overview/EditOverviewFragment.kt
@@ -39,7 +39,7 @@ import com.hootsuite.nachos.validator.ChipifyingNachoValidator
 import com.squareup.picasso.Callback
 import com.squareup.picasso.Picasso
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.rx2.awaitSingleOrNull
+import kotlinx.coroutines.launch
 import openfoodfacts.github.scrachx.openfood.AppFlavors.OBF
 import openfoodfacts.github.scrachx.openfood.AppFlavors.OFF
 import openfoodfacts.github.scrachx.openfood.AppFlavors.OPF
@@ -70,7 +70,6 @@ import openfoodfacts.github.scrachx.openfood.network.ApiFields
 import openfoodfacts.github.scrachx.openfood.network.ApiFields.Keys.lcProductNameKey
 import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient
 import openfoodfacts.github.scrachx.openfood.utils.*
-import openfoodfacts.github.scrachx.openfood.utils.FileDownloader.download
 import org.apache.commons.lang3.StringUtils
 import org.jetbrains.annotations.Contract
 import java.io.File
@@ -95,6 +94,9 @@ class EditOverviewFragment : ProductEditFragment() {
 
     @Inject
     lateinit var client: OpenFoodAPIClient
+
+    @Inject
+    lateinit var fileDownloader: FileDownloader
 
     @Inject
     lateinit var matomoAnalytics: MatomoAnalytics
@@ -635,12 +637,12 @@ class EditOverviewFragment : ProductEditFragment() {
             isFrontImagePresent = true
             if (photoFile == null) {
                 lifecycleScope.launchWhenResumed {
-                    val uri = download(requireContext(), frontImageUrl!!, client).awaitSingleOrNull() ?: return@launchWhenResumed
-
-                    photoFile = uri.toFile()
-                    cropRotateImage(uri, getString(R.string.set_img_front))
+                    val uri = fileDownloader.download(frontImageUrl!!)
+                    if (uri != null) {
+                        photoFile = uri.toFile()
+                        cropRotateImage(uri, getString(R.string.set_img_front))
+                    }
                 }
-
             } else {
                 cropRotateImage(photoFile!!, getString(R.string.set_img_front))
             }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ProductViewActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ProductViewActivity.kt
@@ -56,6 +56,7 @@ import openfoodfacts.github.scrachx.openfood.listeners.CommonBottomListenerInsta
 import openfoodfacts.github.scrachx.openfood.listeners.OnRefreshListener
 import openfoodfacts.github.scrachx.openfood.models.ProductState
 import openfoodfacts.github.scrachx.openfood.models.eventbus.ProductNeedsRefreshEvent
+import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient
 import openfoodfacts.github.scrachx.openfood.utils.Utils
 import openfoodfacts.github.scrachx.openfood.utils.requireProductState
 import org.greenrobot.eventbus.EventBus
@@ -68,7 +69,13 @@ class ProductViewActivity : BaseActivity(), IProductView, OnRefreshListener {
     private val binding get() = _binding!!
 
     @Inject
+    lateinit var client: OpenFoodAPIClient
+
+    @Inject
     lateinit var sharedPreferences: SharedPreferences
+
+    @Inject
+    lateinit var productViewActivityStarter: ProductViewActivityStarter
 
     private var productState: ProductState? = null
     private var adapterResult: ProductFragmentPagerAdapter? = null
@@ -153,7 +160,7 @@ class ProductViewActivity : BaseActivity(), IProductView, OnRefreshListener {
     }
 
     override fun onRefresh() {
-        openProduct(productState!!.product!!.code)
+        productViewActivityStarter.openProduct(productState!!.product!!.code, this)
     }
 
     override fun onNewIntent(intent: Intent) {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ProductViewActivityStarter.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ProductViewActivityStarter.kt
@@ -81,7 +81,7 @@ class ProductViewActivityStarter @Inject constructor(
     private fun showNotFoundDialog(activity: Activity, barcode: String, withBackPressure: Boolean) {
         MaterialAlertDialogBuilder(activity)
             .setTitle(R.string.txtDialogsTitle)
-            .setMessage(R.string.txtDialogsContent)
+            .setMessage(R.string.product_does_not_exist_please_add_it)
             .setPositiveButton(R.string.txtYes) { _, _ ->
                 val product = Product().apply {
                     code = barcode

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ProductViewActivityStarter.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ProductViewActivityStarter.kt
@@ -1,0 +1,112 @@
+package openfoodfacts.github.scrachx.openfood.features.product.view
+
+import android.app.Activity
+import android.content.Intent
+import android.widget.Toast
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import openfoodfacts.github.scrachx.openfood.R
+import openfoodfacts.github.scrachx.openfood.features.product.edit.ProductEditActivity
+import openfoodfacts.github.scrachx.openfood.models.Product
+import openfoodfacts.github.scrachx.openfood.network.ApiFields
+import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient
+import openfoodfacts.github.scrachx.openfood.network.services.ProductsAPI
+import openfoodfacts.github.scrachx.openfood.repositories.NetworkConnectivityRepository
+import openfoodfacts.github.scrachx.openfood.utils.*
+import java.io.IOException
+import javax.inject.Inject
+
+class ProductViewActivityStarter @Inject constructor(
+    private val productsApi: ProductsAPI,
+    private val localeManager: LocaleManager,
+    private val client: OpenFoodAPIClient,
+    private val coroutineDispatchers: CoroutineDispatchers,
+    private val networkConnectivityRepository: NetworkConnectivityRepository,
+) {
+
+    /**
+     * Open the product in [ProductViewActivity] if the barcode exist.
+     * Also add it in the history if the product exist.
+     *
+     * @param barcode product barcode
+     * @param activity
+     */
+    fun openProduct(barcode: String, activity: FragmentActivity) {
+        if (networkConnectivityRepository.isNetworkAvailable()) {
+            activity.hideKeyboard()
+            activity.lifecycleScope.launch {
+                tryToStartActivity(activity, barcode)
+            }
+        } else {
+            showNoNetworkDialog(activity) {
+                openProduct(barcode, activity)
+            }
+        }
+    }
+
+    private suspend fun tryToStartActivity(activity: Activity, barcode: String) {
+        val result = withContext(coroutineDispatchers.io()) {
+            runCatching {
+                productsApi.getProductByBarcode(
+                    barcode,
+                    ApiFields.getAllFields(localeManager.getLanguage()),
+                    localeManager.getLanguage(),
+                    getUserAgent(Utils.HEADER_USER_AGENT_SEARCH)
+                )
+            }
+        }
+        withContext(coroutineDispatchers.main()) {
+            result.fold(
+                onSuccess = { productState ->
+                    if (productState.status == 0L) {
+                        showNotFoundDialog(activity, barcode, true)
+                    } else {
+                        client.addToHistory(productState.product!!)
+                        ProductViewActivity.start(activity, productState)
+                    }
+                },
+                onFailure = {
+                    when (it) {
+                        is IOException -> Toast.makeText(activity, R.string.something_went_wrong, Toast.LENGTH_LONG).show()
+                        else -> showNotFoundDialog(activity, barcode, false)
+                    }
+                }
+            )
+        }
+    }
+
+    private fun showNotFoundDialog(activity: Activity, barcode: String, withBackPressure: Boolean) {
+        MaterialAlertDialogBuilder(activity)
+            .setTitle(R.string.txtDialogsTitle)
+            .setMessage(R.string.txtDialogsContent)
+            .setPositiveButton(R.string.txtYes) { _, _ ->
+                val product = Product().apply {
+                    code = barcode
+                    lang = localeManager.getLanguage()
+                }
+                val intent = Intent(activity, ProductEditActivity::class.java).apply {
+                    putExtra(ProductEditActivity.KEY_EDIT_PRODUCT, product)
+                }
+                activity.startActivity(intent)
+                activity.finish()
+            }
+            .setNegativeButton(R.string.txtNo) { _, _ ->
+                if (withBackPressure) {
+                    activity.onBackPressed()
+                }
+            }
+            .show()
+    }
+
+    private fun showNoNetworkDialog(activity: Activity, positiveAction: () -> Unit) {
+        MaterialAlertDialogBuilder(activity)
+            .setTitle(R.string.device_offline_dialog_title)
+            .setMessage(R.string.connectivity_check)
+            .setPositiveButton(R.string.txt_try_again) { _, _ -> positiveAction() }
+            .setNegativeButton(R.string.dismiss) { d, _ -> d.dismiss() }
+            .show()
+    }
+}

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlist/ProductListActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlist/ProductListActivity.kt
@@ -32,6 +32,7 @@ import openfoodfacts.github.scrachx.openfood.R
 import openfoodfacts.github.scrachx.openfood.analytics.AnalyticsEvent
 import openfoodfacts.github.scrachx.openfood.analytics.MatomoAnalytics
 import openfoodfacts.github.scrachx.openfood.databinding.ActivityYourListedProductsBinding
+import openfoodfacts.github.scrachx.openfood.features.product.view.ProductViewActivityStarter
 import openfoodfacts.github.scrachx.openfood.features.shared.BaseActivity
 import openfoodfacts.github.scrachx.openfood.listeners.CommonBottomListenerInstaller.installBottomNavigation
 import openfoodfacts.github.scrachx.openfood.listeners.CommonBottomListenerInstaller.selectNavigationItem
@@ -65,6 +66,9 @@ class ProductListActivity : BaseActivity(), SwipeController.Actions {
 
     @Inject
     lateinit var picasso: Picasso
+
+    @Inject
+    lateinit var productViewActivityStarter: ProductViewActivityStarter
 
     private var listID by Delegates.notNull<Long>()
     private lateinit var productList: ProductLists
@@ -144,7 +148,7 @@ class ProductListActivity : BaseActivity(), SwipeController.Actions {
             isLowBatteryMode,
             picasso,
             onItemClickListener = {
-                lifecycleScope.launch { client.openProduct(it.barcode, this@ProductListActivity) }
+                lifecycleScope.launch { productViewActivityStarter.openProduct(it.barcode, this@ProductListActivity) }
             }
         )
         binding.rvYourListedProducts.adapter = adapter

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/scan/ContinuousScanActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/scan/ContinuousScanActivity.kt
@@ -83,6 +83,7 @@ import openfoodfacts.github.scrachx.openfood.models.entities.allergen.AllergenNa
 import openfoodfacts.github.scrachx.openfood.models.entities.analysistagconfig.AnalysisTagConfig
 import openfoodfacts.github.scrachx.openfood.models.eventbus.ProductNeedsRefreshEvent
 import openfoodfacts.github.scrachx.openfood.network.ApiFields.StateTags
+import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient
 import openfoodfacts.github.scrachx.openfood.repositories.ProductRepository
 import openfoodfacts.github.scrachx.openfood.repositories.ScannerPreferencesRepository
 import openfoodfacts.github.scrachx.openfood.utils.*
@@ -97,6 +98,9 @@ import javax.inject.Inject
 class ContinuousScanActivity : BaseActivity(), IProductView {
     private var _binding: ActivityContinuousScanBinding? = null
     internal val binding get() = _binding!!
+
+    @Inject
+    lateinit var client: OpenFoodAPIClient
 
     @Inject
     lateinit var daoSession: DaoSession

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/scanhistory/ScanHistoryActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/scanhistory/ScanHistoryActivity.kt
@@ -33,10 +33,12 @@ import openfoodfacts.github.scrachx.openfood.AppFlavors.isFlavors
 import openfoodfacts.github.scrachx.openfood.BuildConfig
 import openfoodfacts.github.scrachx.openfood.R
 import openfoodfacts.github.scrachx.openfood.databinding.ActivityHistoryScanBinding
+import openfoodfacts.github.scrachx.openfood.features.product.view.ProductViewActivityStarter
 import openfoodfacts.github.scrachx.openfood.features.productlist.CreateCSVContract
 import openfoodfacts.github.scrachx.openfood.features.shared.BaseActivity
 import openfoodfacts.github.scrachx.openfood.listeners.CommonBottomListenerInstaller.installBottomNavigation
 import openfoodfacts.github.scrachx.openfood.listeners.CommonBottomListenerInstaller.selectNavigationItem
+import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient
 import openfoodfacts.github.scrachx.openfood.utils.*
 import openfoodfacts.github.scrachx.openfood.utils.SortType.*
 import java.io.File
@@ -51,6 +53,12 @@ class ScanHistoryActivity : BaseActivity() {
     private val viewModel: ScanHistoryViewModel by viewModels()
 
     @Inject
+    lateinit var client: OpenFoodAPIClient
+
+    @Inject
+    lateinit var productViewActivityStarter: ProductViewActivityStarter
+
+    @Inject
     lateinit var picasso: Picasso
 
     @Inject
@@ -63,7 +71,7 @@ class ScanHistoryActivity : BaseActivity() {
 
     private val adapter by lazy {
         ScanHistoryAdapter(isLowBatteryMode = isDisableImageLoad() && isBatteryLevelLow(), picasso) {
-            openProduct(it.barcode)
+            productViewActivityStarter.openProduct(it.barcode, this)
         }
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/searchbycode/SearchByCodeFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/searchbycode/SearchByCodeFragment.kt
@@ -11,6 +11,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import openfoodfacts.github.scrachx.openfood.R
 import openfoodfacts.github.scrachx.openfood.databinding.FragmentFindProductBinding
+import openfoodfacts.github.scrachx.openfood.features.product.view.ProductViewActivityStarter
 import openfoodfacts.github.scrachx.openfood.features.shared.NavigationBaseFragment
 import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient
 import openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener
@@ -29,6 +30,9 @@ class SearchByCodeFragment : NavigationBaseFragment() {
 
     @Inject
     lateinit var client: OpenFoodAPIClient
+
+    @Inject
+    lateinit var productViewActivityStarter: ProductViewActivityStarter
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentFindProductBinding.inflate(inflater)
@@ -69,7 +73,7 @@ class SearchByCodeFragment : NavigationBaseFragment() {
         } else if (!isBarcodeValid(barCodeTxt)) {
             binding.editTextBarcode.error = resources.getString(R.string.txtBarcodeNotValid)
         } else {
-            lifecycleScope.launch { client.openProduct(barCodeTxt, requireActivity()) }
+            lifecycleScope.launch { productViewActivityStarter.openProduct(barCodeTxt, requireActivity()) }
         }
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/shared/BaseActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/shared/BaseActivity.kt
@@ -24,24 +24,18 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.CallSuper
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.lifecycle.lifecycleScope
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import dagger.hilt.EntryPoints
-import kotlinx.coroutines.launch
 import openfoodfacts.github.scrachx.openfood.R
 import openfoodfacts.github.scrachx.openfood.features.scan.ContinuousScanActivity
 import openfoodfacts.github.scrachx.openfood.hilt.AppEntryPoint
-import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient
-import openfoodfacts.github.scrachx.openfood.utils.*
-import javax.inject.Inject
+import openfoodfacts.github.scrachx.openfood.utils.MY_PERMISSIONS_REQUEST_CAMERA
+import openfoodfacts.github.scrachx.openfood.utils.getLoginPreferences
 
 abstract class BaseActivity : AppCompatActivity() {
 
-    @Inject
-    lateinit var client: OpenFoodAPIClient
-
-    protected val requestCameraThenOpenScan = registerForActivityResult(ActivityResultContracts.RequestPermission())
-    { if (it) startScanActivity() }
+    protected val requestCameraThenOpenScan = registerForActivityResult(ActivityResultContracts.RequestPermission()) {
+        if (it) startScanActivity()
+    }
 
     override fun attachBaseContext(newBase: Context) {
         val lm = EntryPoints.get(newBase.applicationContext, AppEntryPoint::class.java).localeManager()
@@ -76,20 +70,6 @@ abstract class BaseActivity : AppCompatActivity() {
         Intent(this, ContinuousScanActivity::class.java)
             .apply { addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP) }
             .let { startActivity(it) }
-    }
-
-    protected fun openProduct(barcode: String) {
-        if (isNetworkConnected()) {
-            hideKeyboard()
-            lifecycleScope.launch { client.openProduct(barcode, this@BaseActivity) }
-        } else {
-            MaterialAlertDialogBuilder(this)
-                .setTitle(R.string.device_offline_dialog_title)
-                .setMessage(R.string.connectivity_check)
-                .setPositiveButton(R.string.txt_try_again) { _, _ -> openProduct(barcode) }
-                .setNegativeButton(R.string.dismiss) { d, _ -> d.dismiss() }
-                .show()
-        }
     }
 }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/ApiFields.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/ApiFields.kt
@@ -307,4 +307,16 @@ object ApiFields {
             NOVA_GROUPS
         )
     }
+
+    fun getAllFields(langCode: String): String {
+        val allFields = Keys.PRODUCT_COMMON_FIELDS
+        val fieldsToLocalize = Keys.PRODUCT_LOCAL_FIELDS
+
+        val fieldsSet = allFields.toMutableSet()
+        fieldsToLocalize.forEach { (field, shouldAddEn) ->
+            fieldsSet += "${field}_$langCode"
+            if (shouldAddEn) fieldsSet += "${field}_en"
+        }
+        return fieldsSet.joinToString(",")
+    }
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/FileDownloader.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/FileDownloader.kt
@@ -4,74 +4,77 @@ import android.content.Context
 import android.net.Uri
 import android.util.Log
 import androidx.core.net.toUri
-import io.reactivex.Maybe
-import io.reactivex.schedulers.Schedulers
-import kotlinx.coroutines.Dispatchers
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.rx2.await
-import kotlinx.coroutines.rx2.rxMaybe
 import kotlinx.coroutines.withContext
 import okhttp3.ResponseBody
-import openfoodfacts.github.scrachx.openfood.network.OpenFoodAPIClient
+import openfoodfacts.github.scrachx.openfood.network.services.ProductsAPI
 import openfoodfacts.github.scrachx.openfood.utils.Utils.makeOrGetPictureDirectory
 import java.io.File
 import java.io.IOException
+import javax.inject.Inject
 
 /**
  * File Downloader class which is used to download a file and
  * write response to the disk.
  */
-object FileDownloader {
-    private val LOG_TAG = FileDownloader::class.simpleName
+class FileDownloader @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val productsAPI: ProductsAPI,
+    private val coroutineDispatchers: CoroutineDispatchers,
+) {
+
+    companion object {
+        private const val LOG_TAG = "FileDownloader"
+    }
 
     /**
-     * Downloads a file from the given fileUrl.
-     * If file is found write to disk and then return it via [Maybe].
+     * Downloads a file from the given fileUrl and stores it on disk.
      *
-     * Network operations are done via [Schedulers.io]
-     *
-     * To use the result for UI updated remember to *OBSERVE ON MAIN THREAD*
-     *
-     * @param context
-     * @param fileUrl provides the URL of the file to download.
-     * @return [Maybe]
+     * @param fileUrl provides the URL of the file to download
+     * @return [Uri] in case of success and null otherwise
      */
-    fun download(context: Context, fileUrl: String, client: OpenFoodAPIClient): Maybe<Uri> = rxMaybe(Dispatchers.IO) {
-        val body = try {
-            client.rawApi.downloadFile(fileUrl).await()
-        } catch (err: Exception) {
-            Log.e(LOG_TAG, "error", err)
-            return@rxMaybe null
+    suspend fun download(fileUrl: String): Uri? {
+        val file = withContext(coroutineDispatchers.io()) {
+            val result = runCatching {
+                productsAPI.downloadFile(fileUrl).await()
+            }
+            result.fold(
+                onSuccess = { response ->
+                    writeResponseBodyToDisk(response, fileUrl)
+                },
+                onFailure = {
+                    Log.e(LOG_TAG, "error", it)
+                    null
+                }
+            )
         }
-        Log.d(LOG_TAG, "Server contacted and has file")
-
-        writeResponseBodyToDiskSync(context, body, fileUrl).also {
-            Log.d(LOG_TAG, "Downloaded file $it")
+        return withContext(coroutineDispatchers.main()) {
+            file?.toUri()
         }
     }
+
 
     /**
      * A method to write the response body to disk.
      *
-     * @param context: [Context] of the class.
      * @param body: [ResponseBody] from the call.
      * @param request: url of the downloaded file.
-     * @return [File] that has been written to the disk.
+     * @return [File] that has been written to the disk or null in case of failure
      */
-    private suspend fun writeResponseBodyToDiskSync(context: Context, body: ResponseBody, request: String): Uri? =
-        withContext(Dispatchers.IO) {
-            val requestUri = request.toUri()
-            val writtenFile = File(makeOrGetPictureDirectory(context), "${System.currentTimeMillis()}-${requestUri.lastPathSegment}")
-            try {
-                body.byteStream().use { stream ->
-                    writtenFile.outputStream().use { out ->
-                        stream.copyTo(out)
-                        out.flush()
-                    }
+    private fun writeResponseBodyToDisk(body: ResponseBody, request: String): File? {
+        val requestUri = request.toUri()
+        val writtenFile = File(makeOrGetPictureDirectory(context), "${System.currentTimeMillis()}-${requestUri.lastPathSegment}")
+        return try {
+            body.byteStream().use { input ->
+                writtenFile.outputStream().use { output ->
+                    input.copyTo(output)
                 }
-                writtenFile.toUri()
-            } catch (e: IOException) {
-                Log.w(LOG_TAG, "Could not write file $writtenFile to disk.", e)
-                null
             }
+            writtenFile
+        } catch (e: IOException) {
+            Log.w(LOG_TAG, "Could not write file $writtenFile to disk.", e)
+            null
         }
+    }
 }


### PR DESCRIPTION
####  Description
Paying the tech debt from this TODO "This is not part of the client, move it to another class (preferably a utility class)" in `OpenFoodAPIClient`. 

Details:
- moved the functionality of opening product screen to a separate class called `ProductViewActivityStarter`
- refactored FileDownloader to be within Hilt and without rxjava

Made a smoke test on my device - looks like I didn't break anything 😅