### PR TITLE
chore: remove keylistener for additional nutrients in edit mode

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
@@ -20,9 +20,7 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import android.text.Editable
 import android.text.Html
-import android.text.InputType
 import android.text.TextWatcher
-import android.text.method.NumberKeyListener
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -94,12 +92,6 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
 
     @Inject
     lateinit var localeManager: LocaleManager
-
-    private val keyListener = object : NumberKeyListener() {
-        override fun getInputType() = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD
-
-        override fun getAcceptedChars() = charArrayOf('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ',', '.')
-    }
 
     private val photoReceiverHandler: PhotoReceiverHandler by lazy {
         PhotoReceiverHandler(sharedPreferences) {
@@ -767,7 +759,6 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
 
         val editText = rowView.findViewById<CustomValidatingEditTextView>(R.id.value)
         editText.entryName = nutrientShortName
-        editText.keyListener = keyListener
 
         lastEditText!!.nextFocusDownId = editText.id
         lastEditText!!.imeOptions = EditorInfo.IME_ACTION_NEXT


### PR DESCRIPTION
####  Description
On the edit page for nutrients (`ProductEditNutritionFactsFragment`), I removed the additional keylistener from the code. The input type and allowed characters are already defined in the XML for the additional nutrients (in the fragment as well as in the layout for the additional rows). Input is correctly filtered. Tested it with an external keyboard as  well as with copy & pasting values into the field.

#### Related issues
- Fixes #4143 

#### Screenshots
![4143 - Number keyboard](https://user-images.githubusercontent.com/2601296/138959333-6267a2ed-b86e-45e1-99c1-d4cde9a3a69f.PNG)

#### Link to the automatically generated build APK
<!-- If your build succeeds after making this PR, you will get an APK. Please edit your PR and add the link here -->
OFF APK: https://github.com/openfoodfacts/openfoodfacts-androidapp/suites/4169733298/artifacts/107222517
