### PR TITLE
fix: An incorrect serving size should not crash the app

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
@@ -310,13 +310,16 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
         getModifierIndex(nutriments[nutriment]?.modifier)
 
     private fun updateServingSize(servingSize: String) {
+        try {
+            val (value, unit) = parseServing(servingSize)
 
-        val (value, unit) = parseServing(servingSize)
+            binding.servingSize.setText(value)
 
-        binding.servingSize.setText(value)
-
-        if (unit != null) {
-            binding.servingSize.unitSpinner?.setSelection(getServingUnitIndex(unit))
+            if (unit != null) {
+                binding.servingSize.unitSpinner?.setSelection(getServingUnitIndex(unit))
+            }
+        } catch (exception : IllegalArgumentException) {
+            binding.servingSize.setText("")
         }
     }
 


### PR DESCRIPTION
Today, if the serving has an incorrect value (eg: "serving" with product 5900951251849), the app is crashing immediately.
I have changed the code, to insert a blank value instead. Not sure, if it's the right way to fix it.

Linked to issue #4270