### PR TITLE
fix: When no further fragment is visible, the app should close itself

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/MainActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/MainActivity.kt
@@ -628,15 +628,18 @@ class MainActivity : BaseActivity(), NavigationDrawerListener {
         // activity
         if (drawerResult.isDrawerOpen) {
             drawerResult.closeDrawer()
+        } else if (supportFragmentManager.backStackEntryCount > 0) {
+            supportFragmentManager.popBackStackImmediate(
+                supportFragmentManager.getBackStackEntryAt(0).id,
+                FragmentManager.POP_BACK_STACK_INCLUSIVE
+            )
+
+            // Close the app if no Fragment is visible anymore
+            if (supportFragmentManager.backStackEntryCount == 0) {
+                super.onBackPressed()
+            }
         } else {
-            if (supportFragmentManager.backStackEntryCount > 0) {
-                supportFragmentManager.popBackStack(
-                    supportFragmentManager.getBackStackEntryAt(0).id,
-                    FragmentManager.POP_BACK_STACK_INCLUSIVE
-                )
-                // Recreate the activity onBackPressed
-                recreate()
-            } else super.onBackPressed()
+            super.onBackPressed()
         }
     }
 


### PR DESCRIPTION
When no further fragment is visible on the homescreen, the app should close itself, not recreating an Activity (infinite loop otherwise)

- Link to issue: #4320