### PR TITLE
Updating UI from Main thread

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/ProductEditActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/ProductEditActivity.kt
@@ -527,7 +527,7 @@ class ProductEditActivity : BaseActivity() {
             try {
                 productsApi.performOCR(code, imageField).await()
             } catch (err: Exception) {
-                ingredientsFragment.hideOCRProgress()
+                withContext(Main) { ingredientsFragment.hideOCRProgress() }
                 if (err is IOException) {
                     val view = findViewById<View>(R.id.coordinator_layout)
                     Snackbar.make(view, R.string.no_internet_unable_to_extract_ingredients, LENGTH_INDEFINITE)


### PR DESCRIPTION
####  Description
Wrapping the existing call to `ingredientsFragment.hideOCRProgress()` with main context as is being done a few lines later, outside of the try/catch.

#### Related issues
Fixes #4247
<!--
- Add the issue number here.
- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- If you have solved the issue completely use "Fixes #{issue_number}, example: "Fixes #123, #345".
-->

#### Link to the automatically generated build APK
<!-- If your build succeeds after making this PR, you will get an APK. Please edit your PR and add the link here -->
Will update tomorrow, when the build has completed.