### PR TITLE
Replacing allergens should keep their "enabled" statuses

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
@@ -310,13 +310,16 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
         getModifierIndex(nutriments[nutriment]?.modifier)
 
     private fun updateServingSize(servingSize: String) {
+        try {
+            val (value, unit) = parseServing(servingSize)
 
-        val (value, unit) = parseServing(servingSize)
+            binding.servingSize.setText(value)
 
-        binding.servingSize.setText(value)
-
-        if (unit != null) {
-            binding.servingSize.unitSpinner?.setSelection(getServingUnitIndex(unit))
+            if (unit != null) {
+                binding.servingSize.unitSpinner?.setSelection(getServingUnitIndex(unit))
+            }
+        } catch (exception : IllegalArgumentException) {
+            binding.servingSize.setText("")
         }
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/ProductRepository.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/ProductRepository.kt
@@ -336,7 +336,18 @@ class ProductRepository @Inject constructor(
     fun saveAllergens(allergens: List<Allergen>) {
         daoSession.database.beginTransaction()
         try {
+
             allergens.forEach { allergen ->
+                // If the allergen is already in the database, ensure the "enabled" field is used,
+                // instead of replaced
+                val dbAllergen = daoSession.allergenDao.queryBuilder()
+                    .where(AllergenDao.Properties.Tag.eq(allergen.tag))
+                    .unique()
+
+                if (dbAllergen != null) {
+                    allergen.enabled = dbAllergen.enabled
+                }
+
                 daoSession.allergenDao.insertOrReplace(allergen)
                 allergen.names.forEach { daoSession.allergenNameDao.insertOrReplace(it) }
             }


### PR DESCRIPTION
The issue #4120 come from the fact that when taxonomies are refreshed, all allergens are replaced.
BUT an allergen may have its "enabled" column at `true`, which means it's also an alert.
Here, I copy the "enabled" value to be sure to not lose the previous state