### PR TITLE
Issue/4141 improve edit mode by fixing button at the bottom

### DIFF
--- a/app/src/main/res/layout/activity_edit_product.xml
+++ b/app/src/main/res/layout/activity_edit_product.xml
@@ -113,7 +113,6 @@
         android:id="@+id/viewpager"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_marginTop="@dimen/spacing_small"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@id/grey_line" />

--- a/app/src/main/res/layout/fragment_add_product_ingredients.xml
+++ b/app/src/main/res/layout/fragment_add_product_ingredients.xml
@@ -1,331 +1,346 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_gravity="fill_vertical"
-    android:clipToPadding="false"
-    android:isScrollContainer="false"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior"
-    tools:context=".features.product.edit.ingredients.EditIngredientsFragment">
+    tools:context=".features.product.edit.ingredients.EditIngredientsFragment"
+    >
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_height="0dp"
+        android:layout_width="0dp"
+        app:layout_constraintHeight_default="wrap"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/btn_next"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintVertical_bias="0"
+        android:layout_gravity="fill_vertical"
+        android:isScrollContainer="false"
+        android:paddingTop="@dimen/spacing_small"
+        android:paddingBottom="16dp"
+        android:clipToPadding="false"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        >
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:id="@+id/section_ingredients_picture"
+                style="@style/EditHeader"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
+                android:text="@string/ingredients_picture"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/hint_image_ingredients"
+                style="@style/EditHint"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
+                android:text="@string/take_ingredients_picture_to_extract"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/section_ingredients_picture" />
+
+            <ImageView
+                android:id="@+id/btnAddImageIngredients"
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                android:layout_marginStart="24dp"
+                android:layout_marginTop="8dp"
+                android:background="?android:selectableItemBackground"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/hint_image_ingredients"
+                app:srcCompat="@drawable/ic_add_a_photo_dark_48dp"
+                tools:ignore="ContentDescription" />
+
+            <Button
+                android:id="@+id/btnEditImageIngredients"
+                style="@style/ButtonBorder"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
+                android:text="@string/update_image"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@id/btnAddImageIngredients"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/btnAddImageIngredients"
+                app:layout_constraintTop_toTopOf="@id/btnAddImageIngredients" />
+
+            <ProgressBar
+                android:id="@+id/imageProgress"
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                android:layout_margin="@dimen/spacing_small"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@+id/btnAddImageIngredients"
+                app:layout_constraintEnd_toEndOf="@+id/btnAddImageIngredients"
+                app:layout_constraintStart_toStartOf="@+id/btnAddImageIngredients"
+                app:layout_constraintTop_toTopOf="@+id/btnAddImageIngredients" />
+
+            <TextView
+                android:id="@+id/imageProgressText"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
+                android:text="@string/toastSending"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@id/imageProgress"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/btnAddImageIngredients"
+                app:layout_constraintTop_toTopOf="@id/imageProgress"
+                tools:visibility="visible" />
+
+            <View
+                android:id="@+id/grey_line1"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginStart="@dimen/spacing_small"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_marginEnd="@dimen/spacing_small"
+                android:background="@color/grey_400"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/btn_extract_ingredients" />
+
+            <TextView
+                android:id="@+id/section_ingredients_list"
+                style="@style/EditHeader"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
+                android:labelFor="@id/ingredients_list"
+                android:text="@string/ingredients_list"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/grey_line1" />
+
+            <TextView
+                android:id="@+id/hint_ingredients_list"
+                style="@style/EditHint"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:text="@string/ingredients_hint"
+                app:layout_constraintEnd_toEndOf="@id/ingredients_list"
+                app:layout_constraintStart_toStartOf="@id/section_ingredients_picture"
+                app:layout_constraintTop_toBottomOf="@id/section_ingredients_list" />
+
+
+            <EditText
+                android:id="@+id/ingredients_list"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:background="@drawable/bg_edittext"
+                android:gravity="start|top"
+                android:inputType="textMultiLine"
+                android:minHeight="150dp"
+                android:nextFocusDown="@id/traces"
+                android:padding="@dimen/spacing_small"
+                android:singleLine="false"
+                android:textDirection="anyRtl"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/hint_ingredients_list" />
+
+            <Button
+                android:id="@+id/btn_extract_ingredients"
+                style="@style/ButtonBorder"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="8dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/extract_ingredients"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/btnAddImageIngredients"
+                tools:visibility="visible" />
+
+            <ImageView
+                android:id="@+id/ingredients_list_verified"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/spacing_small"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@id/ingredients_list"
+                app:layout_constraintEnd_toEndOf="@id/ingredients_list"
+                app:srcCompat="@drawable/ic_check_white_24dp"
+                app:tint="@color/brand_green_dark"
+                tools:ignore="ContentDescription" />
+
+            <ProgressBar
+                android:id="@+id/ocr_progress_spinner"
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                app:layout_constraintBottom_toTopOf="@id/ocr_progress_text"
+                app:layout_constraintEnd_toEndOf="@id/ingredients_list"
+                app:layout_constraintStart_toStartOf="@id/ingredients_list"
+                app:layout_constraintTop_toTopOf="@id/ingredients_list"
+                app:layout_constraintVertical_chainStyle="packed" />
+
+            <TextView
+                android:id="@+id/ocr_progress_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/extracting_ingredients"
+                app:layout_constraintBottom_toBottomOf="@+id/ingredients_list"
+                app:layout_constraintEnd_toEndOf="@id/ocr_progress_spinner"
+                app:layout_constraintStart_toStartOf="@id/ocr_progress_spinner"
+                app:layout_constraintTop_toBottomOf="@id/ocr_progress_spinner" />
+
+            <androidx.constraintlayout.widget.Group
+                android:id="@+id/ocr_progress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:constraint_referenced_ids="ocr_progress_spinner,ocr_progress_text" />
+
+            <Button
+                android:id="@+id/btn_looks_good"
+                style="@style/ButtonFlat.Green"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_marginEnd="@dimen/spacing_small"
+                android:text="@string/looksGood"
+                android:textColor="@color/white"
+                android:visibility="gone"
+                app:layout_constraintBottom_toTopOf="@id/btn_barrier"
+                app:layout_constraintEnd_toStartOf="@id/btn_skip_ingredients"
+                app:layout_constraintStart_toStartOf="@id/ingredients_list"
+                app:layout_constraintTop_toBottomOf="@id/ingredients_list"
+                tools:visibility="visible" />
+
+            <Button
+                android:id="@+id/btn_skip_ingredients"
+                style="@style/ButtonFlat.Red"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/spacing_small"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:text="@string/skip_ingredients"
+                android:textColor="@color/white"
+                android:visibility="gone"
+                app:layout_constraintBottom_toTopOf="@id/btn_barrier"
+                app:layout_constraintEnd_toEndOf="@id/ingredients_list"
+                app:layout_constraintStart_toEndOf="@+id/btn_looks_good"
+                app:layout_constraintTop_toBottomOf="@id/ingredients_list"
+                tools:text="Really really long text coming from Narnia"
+                tools:visibility="visible" />
+
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/btn_barrier"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:barrierDirection="bottom"
+                app:constraint_referenced_ids="btn_looks_good,btn_skip_ingredients"
+                tools:layout_editor_absoluteX="165dp"
+                tools:layout_editor_absoluteY="421dp" />
+
+            <View
+                android:id="@+id/grey_line2"
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginStart="@dimen/spacing_small"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_marginEnd="@dimen/spacing_small"
+                android:background="@color/grey_400"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/btn_barrier" />
+
+            <TextView
+                android:id="@+id/section_traces"
+                style="@style/EditHeader"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
+                android:text="@string/traces"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/grey_line2" />
+
+            <TextView
+                android:id="@+id/hint_traces"
+                style="@style/EditHint"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginEnd="16dp"
+                android:layout_marginRight="16dp"
+                android:text="@string/traces_hint"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/section_traces" />
+
+            <com.hootsuite.nachos.NachoTextView
+                android:id="@+id/traces"
+                android:layout_width="0dp"
+                android:layout_height="48dp"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:background="@drawable/bg_edittext"
+                android:completionThreshold="1"
+                android:gravity="center_vertical"
+                android:inputType="text"
+                android:paddingLeft="@dimen/spacing_small"
+                android:paddingRight="@dimen/spacing_small"
+                app:chipBackground="#4389FA"
+                app:chipHeight="30dp"
+                app:chipTextColor="@color/grey_50"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/hint_traces"
+                tools:ignore="SpeakableTextPresentCheck" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </ScrollView>
+
+    <Button
+        android:id="@+id/btn_next"
+        style="@style/ButtonFlat"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:text="@string/next"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        />
 
-        <TextView
-            android:id="@+id/section_ingredients_picture"
-            style="@style/EditHeader"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/ingredients_picture"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <TextView
-            android:id="@+id/hint_image_ingredients"
-            style="@style/EditHint"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/take_ingredients_picture_to_extract"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/section_ingredients_picture" />
-
-        <ImageView
-            android:id="@+id/btnAddImageIngredients"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            android:layout_marginStart="24dp"
-            android:layout_marginTop="8dp"
-            android:background="?android:selectableItemBackground"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/hint_image_ingredients"
-            app:srcCompat="@drawable/ic_add_a_photo_dark_48dp"
-            tools:ignore="ContentDescription" />
-
-        <Button
-            android:id="@+id/btnEditImageIngredients"
-            style="@style/ButtonBorder"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/update_image"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@id/btnAddImageIngredients"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/btnAddImageIngredients"
-            app:layout_constraintTop_toTopOf="@id/btnAddImageIngredients" />
-
-        <ProgressBar
-            android:id="@+id/imageProgress"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            android:layout_margin="@dimen/spacing_small"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@+id/btnAddImageIngredients"
-            app:layout_constraintEnd_toEndOf="@+id/btnAddImageIngredients"
-            app:layout_constraintStart_toStartOf="@+id/btnAddImageIngredients"
-            app:layout_constraintTop_toTopOf="@+id/btnAddImageIngredients" />
-
-        <TextView
-            android:id="@+id/imageProgressText"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/toastSending"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@id/imageProgress"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/btnAddImageIngredients"
-            app:layout_constraintTop_toTopOf="@id/imageProgress"
-            tools:visibility="visible" />
-
-        <View
-            android:id="@+id/grey_line1"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginStart="@dimen/spacing_small"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginEnd="@dimen/spacing_small"
-            android:background="@color/grey_400"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/btn_extract_ingredients" />
-
-        <TextView
-            android:id="@+id/section_ingredients_list"
-            style="@style/EditHeader"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"
-            android:labelFor="@id/ingredients_list"
-            android:text="@string/ingredients_list"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/grey_line1" />
-
-        <TextView
-            android:id="@+id/hint_ingredients_list"
-            style="@style/EditHint"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@string/ingredients_hint"
-            app:layout_constraintEnd_toEndOf="@id/ingredients_list"
-            app:layout_constraintStart_toStartOf="@id/section_ingredients_picture"
-            app:layout_constraintTop_toBottomOf="@id/section_ingredients_list" />
-
-
-        <EditText
-            android:id="@+id/ingredients_list"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:background="@drawable/bg_edittext"
-            android:gravity="start|top"
-            android:inputType="textMultiLine"
-            android:minHeight="150dp"
-            android:nextFocusDown="@id/traces"
-            android:padding="@dimen/spacing_small"
-            android:singleLine="false"
-            android:textDirection="anyRtl"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/hint_ingredients_list" />
-
-        <Button
-            android:id="@+id/btn_extract_ingredients"
-            style="@style/ButtonBorder"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="8dp"
-            android:layout_marginEnd="16dp"
-            android:text="@string/extract_ingredients"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/btnAddImageIngredients"
-            tools:visibility="visible" />
-
-        <ImageView
-            android:id="@+id/ingredients_list_verified"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/spacing_small"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@id/ingredients_list"
-            app:layout_constraintEnd_toEndOf="@id/ingredients_list"
-            app:srcCompat="@drawable/ic_check_white_24dp"
-            app:tint="@color/brand_green_dark"
-            tools:ignore="ContentDescription" />
-
-        <ProgressBar
-            android:id="@+id/ocr_progress_spinner"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            app:layout_constraintBottom_toTopOf="@id/ocr_progress_text"
-            app:layout_constraintEnd_toEndOf="@id/ingredients_list"
-            app:layout_constraintStart_toStartOf="@id/ingredients_list"
-            app:layout_constraintTop_toTopOf="@id/ingredients_list"
-            app:layout_constraintVertical_chainStyle="packed" />
-
-        <TextView
-            android:id="@+id/ocr_progress_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/extracting_ingredients"
-            app:layout_constraintBottom_toBottomOf="@+id/ingredients_list"
-            app:layout_constraintEnd_toEndOf="@id/ocr_progress_spinner"
-            app:layout_constraintStart_toStartOf="@id/ocr_progress_spinner"
-            app:layout_constraintTop_toBottomOf="@id/ocr_progress_spinner" />
-
-        <androidx.constraintlayout.widget.Group
-            android:id="@+id/ocr_progress"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:constraint_referenced_ids="ocr_progress_spinner,ocr_progress_text" />
-
-        <Button
-            android:id="@+id/btn_looks_good"
-            style="@style/ButtonFlat.Green"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginEnd="@dimen/spacing_small"
-            android:text="@string/looksGood"
-            android:textColor="@color/white"
-            android:visibility="gone"
-            app:layout_constraintBottom_toTopOf="@id/btn_barrier"
-            app:layout_constraintEnd_toStartOf="@id/btn_skip_ingredients"
-            app:layout_constraintStart_toStartOf="@id/ingredients_list"
-            app:layout_constraintTop_toBottomOf="@id/ingredients_list"
-            tools:visibility="visible" />
-
-        <Button
-            android:id="@+id/btn_skip_ingredients"
-            style="@style/ButtonFlat.Red"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/spacing_small"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:text="@string/skip_ingredients"
-            android:textColor="@color/white"
-            android:visibility="gone"
-            app:layout_constraintBottom_toTopOf="@id/btn_barrier"
-            app:layout_constraintEnd_toEndOf="@id/ingredients_list"
-            app:layout_constraintStart_toEndOf="@+id/btn_looks_good"
-            app:layout_constraintTop_toBottomOf="@id/ingredients_list"
-            tools:text="Really really long text coming from Narnia"
-            tools:visibility="visible" />
-
-        <androidx.constraintlayout.widget.Barrier
-            android:id="@+id/btn_barrier"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:barrierDirection="bottom"
-            app:constraint_referenced_ids="btn_looks_good,btn_skip_ingredients"
-            tools:layout_editor_absoluteX="165dp"
-            tools:layout_editor_absoluteY="421dp" />
-
-        <View
-            android:id="@+id/grey_line2"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginStart="@dimen/spacing_small"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginEnd="@dimen/spacing_small"
-            android:background="@color/grey_400"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/btn_barrier" />
-
-        <TextView
-            android:id="@+id/section_traces"
-            style="@style/EditHeader"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/traces"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/grey_line2" />
-
-        <TextView
-            android:id="@+id/hint_traces"
-            style="@style/EditHint"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/traces_hint"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/section_traces" />
-
-        <com.hootsuite.nachos.NachoTextView
-            android:id="@+id/traces"
-            android:layout_width="0dp"
-            android:layout_height="48dp"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:background="@drawable/bg_edittext"
-            android:completionThreshold="1"
-            android:gravity="center_vertical"
-            android:inputType="text"
-            android:paddingLeft="@dimen/spacing_small"
-            android:paddingRight="@dimen/spacing_small"
-            app:chipBackground="#4389FA"
-            app:chipHeight="30dp"
-            app:chipTextColor="@color/grey_50"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/hint_traces"
-            tools:ignore="SpeakableTextPresentCheck" />
-
-        <Button
-            android:id="@+id/btn_next"
-            style="@style/ButtonFlat"
-            android:layout_width="match_parent"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:text="@string/next"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/traces" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_add_product_nutrition_facts.xml
+++ b/app/src/main/res/layout/fragment_add_product_nutrition_facts.xml
@@ -1,902 +1,918 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_gravity="fill_vertical"
-    android:clipToPadding="false"
-    android:isScrollContainer="false"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior"
-    tools:context=".features.product.edit.nutrition.ProductEditNutritionFactsFragment">
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <androidx.appcompat.widget.SwitchCompat
-            android:id="@+id/checkbox_no_nutrition_data"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:text="@string/nutrition_facts_not_specified"
-            android:textSize="16sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+    android:layout_height="match_parent"
+    tools:context=".features.product.edit.nutrition.ProductEditNutritionFactsFragment"
+    >
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintHeight_default="wrap"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/btn_add"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintVertical_bias="0"
+        android:paddingTop="@dimen/spacing_small"
+        android:paddingBottom="16dp"
+        android:layout_gravity="fill_vertical"
+        android:clipToPadding="false"
+        android:isScrollContainer="false"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        >
 
         <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/nutrition_facts_layout"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/checkbox_no_nutrition_data">
+            android:layout_height="wrap_content">
 
-            <TextView
-                android:id="@+id/section_nutrition_facts_picture"
-                style="@style/EditHeader"
-                android:layout_width="wrap_content"
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/checkbox_no_nutrition_data"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/activity_horizontal_margin"
                 android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                android:layout_marginTop="@dimen/spacing_small"
-                android:text="@string/nutrition_facts_picture"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:text="@string/nutrition_facts_not_specified"
+                android:textSize="16sp"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
-            <ImageView
-                android:id="@+id/btnAddImageNutritionFacts"
-                android:layout_width="50dp"
-                android:layout_height="50dp"
-                android:layout_margin="@dimen/spacing_small"
-                android:background="?android:selectableItemBackground"
-                app:layout_constraintStart_toStartOf="@id/section_nutrition_facts_picture"
-                app:layout_constraintTop_toBottomOf="@id/section_nutrition_facts_picture"
-                app:srcCompat="@drawable/ic_add_a_photo_dark_48dp"
-                tools:ignore="ContentDescription" />
-
-            <Button
-                android:id="@+id/btnEditImageNutritionFacts"
-                style="@style/ButtonBorder"
-                android:layout_width="wrap_content"
-                android:layout_height="32dp"
-                android:layout_marginLeft="@dimen/padding_large"
-                android:layout_marginRight="@dimen/padding_large"
-                android:text="@string/update_image"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="@id/btnAddImageNutritionFacts"
-                app:layout_constraintStart_toEndOf="@id/btnAddImageNutritionFacts"
-                app:layout_constraintTop_toTopOf="@id/btnAddImageNutritionFacts" />
-
-            <ProgressBar
-                android:id="@+id/imageProgress"
-                android:layout_width="50dp"
-                android:layout_height="50dp"
-                android:layout_margin="@dimen/spacing_small"
-                android:visibility="gone"
-                app:layout_constraintStart_toStartOf="@id/section_nutrition_facts_picture"
-                app:layout_constraintTop_toBottomOf="@id/section_nutrition_facts_picture"
-                tools:visibility="visible" />
-
-            <TextView
-                android:id="@+id/imageProgressText"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_margin="@dimen/spacing_small"
-                android:text="@string/toastSending"
-                android:visibility="gone"
-                app:layout_constraintBottom_toBottomOf="@id/imageProgress"
-                app:layout_constraintStart_toEndOf="@id/imageProgress"
-                app:layout_constraintTop_toTopOf="@id/imageProgress"
-                tools:visibility="visible" />
-
-            <View
-                android:id="@+id/grey_line1"
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/nutrition_facts_layout"
                 android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:layout_marginLeft="@dimen/spacing_small"
-                android:layout_marginTop="@dimen/spacing_small"
-                android:layout_marginRight="@dimen/spacing_small"
-                android:background="@color/grey_400"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/btnAddImageNutritionFacts" />
-
-            <TextView
-                android:id="@+id/section_nutrition_facts"
-                style="@style/EditHeader"
-                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/activity_horizontal_margin"
-                android:layout_marginTop="@dimen/spacing_small"
-                android:text="@string/nutrition_facts"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/grey_line1" />
-
-            <RadioGroup
-                android:id="@+id/radio_group"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:orientation="horizontal"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@id/section_nutrition_facts"
-                app:layout_constraintTop_toBottomOf="@id/section_nutrition_facts">
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/checkbox_no_nutrition_data">
 
-                <RadioButton
-                    android:id="@+id/for100g_100ml"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/for_100g_100ml" />
-
-                <RadioButton
-                    android:id="@+id/per_serving"
+                <TextView
+                    android:id="@+id/section_nutrition_facts_picture"
+                    style="@style/EditHeader"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/activity_horizontal_margin"
                     android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                    android:text="@string/per_serving" />
-            </RadioGroup>
+                    android:layout_marginTop="@dimen/spacing_small"
+                    android:text="@string/nutrition_facts_picture"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/serving_size_til"
-                android:layout_width="0dp"
+                <ImageView
+                    android:id="@+id/btnAddImageNutritionFacts"
+                    android:layout_width="50dp"
+                    android:layout_height="50dp"
+                    android:layout_margin="@dimen/spacing_small"
+                    android:background="?android:selectableItemBackground"
+                    app:layout_constraintStart_toStartOf="@id/section_nutrition_facts_picture"
+                    app:layout_constraintTop_toBottomOf="@id/section_nutrition_facts_picture"
+                    app:srcCompat="@drawable/ic_add_a_photo_dark_48dp"
+                    tools:ignore="ContentDescription" />
+
+                <Button
+                    android:id="@+id/btnEditImageNutritionFacts"
+                    style="@style/ButtonBorder"
+                    android:layout_width="wrap_content"
+                    android:layout_height="32dp"
+                    android:layout_marginLeft="@dimen/padding_large"
+                    android:layout_marginRight="@dimen/padding_large"
+                    android:text="@string/update_image"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="@id/btnAddImageNutritionFacts"
+                    app:layout_constraintStart_toEndOf="@id/btnAddImageNutritionFacts"
+                    app:layout_constraintTop_toTopOf="@id/btnAddImageNutritionFacts" />
+
+                <ProgressBar
+                    android:id="@+id/imageProgress"
+                    android:layout_width="50dp"
+                    android:layout_height="50dp"
+                    android:layout_margin="@dimen/spacing_small"
+                    android:visibility="gone"
+                    app:layout_constraintStart_toStartOf="@id/section_nutrition_facts_picture"
+                    app:layout_constraintTop_toBottomOf="@id/section_nutrition_facts_picture"
+                    tools:visibility="visible" />
+
+                <TextView
+                    android:id="@+id/imageProgressText"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="@dimen/spacing_small"
+                    android:text="@string/toastSending"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="@id/imageProgress"
+                    app:layout_constraintStart_toEndOf="@id/imageProgress"
+                    app:layout_constraintTop_toTopOf="@id/imageProgress"
+                    tools:visibility="visible" />
+
+                <View
+                    android:id="@+id/grey_line1"
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:layout_marginLeft="@dimen/spacing_small"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    android:layout_marginRight="@dimen/spacing_small"
+                    android:background="@color/grey_400"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/btnAddImageNutritionFacts" />
+
+                <TextView
+                    android:id="@+id/section_nutrition_facts"
+                    style="@style/EditHeader"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    android:text="@string/nutrition_facts"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/grey_line1" />
+
+                <RadioGroup
+                    android:id="@+id/radio_group"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                    android:orientation="horizontal"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@id/section_nutrition_facts"
+                    app:layout_constraintTop_toBottomOf="@id/section_nutrition_facts">
+
+                    <RadioButton
+                        android:id="@+id/for100g_100ml"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/for_100g_100ml" />
+
+                    <RadioButton
+                        android:id="@+id/per_serving"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/activity_horizontal_margin"
+                        android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                        android:text="@string/per_serving" />
+                </RadioGroup>
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/serving_size_til"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/activity_horizontal_margin"
+                    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    app:errorTextAppearance="@style/errorText"
+                    app:layout_constraintEnd_toStartOf="@id/spinner_serving_unit"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/radio_group">
+
+                    <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
+                        android:id="@+id/serving_size"
+                        android:layout_width="match_parent"
+                        android:layout_height="45dp"
+                        android:background="@drawable/bg_edittext_til"
+                        android:digits="0123456789.,"
+                        android:gravity="center_vertical"
+                        android:hint="@string/serving_size"
+                        android:inputType="number"
+                        android:nextFocusDown="@id/energy_kcal"
+                        app:attachedUnitSpinner="@id/spinner_serving_unit"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:parentTextInputLayout="@id/serving_size_til" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Spinner
+                    android:id="@+id/spinner_serving_unit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="35dp"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                    android:layout_marginRight="@dimen/activity_horizontal_margin"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_serving_weight_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/serving_size_til"
+                    app:layout_constraintTop_toTopOf="@id/serving_size_til" />
+
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/energy_kcal_til"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/activity_horizontal_margin"
+                    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    app:errorTextAppearance="@style/errorText"
+                    app:layout_constraintEnd_toStartOf="@+id/energy_kcal_unit"
+                    app:layout_constraintHorizontal_bias="0.5"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/serving_size_til">
+
+                    <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
+                        android:id="@+id/energy_kcal"
+                        android:layout_width="match_parent"
+                        android:layout_height="45dp"
+                        android:background="@drawable/bg_edittext_til"
+                        android:digits="0123456789.,"
+                        android:gravity="center_vertical"
+                        android:hint="@string/nutrition_energy_kcal"
+                        android:inputType="numberDecimal"
+                        android:nextFocusDown="@id/fat"
+                        android:singleLine="true"
+                        app:fieldName="energy-kcal"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:parentTextInputLayout="@+id/energy_kcal_til" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <TextView
+                    android:id="@+id/energy_kcal_unit"
+                    android:layout_width="0dp"
+                    android:layout_height="35dp"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                    android:layout_marginRight="@dimen/activity_horizontal_margin"
+                    android:gravity="start|center_vertical"
+                    android:text="@string/kcal"
+                    android:textSize="14sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@+id/spinner_serving_unit"
+                    app:layout_constraintTop_toTopOf="@id/energy_kcal_til" />
+
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/energy_kj_til"
+                    android:layout_width="0dp"
+                    android:layout_height="match_parent"
+                    android:layout_marginStart="@dimen/activity_horizontal_margin"
+                    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    app:errorTextAppearance="@style/errorText"
+                    app:layout_constraintEnd_toStartOf="@+id/energy_kj_unit"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/energy_kcal_til">
+
+                    <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
+                        android:id="@+id/energy_kj"
+                        android:layout_width="match_parent"
+                        android:layout_height="45dp"
+                        android:background="@drawable/bg_edittext_til"
+                        android:digits="0123456789.,"
+                        android:gravity="center_vertical"
+                        android:hint="@string/nutrition_energy_kj"
+                        android:inputType="numberDecimal"
+                        android:nextFocusDown="@id/fat"
+                        android:singleLine="true"
+                        app:fieldName="energy-kj"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:parentTextInputLayout="@+id/energy_kcal_til" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <TextView
+                    android:id="@+id/energy_kj_unit"
+                    android:layout_width="0dp"
+                    android:layout_height="35dp"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                    android:gravity="start|center_vertical"
+                    android:text="@string/kj"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="@+id/energy_kcal_unit"
+                    app:layout_constraintTop_toTopOf="@+id/energy_kj_til" />
+
+                <Spinner
+                    android:id="@+id/spinner_fat_comp"
+                    android:layout_width="wrap_content"
+                    android:layout_height="35dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_comparison_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toStartOf="@id/fat_til"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/fat_til" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/fat_til"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    app:errorTextAppearance="@style/errorText"
+                    app:layout_constraintEnd_toStartOf="@id/spinner_fat_unit"
+                    app:layout_constraintStart_toEndOf="@id/spinner_fat_comp"
+                    app:layout_constraintTop_toBottomOf="@id/energy_kj_til">
+
+                    <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
+                        android:id="@+id/fat"
+                        android:layout_width="match_parent"
+                        android:layout_height="45dp"
+                        android:background="@drawable/bg_edittext_til"
+                        android:digits="0123456789.,"
+                        android:gravity="center_vertical"
+                        android:hint="@string/nutrition_fat"
+                        android:inputType="numberDecimal"
+                        android:nextFocusDown="@id/saturated_fat"
+                        android:singleLine="true"
+                        app:attachedModSpinner="@id/spinner_fat_comp"
+                        app:attachedUnitSpinner="@id/spinner_fat_unit"
+                        app:fieldName="fat"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:parentTextInputLayout="@+id/fat_til" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Spinner
+                    android:id="@+id/spinner_fat_unit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="35dp"
+                    android:layout_marginStart="@dimen/padding_short"
+                    android:layout_marginLeft="@dimen/padding_short"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                    android:layout_marginRight="@dimen/activity_horizontal_margin"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_weight_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/fat_til"
+                    app:layout_constraintTop_toTopOf="@id/fat_til" />
+
+
+                <Spinner
+                    android:id="@+id/spinner_saturated_fat_comp"
+                    android:layout_width="wrap_content"
+
+                    android:layout_height="35dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_comparison_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toStartOf="@id/saturated_fat_til"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/saturated_fat_til" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/saturated_fat_til"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    app:errorTextAppearance="@style/errorText"
+                    app:layout_constraintEnd_toStartOf="@id/spinner_saturated_fat_unit"
+                    app:layout_constraintStart_toEndOf="@id/spinner_saturated_fat_comp"
+                    app:layout_constraintTop_toBottomOf="@id/fat_til">
+
+                    <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
+                        android:id="@+id/saturated_fat"
+                        android:layout_width="match_parent"
+                        android:layout_height="45dp"
+                        android:background="@drawable/bg_edittext_til"
+                        android:digits="0123456789.,"
+                        android:gravity="center_vertical"
+                        android:hint="@string/nutrition_satured_fat"
+                        android:inputType="numberDecimal"
+                        android:nextFocusDown="@id/carbohydrates"
+                        android:singleLine="true"
+                        app:attachedModSpinner="@id/spinner_saturated_fat_comp"
+                        app:attachedUnitSpinner="@id/spinner_saturated_fat_unit"
+                        app:fieldName="saturated-fat"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:parentTextInputLayout="@+id/saturated_fat_til" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Spinner
+                    android:id="@+id/spinner_saturated_fat_unit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="35dp"
+                    android:layout_marginStart="@dimen/padding_short"
+                    android:layout_marginLeft="@dimen/padding_short"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                    android:layout_marginRight="@dimen/activity_horizontal_margin"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_weight_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/saturated_fat_til"
+                    app:layout_constraintTop_toTopOf="@id/saturated_fat_til" />
+
+
+                <Spinner
+                    android:id="@+id/spinner_carbohydrates_comp"
+                    android:layout_width="wrap_content"
+
+                    android:layout_height="35dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_comparison_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toStartOf="@id/carbohydrates_til"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/carbohydrates_til" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/carbohydrates_til"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    app:errorTextAppearance="@style/errorText"
+                    app:layout_constraintEnd_toStartOf="@+id/spinner_carbohydrates_unit"
+                    app:layout_constraintStart_toEndOf="@+id/spinner_carbohydrates_comp"
+                    app:layout_constraintTop_toBottomOf="@id/saturated_fat_til">
+
+                    <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
+                        android:id="@+id/carbohydrates"
+                        android:layout_width="match_parent"
+                        android:layout_height="45dp"
+                        android:background="@drawable/bg_edittext_til"
+                        android:digits="0123456789.,"
+                        android:gravity="center_vertical"
+                        android:hint="@string/nutrition_carbohydrate"
+                        android:inputType="numberDecimal"
+                        android:nextFocusDown="@id/sugars"
+                        android:singleLine="true"
+                        app:attachedModSpinner="@id/spinner_carbohydrates_comp"
+                        app:attachedUnitSpinner="@id/spinner_carbohydrates_unit"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:parentTextInputLayout="@+id/carbohydrates_til" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Spinner
+                    android:id="@+id/spinner_carbohydrates_unit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="35dp"
+                    android:layout_marginStart="@dimen/padding_short"
+                    android:layout_marginLeft="@dimen/padding_short"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                    android:layout_marginRight="@dimen/activity_horizontal_margin"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_weight_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/carbohydrates_til"
+                    app:layout_constraintTop_toTopOf="@id/carbohydrates_til" />
+
+
+                <Spinner
+                    android:id="@+id/spinner_sugars_comp"
+                    android:layout_width="wrap_content"
+
+                    android:layout_height="35dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_comparison_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toStartOf="@id/sugars_til"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/sugars_til" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/sugars_til"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    app:errorTextAppearance="@style/errorText"
+                    app:layout_constraintEnd_toStartOf="@+id/spinner_sugars_unit"
+                    app:layout_constraintStart_toEndOf="@+id/spinner_sugars_comp"
+                    app:layout_constraintTop_toBottomOf="@id/carbohydrates_til">
+
+                    <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
+                        android:id="@+id/sugars"
+                        android:layout_width="match_parent"
+                        android:layout_height="45dp"
+                        android:background="@drawable/bg_edittext_til"
+                        android:digits="0123456789.,"
+                        android:gravity="center_vertical"
+                        android:hint="@string/nutrition_sugars"
+                        android:inputType="numberDecimal"
+                        android:nextFocusDown="@id/fiber"
+                        android:singleLine="true"
+                        app:attachedModSpinner="@+id/spinner_sugars_comp"
+                        app:attachedUnitSpinner="@+id/spinner_sugars_unit"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:parentTextInputLayout="@+id/sugars_til" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Spinner
+                    android:id="@+id/spinner_sugars_unit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="35dp"
+                    android:layout_marginStart="@dimen/padding_short"
+                    android:layout_marginLeft="@dimen/padding_short"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                    android:layout_marginRight="@dimen/activity_horizontal_margin"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_weight_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/sugars_til"
+                    app:layout_constraintTop_toTopOf="@id/sugars_til" />
+
+
+                <Spinner
+                    android:id="@+id/spinner_fiber_comp"
+                    android:layout_width="wrap_content"
+
+                    android:layout_height="35dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_comparison_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toStartOf="@id/fiber_til"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/fiber_til" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/fiber_til"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    app:errorTextAppearance="@style/errorText"
+                    app:layout_constraintEnd_toStartOf="@+id/spinner_fiber_unit"
+                    app:layout_constraintStart_toEndOf="@+id/spinner_fiber_comp"
+                    app:layout_constraintTop_toBottomOf="@id/sugars_til">
+
+                    <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
+                        android:id="@+id/fiber"
+                        android:layout_width="match_parent"
+                        android:layout_height="45dp"
+                        android:background="@drawable/bg_edittext_til"
+                        android:digits="0123456789.,"
+                        android:gravity="center_vertical"
+                        android:hint="@string/nutrition_fiber"
+                        android:inputType="numberDecimal"
+                        android:nextFocusDown="@id/proteins"
+                        android:singleLine="true"
+                        app:attachedModSpinner="@+id/spinner_fiber_comp"
+                        app:attachedUnitSpinner="@+id/spinner_fiber_unit"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:parentTextInputLayout="@+id/fiber_til" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Spinner
+                    android:id="@+id/spinner_fiber_unit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="35dp"
+                    android:layout_marginStart="@dimen/padding_short"
+                    android:layout_marginLeft="@dimen/padding_short"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                    android:layout_marginRight="@dimen/activity_horizontal_margin"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_weight_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/fiber_til"
+                    app:layout_constraintTop_toTopOf="@id/fiber_til" />
+
+
+                <Spinner
+                    android:id="@+id/spinner_proteins_comp"
+                    android:layout_width="wrap_content"
+
+                    android:layout_height="35dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_comparison_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toStartOf="@id/proteins_til"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/proteins_til" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/proteins_til"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    app:errorTextAppearance="@style/errorText"
+                    app:layout_constraintEnd_toStartOf="@+id/spinner_proteins_unit"
+                    app:layout_constraintStart_toEndOf="@+id/spinner_proteins_comp"
+                    app:layout_constraintTop_toBottomOf="@id/fiber_til">
+
+                    <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
+                        android:id="@+id/proteins"
+                        android:layout_width="match_parent"
+                        android:layout_height="45dp"
+                        android:background="@drawable/bg_edittext_til"
+                        android:digits="0123456789.,"
+                        android:gravity="center_vertical"
+                        android:hint="@string/nutrition_proteins"
+                        android:inputType="numberDecimal"
+                        android:nextFocusDown="@id/salt"
+                        android:singleLine="true"
+                        app:attachedModSpinner="@+id/spinner_proteins_comp"
+                        app:attachedUnitSpinner="@+id/spinner_proteins_unit"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:parentTextInputLayout="@+id/proteins_til" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Spinner
+                    android:id="@+id/spinner_proteins_unit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="35dp"
+                    android:layout_marginStart="@dimen/padding_short"
+                    android:layout_marginLeft="@dimen/padding_short"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                    android:layout_marginRight="@dimen/activity_horizontal_margin"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_weight_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/proteins_til"
+                    app:layout_constraintTop_toTopOf="@id/proteins_til" />
+
+
+                <Spinner
+                    android:id="@+id/spinner_salt_comp"
+                    android:layout_width="wrap_content"
+
+                    android:layout_height="35dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_comparison_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toStartOf="@id/salt_til"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/salt_til" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/salt_til"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    app:errorTextAppearance="@style/errorText"
+                    app:layout_constraintEnd_toStartOf="@+id/spinner_salt_unit"
+                    app:layout_constraintStart_toEndOf="@+id/spinner_salt_comp"
+                    app:layout_constraintTop_toBottomOf="@id/proteins_til">
+
+                    <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
+                        android:id="@+id/salt"
+                        android:layout_width="match_parent"
+                        android:layout_height="45dp"
+                        android:background="@drawable/bg_edittext_til"
+                        android:digits="0123456789.,"
+                        android:gravity="center_vertical"
+                        android:hint="@string/nutrition_salt"
+                        android:inputType="numberDecimal"
+                        android:nextFocusDown="@id/sodium"
+                        android:singleLine="true"
+                        app:attachedModSpinner="@+id/spinner_salt_comp"
+                        app:attachedUnitSpinner="@+id/spinner_salt_unit"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:parentTextInputLayout="@+id/salt_til" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Spinner
+                    android:id="@+id/spinner_salt_unit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="35dp"
+                    android:layout_marginStart="@dimen/padding_short"
+                    android:layout_marginLeft="@dimen/padding_short"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                    android:layout_marginRight="@dimen/activity_horizontal_margin"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_weight_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/salt_til"
+                    app:layout_constraintTop_toTopOf="@id/salt_til" />
+
+
+                <Spinner
+                    android:id="@+id/spinner_sodium_comp"
+                    android:layout_width="wrap_content"
+
+                    android:layout_height="35dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_comparison_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toStartOf="@id/sodium_til"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/sodium_til" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/sodium_til"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    app:errorTextAppearance="@style/errorText"
+                    app:layout_constraintEnd_toStartOf="@+id/spinner_sodium_unit"
+                    app:layout_constraintStart_toEndOf="@+id/spinner_sodium_comp"
+                    app:layout_constraintTop_toBottomOf="@id/salt_til">
+
+                    <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
+                        android:id="@+id/sodium"
+                        android:layout_width="match_parent"
+                        android:layout_height="45dp"
+                        android:background="@drawable/bg_edittext_til"
+                        android:digits="0123456789.,"
+                        android:gravity="center_vertical"
+                        android:hint="@string/nutrition_sodium"
+                        android:inputType="numberDecimal"
+                        android:nextFocusDown="@id/alcohol"
+                        android:singleLine="true"
+                        app:attachedModSpinner="@id/spinner_sodium_comp"
+                        app:attachedUnitSpinner="@id/spinner_sodium_unit"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:parentTextInputLayout="@+id/sodium_til" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <Spinner
+                    android:id="@+id/spinner_sodium_unit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="35dp"
+                    android:layout_marginStart="@dimen/padding_short"
+                    android:layout_marginLeft="@dimen/padding_short"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                    android:layout_marginRight="@dimen/activity_horizontal_margin"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_weight_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/sodium_til"
+                    app:layout_constraintTop_toTopOf="@id/sodium_til" />
+
+                <Spinner
+                    android:id="@+id/spinner_alcohol_comp"
+                    android:layout_width="wrap_content"
+
+                    android:layout_height="35dp"
+                    android:layout_marginStart="16dp"
+                    android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    android:background="@drawable/spinner_weights_grey"
+                    android:entries="@array/nutrition_comparison_units"
+                    android:gravity="center_vertical"
+                    android:spinnerMode="dropdown"
+                    app:layout_constraintEnd_toStartOf="@id/alcohol_til"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="@id/alcohol_til" />
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/alcohol_til"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginRight="8dp"
+                    app:errorTextAppearance="@style/errorText"
+                    app:layout_constraintEnd_toStartOf="@+id/text_alcohol_unit"
+                    app:layout_constraintStart_toEndOf="@+id/spinner_alcohol_comp"
+                    app:layout_constraintTop_toBottomOf="@id/sodium_til">
+
+                    <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
+                        android:id="@+id/alcohol"
+                        android:layout_width="match_parent"
+                        android:layout_height="45dp"
+                        android:background="@drawable/bg_edittext_til"
+                        android:digits="0123456789.,"
+                        android:gravity="center_vertical"
+                        android:hint="@string/nutrition_alcohol"
+                        android:inputType="numberDecimal"
+                        android:singleLine="true"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:parentTextInputLayout="@+id/alcohol_til" />
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <TextView
+                    android:id="@+id/text_alcohol_unit"
+                    android:layout_width="0dp"
+                    android:layout_height="35dp"
+                    android:layout_marginTop="@dimen/top_margin_spinner_hint"
+                    android:gravity="center"
+                    android:text="@string/alcohol_unit"
+                    android:textSize="14sp"
+                    app:layout_constraintBottom_toBottomOf="@id/alcohol_til"
+                    app:layout_constraintEnd_toEndOf="@+id/spinner_sodium_unit"
+                    app:layout_constraintStart_toStartOf="@+id/spinner_sodium_unit"
+                    app:layout_constraintTop_toTopOf="@id/alcohol_til" />
+
+                <LinearLayout
+                    android:id="@+id/table_layout"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/alcohol_til" />
+
+                <Button
+                    android:id="@+id/btn_add_a_nutrient"
+                    style="@style/ButtonBorder"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/spacing_small"
+                    android:drawablePadding="@dimen/spacing_tiny"
+                    android:text="@string/add_a_nutrient"
+                    app:drawableLeftCompat="@drawable/ic_add_box_blue_18dp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/table_layout" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <TextView
+                android:id="@+id/global_validation_msg"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/activity_horizontal_margin"
                 android:layout_marginLeft="@dimen/activity_horizontal_margin"
                 android:layout_marginTop="@dimen/spacing_small"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                app:errorTextAppearance="@style/errorText"
-                app:layout_constraintEnd_toStartOf="@id/spinner_serving_unit"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/radio_group">
-
-                <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
-                    android:id="@+id/serving_size"
-                    android:layout_width="match_parent"
-                    android:layout_height="45dp"
-                    android:background="@drawable/bg_edittext_til"
-                    android:digits="0123456789.,"
-                    android:gravity="center_vertical"
-                    android:hint="@string/serving_size"
-                    android:inputType="number"
-                    android:nextFocusDown="@id/energy_kcal"
-                    app:attachedUnitSpinner="@id/spinner_serving_unit"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:parentTextInputLayout="@id/serving_size_til" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <Spinner
-                android:id="@+id/spinner_serving_unit"
-                android:layout_width="wrap_content"
-                android:layout_height="35dp"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:layout_marginRight="@dimen/activity_horizontal_margin"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_serving_weight_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/serving_size_til"
-                app:layout_constraintTop_toTopOf="@id/serving_size_til" />
-
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/energy_kcal_til"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/activity_horizontal_margin"
-                android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                android:layout_marginTop="@dimen/spacing_small"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                app:errorTextAppearance="@style/errorText"
-                app:layout_constraintEnd_toStartOf="@+id/energy_kcal_unit"
-                app:layout_constraintHorizontal_bias="0.5"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/serving_size_til">
-
-                <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
-                    android:id="@+id/energy_kcal"
-                    android:layout_width="match_parent"
-                    android:layout_height="45dp"
-                    android:background="@drawable/bg_edittext_til"
-                    android:digits="0123456789.,"
-                    android:gravity="center_vertical"
-                    android:hint="@string/nutrition_energy_kcal"
-                    android:inputType="numberDecimal"
-                    android:nextFocusDown="@id/fat"
-                    android:singleLine="true"
-                    app:fieldName="energy-kcal"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:parentTextInputLayout="@+id/energy_kcal_til" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <TextView
-                android:id="@+id/energy_kcal_unit"
-                android:layout_width="0dp"
-                android:layout_height="35dp"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:layout_marginRight="@dimen/activity_horizontal_margin"
-                android:gravity="start|center_vertical"
-                android:text="@string/kcal"
-                android:textSize="14sp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/spinner_serving_unit"
-                app:layout_constraintTop_toTopOf="@id/energy_kcal_til" />
-
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/energy_kj_til"
-                android:layout_width="0dp"
-                android:layout_height="match_parent"
-                android:layout_marginStart="@dimen/activity_horizontal_margin"
-                android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                android:layout_marginTop="@dimen/spacing_small"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                app:errorTextAppearance="@style/errorText"
-                app:layout_constraintEnd_toStartOf="@+id/energy_kj_unit"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/energy_kcal_til">
-
-                <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
-                    android:id="@+id/energy_kj"
-                    android:layout_width="match_parent"
-                    android:layout_height="45dp"
-                    android:background="@drawable/bg_edittext_til"
-                    android:digits="0123456789.,"
-                    android:gravity="center_vertical"
-                    android:hint="@string/nutrition_energy_kj"
-                    android:inputType="numberDecimal"
-                    android:nextFocusDown="@id/fat"
-                    android:singleLine="true"
-                    app:fieldName="energy-kj"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:parentTextInputLayout="@+id/energy_kcal_til" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <TextView
-                android:id="@+id/energy_kj_unit"
-                android:layout_width="0dp"
-                android:layout_height="35dp"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:gravity="start|center_vertical"
-                android:text="@string/kj"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="@+id/energy_kcal_unit"
-                app:layout_constraintTop_toTopOf="@+id/energy_kj_til" />
-
-            <Spinner
-                android:id="@+id/spinner_fat_comp"
-                android:layout_width="wrap_content"
-                android:layout_height="35dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_comparison_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toStartOf="@id/fat_til"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/fat_til" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/fat_til"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                app:errorTextAppearance="@style/errorText"
-                app:layout_constraintEnd_toStartOf="@id/spinner_fat_unit"
-                app:layout_constraintStart_toEndOf="@id/spinner_fat_comp"
-                app:layout_constraintTop_toBottomOf="@id/energy_kj_til">
-
-                <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
-                    android:id="@+id/fat"
-                    android:layout_width="match_parent"
-                    android:layout_height="45dp"
-                    android:background="@drawable/bg_edittext_til"
-                    android:digits="0123456789.,"
-                    android:gravity="center_vertical"
-                    android:hint="@string/nutrition_fat"
-                    android:inputType="numberDecimal"
-                    android:nextFocusDown="@id/saturated_fat"
-                    android:singleLine="true"
-                    app:attachedModSpinner="@id/spinner_fat_comp"
-                    app:attachedUnitSpinner="@id/spinner_fat_unit"
-                    app:fieldName="fat"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:parentTextInputLayout="@+id/fat_til" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <Spinner
-                android:id="@+id/spinner_fat_unit"
-                android:layout_width="wrap_content"
-                android:layout_height="35dp"
-                android:layout_marginStart="@dimen/padding_short"
-                android:layout_marginLeft="@dimen/padding_short"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:layout_marginRight="@dimen/activity_horizontal_margin"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_weight_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/fat_til"
-                app:layout_constraintTop_toTopOf="@id/fat_til" />
-
-
-            <Spinner
-                android:id="@+id/spinner_saturated_fat_comp"
-                android:layout_width="wrap_content"
-
-                android:layout_height="35dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_comparison_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toStartOf="@id/saturated_fat_til"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/saturated_fat_til" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/saturated_fat_til"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                app:errorTextAppearance="@style/errorText"
-                app:layout_constraintEnd_toStartOf="@id/spinner_saturated_fat_unit"
-                app:layout_constraintStart_toEndOf="@id/spinner_saturated_fat_comp"
-                app:layout_constraintTop_toBottomOf="@id/fat_til">
-
-                <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
-                    android:id="@+id/saturated_fat"
-                    android:layout_width="match_parent"
-                    android:layout_height="45dp"
-                    android:background="@drawable/bg_edittext_til"
-                    android:digits="0123456789.,"
-                    android:gravity="center_vertical"
-                    android:hint="@string/nutrition_satured_fat"
-                    android:inputType="numberDecimal"
-                    android:nextFocusDown="@id/carbohydrates"
-                    android:singleLine="true"
-                    app:attachedModSpinner="@id/spinner_saturated_fat_comp"
-                    app:attachedUnitSpinner="@id/spinner_saturated_fat_unit"
-                    app:fieldName="saturated-fat"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:parentTextInputLayout="@+id/saturated_fat_til" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <Spinner
-                android:id="@+id/spinner_saturated_fat_unit"
-                android:layout_width="wrap_content"
-                android:layout_height="35dp"
-                android:layout_marginStart="@dimen/padding_short"
-                android:layout_marginLeft="@dimen/padding_short"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:layout_marginRight="@dimen/activity_horizontal_margin"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_weight_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/saturated_fat_til"
-                app:layout_constraintTop_toTopOf="@id/saturated_fat_til" />
-
-
-            <Spinner
-                android:id="@+id/spinner_carbohydrates_comp"
-                android:layout_width="wrap_content"
-
-                android:layout_height="35dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_comparison_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toStartOf="@id/carbohydrates_til"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/carbohydrates_til" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/carbohydrates_til"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                app:errorTextAppearance="@style/errorText"
-                app:layout_constraintEnd_toStartOf="@+id/spinner_carbohydrates_unit"
-                app:layout_constraintStart_toEndOf="@+id/spinner_carbohydrates_comp"
-                app:layout_constraintTop_toBottomOf="@id/saturated_fat_til">
-
-                <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
-                    android:id="@+id/carbohydrates"
-                    android:layout_width="match_parent"
-                    android:layout_height="45dp"
-                    android:background="@drawable/bg_edittext_til"
-                    android:digits="0123456789.,"
-                    android:gravity="center_vertical"
-                    android:hint="@string/nutrition_carbohydrate"
-                    android:inputType="numberDecimal"
-                    android:nextFocusDown="@id/sugars"
-                    android:singleLine="true"
-                    app:attachedModSpinner="@id/spinner_carbohydrates_comp"
-                    app:attachedUnitSpinner="@id/spinner_carbohydrates_unit"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:parentTextInputLayout="@+id/carbohydrates_til" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <Spinner
-                android:id="@+id/spinner_carbohydrates_unit"
-                android:layout_width="wrap_content"
-                android:layout_height="35dp"
-                android:layout_marginStart="@dimen/padding_short"
-                android:layout_marginLeft="@dimen/padding_short"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:layout_marginRight="@dimen/activity_horizontal_margin"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_weight_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/carbohydrates_til"
-                app:layout_constraintTop_toTopOf="@id/carbohydrates_til" />
-
-
-            <Spinner
-                android:id="@+id/spinner_sugars_comp"
-                android:layout_width="wrap_content"
-
-                android:layout_height="35dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_comparison_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toStartOf="@id/sugars_til"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/sugars_til" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/sugars_til"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                app:errorTextAppearance="@style/errorText"
-                app:layout_constraintEnd_toStartOf="@+id/spinner_sugars_unit"
-                app:layout_constraintStart_toEndOf="@+id/spinner_sugars_comp"
-                app:layout_constraintTop_toBottomOf="@id/carbohydrates_til">
-
-                <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
-                    android:id="@+id/sugars"
-                    android:layout_width="match_parent"
-                    android:layout_height="45dp"
-                    android:background="@drawable/bg_edittext_til"
-                    android:digits="0123456789.,"
-                    android:gravity="center_vertical"
-                    android:hint="@string/nutrition_sugars"
-                    android:inputType="numberDecimal"
-                    android:nextFocusDown="@id/fiber"
-                    android:singleLine="true"
-                    app:attachedModSpinner="@+id/spinner_sugars_comp"
-                    app:attachedUnitSpinner="@+id/spinner_sugars_unit"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:parentTextInputLayout="@+id/sugars_til" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <Spinner
-                android:id="@+id/spinner_sugars_unit"
-                android:layout_width="wrap_content"
-                android:layout_height="35dp"
-                android:layout_marginStart="@dimen/padding_short"
-                android:layout_marginLeft="@dimen/padding_short"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:layout_marginRight="@dimen/activity_horizontal_margin"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_weight_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/sugars_til"
-                app:layout_constraintTop_toTopOf="@id/sugars_til" />
-
-
-            <Spinner
-                android:id="@+id/spinner_fiber_comp"
-                android:layout_width="wrap_content"
-
-                android:layout_height="35dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_comparison_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toStartOf="@id/fiber_til"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/fiber_til" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/fiber_til"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                app:errorTextAppearance="@style/errorText"
-                app:layout_constraintEnd_toStartOf="@+id/spinner_fiber_unit"
-                app:layout_constraintStart_toEndOf="@+id/spinner_fiber_comp"
-                app:layout_constraintTop_toBottomOf="@id/sugars_til">
-
-                <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
-                    android:id="@+id/fiber"
-                    android:layout_width="match_parent"
-                    android:layout_height="45dp"
-                    android:background="@drawable/bg_edittext_til"
-                    android:digits="0123456789.,"
-                    android:gravity="center_vertical"
-                    android:hint="@string/nutrition_fiber"
-                    android:inputType="numberDecimal"
-                    android:nextFocusDown="@id/proteins"
-                    android:singleLine="true"
-                    app:attachedModSpinner="@+id/spinner_fiber_comp"
-                    app:attachedUnitSpinner="@+id/spinner_fiber_unit"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:parentTextInputLayout="@+id/fiber_til" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <Spinner
-                android:id="@+id/spinner_fiber_unit"
-                android:layout_width="wrap_content"
-                android:layout_height="35dp"
-                android:layout_marginStart="@dimen/padding_short"
-                android:layout_marginLeft="@dimen/padding_short"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:layout_marginRight="@dimen/activity_horizontal_margin"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_weight_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/fiber_til"
-                app:layout_constraintTop_toTopOf="@id/fiber_til" />
-
-
-            <Spinner
-                android:id="@+id/spinner_proteins_comp"
-                android:layout_width="wrap_content"
-
-                android:layout_height="35dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_comparison_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toStartOf="@id/proteins_til"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/proteins_til" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/proteins_til"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                app:errorTextAppearance="@style/errorText"
-                app:layout_constraintEnd_toStartOf="@+id/spinner_proteins_unit"
-                app:layout_constraintStart_toEndOf="@+id/spinner_proteins_comp"
-                app:layout_constraintTop_toBottomOf="@id/fiber_til">
-
-                <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
-                    android:id="@+id/proteins"
-                    android:layout_width="match_parent"
-                    android:layout_height="45dp"
-                    android:background="@drawable/bg_edittext_til"
-                    android:digits="0123456789.,"
-                    android:gravity="center_vertical"
-                    android:hint="@string/nutrition_proteins"
-                    android:inputType="numberDecimal"
-                    android:nextFocusDown="@id/salt"
-                    android:singleLine="true"
-                    app:attachedModSpinner="@+id/spinner_proteins_comp"
-                    app:attachedUnitSpinner="@+id/spinner_proteins_unit"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:parentTextInputLayout="@+id/proteins_til" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <Spinner
-                android:id="@+id/spinner_proteins_unit"
-                android:layout_width="wrap_content"
-                android:layout_height="35dp"
-                android:layout_marginStart="@dimen/padding_short"
-                android:layout_marginLeft="@dimen/padding_short"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:layout_marginRight="@dimen/activity_horizontal_margin"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_weight_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/proteins_til"
-                app:layout_constraintTop_toTopOf="@id/proteins_til" />
-
-
-            <Spinner
-                android:id="@+id/spinner_salt_comp"
-                android:layout_width="wrap_content"
-
-                android:layout_height="35dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_comparison_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toStartOf="@id/salt_til"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/salt_til" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/salt_til"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                app:errorTextAppearance="@style/errorText"
-                app:layout_constraintEnd_toStartOf="@+id/spinner_salt_unit"
-                app:layout_constraintStart_toEndOf="@+id/spinner_salt_comp"
-                app:layout_constraintTop_toBottomOf="@id/proteins_til">
-
-                <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
-                    android:id="@+id/salt"
-                    android:layout_width="match_parent"
-                    android:layout_height="45dp"
-                    android:background="@drawable/bg_edittext_til"
-                    android:digits="0123456789.,"
-                    android:gravity="center_vertical"
-                    android:hint="@string/nutrition_salt"
-                    android:inputType="numberDecimal"
-                    android:nextFocusDown="@id/sodium"
-                    android:singleLine="true"
-                    app:attachedModSpinner="@+id/spinner_salt_comp"
-                    app:attachedUnitSpinner="@+id/spinner_salt_unit"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:parentTextInputLayout="@+id/salt_til" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <Spinner
-                android:id="@+id/spinner_salt_unit"
-                android:layout_width="wrap_content"
-                android:layout_height="35dp"
-                android:layout_marginStart="@dimen/padding_short"
-                android:layout_marginLeft="@dimen/padding_short"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:layout_marginRight="@dimen/activity_horizontal_margin"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_weight_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/salt_til"
-                app:layout_constraintTop_toTopOf="@id/salt_til" />
-
-
-            <Spinner
-                android:id="@+id/spinner_sodium_comp"
-                android:layout_width="wrap_content"
-
-                android:layout_height="35dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_comparison_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toStartOf="@id/sodium_til"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/sodium_til" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/sodium_til"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                app:errorTextAppearance="@style/errorText"
-                app:layout_constraintEnd_toStartOf="@+id/spinner_sodium_unit"
-                app:layout_constraintStart_toEndOf="@+id/spinner_sodium_comp"
-                app:layout_constraintTop_toBottomOf="@id/salt_til">
-
-                <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
-                    android:id="@+id/sodium"
-                    android:layout_width="match_parent"
-                    android:layout_height="45dp"
-                    android:background="@drawable/bg_edittext_til"
-                    android:digits="0123456789.,"
-                    android:gravity="center_vertical"
-                    android:hint="@string/nutrition_sodium"
-                    android:inputType="numberDecimal"
-                    android:nextFocusDown="@id/alcohol"
-                    android:singleLine="true"
-                    app:attachedModSpinner="@id/spinner_sodium_comp"
-                    app:attachedUnitSpinner="@id/spinner_sodium_unit"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:parentTextInputLayout="@+id/sodium_til" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <Spinner
-                android:id="@+id/spinner_sodium_unit"
-                android:layout_width="wrap_content"
-                android:layout_height="35dp"
-                android:layout_marginStart="@dimen/padding_short"
-                android:layout_marginLeft="@dimen/padding_short"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                android:layout_marginRight="@dimen/activity_horizontal_margin"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_weight_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/sodium_til"
-                app:layout_constraintTop_toTopOf="@id/sodium_til" />
-
-            <Spinner
-                android:id="@+id/spinner_alcohol_comp"
-                android:layout_width="wrap_content"
-
-                android:layout_height="35dp"
-                android:layout_marginStart="16dp"
-                android:layout_marginLeft="@dimen/activity_horizontal_margin"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                android:background="@drawable/spinner_weights_grey"
-                android:entries="@array/nutrition_comparison_units"
-                android:gravity="center_vertical"
-                android:spinnerMode="dropdown"
-                app:layout_constraintEnd_toStartOf="@id/alcohol_til"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/alcohol_til" />
-
-            <com.google.android.material.textfield.TextInputLayout
-                android:id="@+id/alcohol_til"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                android:layout_marginEnd="8dp"
-                android:layout_marginRight="8dp"
-                app:errorTextAppearance="@style/errorText"
-                app:layout_constraintEnd_toStartOf="@+id/text_alcohol_unit"
-                app:layout_constraintStart_toEndOf="@+id/spinner_alcohol_comp"
-                app:layout_constraintTop_toBottomOf="@id/sodium_til">
-
-                <openfoodfacts.github.scrachx.openfood.features.shared.views.CustomValidatingEditTextView
-                    android:id="@+id/alcohol"
-                    android:layout_width="match_parent"
-                    android:layout_height="45dp"
-                    android:background="@drawable/bg_edittext_til"
-                    android:digits="0123456789.,"
-                    android:gravity="center_vertical"
-                    android:hint="@string/nutrition_alcohol"
-                    android:inputType="numberDecimal"
-                    android:singleLine="true"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:parentTextInputLayout="@+id/alcohol_til" />
-            </com.google.android.material.textfield.TextInputLayout>
-
-            <TextView
-                android:id="@+id/text_alcohol_unit"
-                android:layout_width="0dp"
-                android:layout_height="35dp"
-                android:layout_marginTop="@dimen/top_margin_spinner_hint"
-                android:gravity="center"
-                android:text="@string/alcohol_unit"
-                android:textSize="14sp"
-                app:layout_constraintBottom_toBottomOf="@id/alcohol_til"
-                app:layout_constraintEnd_toEndOf="@+id/spinner_sodium_unit"
-                app:layout_constraintStart_toStartOf="@+id/spinner_sodium_unit"
-                app:layout_constraintTop_toTopOf="@id/alcohol_til" />
-
-            <LinearLayout
-                android:id="@+id/table_layout"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
+                android:layout_marginEnd="85dp"
+                android:layout_marginRight="85dp"
+                android:text="@string/error_in_nutrient_data"
+                android:textColor="#dd0b16"
+                android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/alcohol_til" />
-
-            <Button
-                android:id="@+id/btn_add_a_nutrient"
-                style="@style/ButtonBorder"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/spacing_small"
-                android:drawablePadding="@dimen/spacing_tiny"
-                android:text="@string/add_a_nutrient"
-                app:drawableLeftCompat="@drawable/ic_add_box_blue_18dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/table_layout" />
-
+                app:layout_constraintTop_toBottomOf="@+id/nutrition_facts_layout" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <TextView
-            android:id="@+id/global_validation_msg"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/activity_horizontal_margin"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginEnd="85dp"
-            android:layout_marginRight="85dp"
-            android:text="@string/error_in_nutrient_data"
-            android:textColor="#dd0b16"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/nutrition_facts_layout" />
+    </ScrollView>
 
-        <Button
-            android:id="@+id/btn_add"
-            style="@style/ButtonFlat.Green"
-            android:layout_width="match_parent"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:clickable="true"
-            android:focusable="true"
-            android:text="@string/add_this_product"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/global_validation_msg" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</ScrollView>
+    <Button
+        android:id="@+id/btn_add"
+        style="@style/ButtonFlat.Green"
+        android:layout_width="match_parent"
+        android:clickable="true"
+        android:focusable="true"
+        android:text="@string/add_this_product"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_add_product_overview.xml
+++ b/app/src/main/res/layout/fragment_add_product_overview.xml
@@ -1,804 +1,818 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/scrollView"
+    android:layout_height="match_parent"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_gravity="fill_vertical"
-    android:clipToPadding="false"
-    android:isScrollContainer="false"
-    app:layout_behavior="@string/appbar_scrolling_view_behavior"
-    tools:context=".features.product.edit.overview.EditOverviewFragment">
+    tools:context=".features.product.edit.overview.EditOverviewFragment"
+    >
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_height="0dp"
+        android:layout_width="0dp"
+        app:layout_constraintHeight_default="wrap"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/btn_next"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintVertical_bias="0"
+        android:isScrollContainer="false"
+        android:layout_gravity="fill_vertical"
+        android:paddingTop="@dimen/spacing_small"
+        android:paddingBottom="16dp"
+        android:clipToPadding="false"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        >
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-
-        <TextView
-            android:id="@+id/section_product_picture"
-            style="@style/EditHeader"
-            android:layout_width="wrap_content"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/product_picture"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:layout_width="match_parent">
 
-        <TextView
-            android:id="@+id/hint_image_front"
-            style="@style/EditHint.Important"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/one_photo_compulsory"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/section_product_picture" />
+            <TextView
+                style="@style/EditHeader"
+                android:id="@+id/section_product_picture"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_width="wrap_content"
+                android:text="@string/product_picture"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-        <ImageView
-            android:id="@+id/img_front"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            android:layout_margin="@dimen/spacing_small"
-            android:background="?android:selectableItemBackground"
-            app:layout_constraintStart_toStartOf="@id/section_product_picture"
-            app:layout_constraintTop_toBottomOf="@id/hint_image_front"
-            app:srcCompat="@drawable/ic_add_a_photo_dark_48dp"
-            tools:ignore="ContentDescription" />
+            <TextView
+                style="@style/EditHint.Important"
+                android:id="@+id/hint_image_front"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_width="0dp"
+                android:text="@string/one_photo_compulsory"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/section_product_picture" />
 
-        <Button
-            android:id="@+id/btn_edit_img_front"
-            style="@style/ButtonBorder"
-            android:layout_width="wrap_content"
-            android:layout_height="32dp"
-            android:layout_marginLeft="@dimen/padding_large"
-            android:layout_marginRight="@dimen/padding_large"
-            android:text="@string/update_image"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@id/img_front"
-            app:layout_constraintStart_toEndOf="@id/img_front"
-            app:layout_constraintTop_toTopOf="@id/img_front"
-            tools:visibility="visible"
-
-            />
-
-        <ProgressBar
-            android:id="@+id/imageProgress"
-            android:layout_width="50dp"
-            android:layout_height="50dp"
-            android:layout_margin="@dimen/spacing_small"
-            android:visibility="gone"
-            app:layout_constraintStart_toStartOf="@id/section_product_picture"
-            app:layout_constraintTop_toBottomOf="@id/hint_image_front"
-            tools:visibility="visible" />
-
-        <TextView
-            android:id="@+id/imageProgressText"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/spacing_small"
-            android:text="@string/toastSending"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="@id/imageProgress"
-            app:layout_constraintStart_toEndOf="@id/imageProgress"
-            app:layout_constraintTop_toTopOf="@id/imageProgress"
-            tools:visibility="visible" />
-
-        <View
-            android:id="@+id/grey_line1"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginStart="@dimen/spacing_small"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginEnd="10dp"
-            android:layout_marginRight="10dp"
-            android:background="@color/grey_400"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/img_front" />
-
-        <TextView
-            android:id="@+id/section_product_details"
-            style="@style/EditHeader"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginEnd="16dp"
-            android:layout_marginRight="16dp"
-            android:text="@string/product_details"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.0"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/grey_line1" />
-
-        <TextView
-            android:id="@+id/barcode"
-            android:layout_width="0dp"
-            android:layout_height="40dp"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:gravity="center_vertical"
-            android:textSize="16sp"
-            android:textStyle="bold"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/section_product_details"
-            tools:text="Barcode : 8888888888888" />
-
-        <TextView
-            android:id="@+id/language"
-            android:layout_width="0dp"
-            android:layout_height="40dp"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:background="@drawable/bg_edittext"
-            android:gravity="center_vertical"
-            android:textSize="16sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/barcode"
-            tools:drawableEnd="@drawable/ic_arrow_drop_down"
-            tools:drawableRight="@drawable/ic_arrow_drop_down"
-            tools:text="Product language : English" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/name_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/language">
-
-            <EditText
-                android:id="@+id/name"
-                android:layout_width="match_parent"
+            <ImageView
+                android:background="?android:selectableItemBackground"
+                android:id="@+id/img_front"
                 android:layout_height="50dp"
-                android:background="@drawable/bg_edittext_til"
-                android:gravity="center_vertical"
-                android:hint="@string/product_name"
-                android:importantForAutofill="no"
-                android:inputType="text"
-                android:nextFocusDown="@id/quantity"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_margin="@dimen/spacing_small"
+                android:layout_width="50dp"
+                app:layout_constraintStart_toStartOf="@id/section_product_picture"
+                app:layout_constraintTop_toBottomOf="@id/hint_image_front"
+                app:srcCompat="@drawable/ic_add_a_photo_dark_48dp"
+                tools:ignore="ContentDescription" />
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/quantity_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:layout_marginBottom="0dp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/name_til">
+            <Button
+                style="@style/ButtonBorder"
+                android:id="@+id/btn_edit_img_front"
+                android:layout_height="32dp"
+                android:layout_marginLeft="@dimen/padding_large"
+                android:layout_marginRight="@dimen/padding_large"
+                android:layout_width="wrap_content"
+                android:text="@string/update_image"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@id/img_front"
+                app:layout_constraintStart_toEndOf="@id/img_front"
+                app:layout_constraintTop_toTopOf="@id/img_front"
+                tools:visibility="visible"
 
-            <EditText
-                android:id="@+id/quantity"
-                android:layout_width="match_parent"
+                />
+
+            <ProgressBar
+                android:id="@+id/imageProgress"
                 android:layout_height="50dp"
-                android:background="@drawable/bg_edittext_til"
-                android:gravity="center_vertical"
-                android:hint="@string/quantity"
-                android:inputType="text"
-                android:nextFocusDown="@id/brand"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_margin="@dimen/spacing_small"
+                android:layout_width="50dp"
+                android:visibility="gone"
+                app:layout_constraintStart_toStartOf="@id/section_product_picture"
+                app:layout_constraintTop_toBottomOf="@id/hint_image_front"
+                tools:visibility="visible" />
 
-        <TextView
-            android:id="@+id/quantity_hint"
-            style="@style/EditHint"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@string/hint_quantity"
-            app:layout_constraintEnd_toEndOf="@id/quantity_til"
-            app:layout_constraintStart_toStartOf="@id/quantity_til"
-            app:layout_constraintTop_toBottomOf="@id/quantity_til" />
-
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/brand_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/quantity_hint">
-
-            <com.hootsuite.nachos.NachoTextView
-                android:id="@+id/brand"
-                android:layout_width="match_parent"
+            <TextView
+                android:id="@+id/imageProgressText"
                 android:layout_height="wrap_content"
-                android:background="@drawable/bg_edittext_til"
-                android:gravity="center_vertical"
-                android:hint="@string/hintBrand"
-                android:inputType="text"
-                android:minHeight="50dp"
-                android:nextFocusDown="@id/packaging"
-                android:paddingTop="@dimen/floating_hint_margin_nacho"
-                android:paddingBottom="@dimen/floating_hint_margin_nacho"
-                app:chipBackground="#4389FA"
-                app:chipHeight="30dp"
-                app:chipTextColor="@color/grey_50"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-        </com.google.android.material.textfield.TextInputLayout>
+                android:layout_margin="@dimen/spacing_small"
+                android:layout_width="wrap_content"
+                android:text="@string/toastSending"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="@id/imageProgress"
+                app:layout_constraintStart_toEndOf="@id/imageProgress"
+                app:layout_constraintTop_toTopOf="@id/imageProgress"
+                tools:visibility="visible" />
 
-        <TextView
-            android:id="@+id/brand_hint"
-            style="@style/EditHint"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@string/brand_hint"
-            app:layout_constraintEnd_toEndOf="@id/brand_til"
-            app:layout_constraintStart_toStartOf="@id/brand_til"
-            app:layout_constraintTop_toBottomOf="@id/brand_til" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/packaging_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/brand_hint">
-
-            <com.hootsuite.nachos.NachoTextView
-                android:id="@+id/packaging"
+            <View
+                android:background="@color/grey_400"
+                android:id="@+id/grey_line1"
+                android:layout_height="1dp"
+                android:layout_marginEnd="10dp"
+                android:layout_marginRight="10dp"
+                android:layout_marginStart="@dimen/spacing_small"
+                android:layout_marginTop="@dimen/spacing_small"
                 android:layout_width="match_parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/img_front" />
+
+            <TextView
+                style="@style/EditHeader"
+                android:id="@+id/section_product_details"
                 android:layout_height="wrap_content"
-                android:background="@drawable/bg_edittext_til"
-                android:gravity="center_vertical"
-                android:hint="@string/packaging_string"
-                android:minHeight="50dp"
-                android:nextFocusDown="@id/categories"
-                android:paddingTop="@dimen/floating_hint_margin_nacho"
-                android:paddingBottom="@dimen/floating_hint_margin_nacho"
-                app:chipBackground="#4389FA"
-                app:chipHeight="30dp"
-                app:chipTextColor="@color/grey_50"
+                android:layout_marginEnd="16dp"
+                android:layout_marginLeft="16dp"
+                android:layout_marginRight="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="wrap_content"
+                android:text="@string/product_details"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/grey_line1" />
 
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <TextView
-            android:id="@+id/packaging_hint"
-            style="@style/EditHint"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="@string/hint_packaging"
-            app:layout_constraintEnd_toEndOf="@id/packaging_til"
-            app:layout_constraintStart_toStartOf="@id/packaging_til"
-            app:layout_constraintTop_toBottomOf="@id/packaging_til" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/categories_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/packaging_hint">
-
-            <com.hootsuite.nachos.NachoTextView
-                android:id="@+id/categories"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/bg_edittext_til"
-                android:completionThreshold="1"
+            <TextView
                 android:gravity="center_vertical"
-                android:hint="@string/category_drawer"
-                android:imeOptions="actionNext"
-                android:minHeight="50dp"
-                android:nextFocusDown="@id/label"
-                android:paddingTop="@dimen/floating_hint_margin_nacho"
-                android:paddingBottom="@dimen/floating_hint_margin_nacho"
-                app:chipBackground="#4389FA"
-                app:chipHeight="30dp"
-                app:chipTextColor="@color/grey_50"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <TextView
-            android:id="@+id/category_hint"
-            style="@style/EditHint.Important"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@string/required_to_compute_nutriscore"
-            app:layout_constraintEnd_toEndOf="@+id/categories_til"
-            app:layout_constraintStart_toStartOf="@+id/categories_til"
-            app:layout_constraintTop_toBottomOf="@+id/categories_til" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/label_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/category_hint">
-
-            <com.hootsuite.nachos.NachoTextView
-                android:id="@+id/label"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/bg_edittext_til"
-                android:completionThreshold="1"
-                android:gravity="center_vertical"
-                android:hint="@string/labels"
-                android:imeOptions="actionNext"
-                android:minHeight="50dp"
-                android:nextFocusDown="@id/period_of_time_after_opening"
-                android:paddingTop="@dimen/floating_hint_margin_nacho"
-                android:paddingBottom="@dimen/floating_hint_margin_nacho"
-                app:chipBackground="#4389FA"
-                app:chipHeight="30dp"
-                app:chipTextColor="@color/grey_50"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/period_of_time_after_opening_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/label_til">
-
-            <AutoCompleteTextView
-                android:id="@+id/period_of_time_after_opening"
-                android:layout_width="match_parent"
+                android:id="@+id/barcode"
                 android:layout_height="40dp"
-                android:background="@drawable/bg_edittext_til"
-                android:completionThreshold="1"
-                android:gravity="center_vertical"
-                android:hint="@string/period_of_time_after_opening"
-                android:imeOptions="actionNext"
-                android:inputType="textVisiblePassword"
-                android:nextFocusDown="@id/origin_of_ingredients"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                android:textSize="16sp"
+                android:textStyle="bold"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                tools:visibility="visible" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-
-        <View
-            android:id="@+id/grey_line2"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginLeft="@dimen/spacing_small"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/spacing_small"
-            android:background="@color/grey_400"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/period_of_time_after_opening_til" />
-
-        <TextView
-            android:id="@+id/section_manufacturing_details"
-            style="@style/EditHeader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:text="@string/manufacturing_details"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/grey_line2"
-            tools:drawableEnd="@drawable/ic_keyboard_arrow_down_grey_24dp"
-            tools:drawableRight="@drawable/ic_keyboard_arrow_down_grey_24dp" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/origin_of_ingredients_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/section_manufacturing_details">
-
-            <com.hootsuite.nachos.NachoTextView
-                android:id="@+id/origin_of_ingredients"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/bg_edittext_til"
-                android:completionThreshold="1"
-                android:gravity="center_vertical"
-                android:hint="@string/origin_of_ingredients"
-                android:imeOptions="actionNext"
-                android:inputType="text"
-                android:minHeight="50dp"
-                android:nextFocusDown="@id/manufacturing_place"
-                android:paddingTop="@dimen/floating_hint_margin_nacho"
-                android:paddingBottom="@dimen/floating_hint_margin_nacho"
-                app:chipBackground="#4389FA"
-                app:chipHeight="30dp"
-                app:chipTextColor="@color/grey_50"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent" />
-
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <TextView
-            android:id="@+id/origin_warning"
-            style="@style/EditHint.Important"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@string/required_for_ecoscore"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="@id/origin_of_ingredients_til"
-            app:layout_constraintStart_toStartOf="@id/origin_of_ingredients_til"
-            app:layout_constraintTop_toBottomOf="@id/origin_of_ingredients_til" />
-
-        <TextView
-            android:id="@+id/origin_hint"
-            style="@style/EditHint"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@string/hint_origin"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="@id/origin_of_ingredients_til"
-            app:layout_constraintStart_toStartOf="@id/origin_of_ingredients_til"
-            app:layout_constraintTop_toBottomOf="@id/origin_warning" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/manufacturing_place_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/origin_hint">
-
-            <EditText
-                android:id="@+id/manufacturing_place"
-                android:layout_width="match_parent"
-                android:layout_height="50dp"
-                android:background="@drawable/bg_edittext_til"
-                android:gravity="center_vertical"
-                android:hint="@string/manufacturing_place"
-                android:inputType="text"
-                android:nextFocusDown="@id/emb_code"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                tools:visibility="visible" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/emb_code_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/manufacturing_place_til">
-
-            <com.hootsuite.nachos.NachoTextView
-                android:id="@+id/emb_code"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/bg_edittext_til"
-                android:completionThreshold="1"
-                android:gravity="center_vertical"
-                android:hint="@string/emb_code"
-                android:imeOptions="actionNext"
-                android:inputType="text"
-                android:minHeight="50dp"
-                android:nextFocusDown="@id/link"
-                android:paddingTop="@dimen/floating_hint_margin_nacho"
-                android:paddingBottom="@dimen/floating_hint_margin_nacho"
-                app:chipBackground="#4389FA"
-                app:chipHeight="30dp"
-                app:chipTextColor="@color/grey_50"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                tools:visibility="visible" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <TextView
-            android:id="@+id/trace_hint"
-            style="@style/EditHint"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:text="@string/hint_trace_code"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="@id/emb_code_til"
-            app:layout_constraintStart_toStartOf="@id/emb_code_til"
-            app:layout_constraintTop_toBottomOf="@id/emb_code_til" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/link_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:layout_marginBottom="0dp"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/trace_hint">
-
-            <EditText
-                android:id="@+id/link"
-                android:layout_width="match_parent"
-                android:layout_height="50dp"
-                android:background="@drawable/bg_edittext_til"
-                android:gravity="center_vertical"
-                android:hint="@string/hint_product_URL"
-                android:inputType="textUri"
-                android:nextFocusDown="@id/country_where_purchased"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                tools:visibility="visible" />
-        </com.google.android.material.textfield.TextInputLayout>
-
-        <LinearLayout
-            android:id="@+id/linearLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:gravity="center"
-            android:orientation="horizontal"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="@id/link_til"
-            app:layout_constraintStart_toStartOf="@id/link_til"
-            app:layout_constraintTop_toBottomOf="@id/link_til">
+                app:layout_constraintTop_toBottomOf="@id/section_product_details"
+                tools:text="Barcode : 8888888888888" />
 
             <TextView
-                android:id="@+id/extract_url_text"
-                android:layout_width="match_parent"
+                android:background="@drawable/bg_edittext"
+                android:gravity="center_vertical"
+                android:id="@+id/language"
+                android:layout_height="40dp"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                android:textSize="16sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/barcode"
+                tools:drawableEnd="@drawable/ic_arrow_drop_down"
+                tools:drawableRight="@drawable/ic_arrow_drop_down"
+                tools:text="Product language : English" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/name_til"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="center"
-                android:text="@string/extract_url"
-                android:textAlignment="center"
-                android:textSize="12.5sp"
-                app:drawableLeftCompat="@drawable/barcode_grey_24dp" />
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/language">
+
+                <EditText
+                    android:background="@drawable/bg_edittext_til"
+                    android:gravity="center_vertical"
+                    android:hint="@string/product_name"
+                    android:id="@+id/name"
+                    android:importantForAutofill="no"
+                    android:inputType="text"
+                    android:layout_height="50dp"
+                    android:layout_width="match_parent"
+                    android:nextFocusDown="@id/quantity"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/quantity_til"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="0dp"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/name_til">
+
+                <EditText
+                    android:background="@drawable/bg_edittext_til"
+                    android:gravity="center_vertical"
+                    android:hint="@string/quantity"
+                    android:id="@+id/quantity"
+                    android:inputType="text"
+                    android:layout_height="50dp"
+                    android:layout_width="match_parent"
+                    android:nextFocusDown="@id/brand"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+            </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
-                android:id="@+id/search_url_text"
-                android:layout_width="match_parent"
+                style="@style/EditHint"
+                android:id="@+id/quantity_hint"
+                android:layout_height="wrap_content"
+                android:layout_width="0dp"
+                android:text="@string/hint_quantity"
+                app:layout_constraintEnd_toEndOf="@id/quantity_til"
+                app:layout_constraintStart_toStartOf="@id/quantity_til"
+                app:layout_constraintTop_toBottomOf="@id/quantity_til" />
+
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/brand_til"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/quantity_hint">
+
+                <com.hootsuite.nachos.NachoTextView
+                    android:background="@drawable/bg_edittext_til"
+                    android:gravity="center_vertical"
+                    android:hint="@string/hintBrand"
+                    android:id="@+id/brand"
+                    android:inputType="text"
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:minHeight="50dp"
+                    android:nextFocusDown="@id/packaging"
+                    android:paddingBottom="@dimen/floating_hint_margin_nacho"
+                    android:paddingTop="@dimen/floating_hint_margin_nacho"
+                    app:chipBackground="#4389FA"
+                    app:chipHeight="30dp"
+                    app:chipTextColor="@color/grey_50"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                style="@style/EditHint"
+                android:id="@+id/brand_hint"
+                android:layout_height="wrap_content"
+                android:layout_width="0dp"
+                android:text="@string/brand_hint"
+                app:layout_constraintEnd_toEndOf="@id/brand_til"
+                app:layout_constraintStart_toStartOf="@id/brand_til"
+                app:layout_constraintTop_toBottomOf="@id/brand_til" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/packaging_til"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/brand_hint">
+
+                <com.hootsuite.nachos.NachoTextView
+                    android:background="@drawable/bg_edittext_til"
+                    android:gravity="center_vertical"
+                    android:hint="@string/packaging_string"
+                    android:id="@+id/packaging"
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:minHeight="50dp"
+                    android:nextFocusDown="@id/categories"
+                    android:paddingBottom="@dimen/floating_hint_margin_nacho"
+                    android:paddingTop="@dimen/floating_hint_margin_nacho"
+                    app:chipBackground="#4389FA"
+                    app:chipHeight="30dp"
+                    app:chipTextColor="@color/grey_50"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                style="@style/EditHint"
+                android:id="@+id/packaging_hint"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:layout_width="0dp"
+                android:text="@string/hint_packaging"
+                app:layout_constraintEnd_toEndOf="@id/packaging_til"
+                app:layout_constraintStart_toStartOf="@id/packaging_til"
+                app:layout_constraintTop_toBottomOf="@id/packaging_til" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/categories_til"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/packaging_hint">
+
+                <com.hootsuite.nachos.NachoTextView
+                    android:background="@drawable/bg_edittext_til"
+                    android:completionThreshold="1"
+                    android:gravity="center_vertical"
+                    android:hint="@string/category_drawer"
+                    android:id="@+id/categories"
+                    android:imeOptions="actionNext"
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:minHeight="50dp"
+                    android:nextFocusDown="@id/label"
+                    android:paddingBottom="@dimen/floating_hint_margin_nacho"
+                    android:paddingTop="@dimen/floating_hint_margin_nacho"
+                    app:chipBackground="#4389FA"
+                    app:chipHeight="30dp"
+                    app:chipTextColor="@color/grey_50"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                style="@style/EditHint.Important"
+                android:id="@+id/category_hint"
+                android:layout_height="wrap_content"
+                android:layout_width="0dp"
+                android:text="@string/required_to_compute_nutriscore"
+                app:layout_constraintEnd_toEndOf="@+id/categories_til"
+                app:layout_constraintStart_toStartOf="@+id/categories_til"
+                app:layout_constraintTop_toBottomOf="@+id/categories_til" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/label_til"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/category_hint">
+
+                <com.hootsuite.nachos.NachoTextView
+                    android:background="@drawable/bg_edittext_til"
+                    android:completionThreshold="1"
+                    android:gravity="center_vertical"
+                    android:hint="@string/labels"
+                    android:id="@+id/label"
+                    android:imeOptions="actionNext"
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:minHeight="50dp"
+                    android:nextFocusDown="@id/period_of_time_after_opening"
+                    android:paddingBottom="@dimen/floating_hint_margin_nacho"
+                    android:paddingTop="@dimen/floating_hint_margin_nacho"
+                    app:chipBackground="#4389FA"
+                    app:chipHeight="30dp"
+                    app:chipTextColor="@color/grey_50"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/period_of_time_after_opening_til"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/label_til">
+
+                <AutoCompleteTextView
+                    android:background="@drawable/bg_edittext_til"
+                    android:completionThreshold="1"
+                    android:gravity="center_vertical"
+                    android:hint="@string/period_of_time_after_opening"
+                    android:id="@+id/period_of_time_after_opening"
+                    android:imeOptions="actionNext"
+                    android:inputType="textVisiblePassword"
+                    android:layout_height="40dp"
+                    android:layout_width="match_parent"
+                    android:nextFocusDown="@id/origin_of_ingredients"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    tools:visibility="visible" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+
+            <View
+                android:background="@color/grey_400"
+                android:id="@+id/grey_line2"
+                android:layout_height="1dp"
+                android:layout_marginLeft="@dimen/spacing_small"
+                android:layout_marginRight="@dimen/spacing_small"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="match_parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/period_of_time_after_opening_til" />
+
+            <TextView
+                style="@style/EditHeader"
+                android:id="@+id/section_manufacturing_details"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="match_parent"
+                android:text="@string/manufacturing_details"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/grey_line2"
+                tools:drawableEnd="@drawable/ic_keyboard_arrow_down_grey_24dp"
+                tools:drawableRight="@drawable/ic_keyboard_arrow_down_grey_24dp" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/origin_of_ingredients_til"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/section_manufacturing_details">
+
+                <com.hootsuite.nachos.NachoTextView
+                    android:background="@drawable/bg_edittext_til"
+                    android:completionThreshold="1"
+                    android:gravity="center_vertical"
+                    android:hint="@string/origin_of_ingredients"
+                    android:id="@+id/origin_of_ingredients"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:minHeight="50dp"
+                    android:nextFocusDown="@id/manufacturing_place"
+                    android:paddingBottom="@dimen/floating_hint_margin_nacho"
+                    android:paddingTop="@dimen/floating_hint_margin_nacho"
+                    app:chipBackground="#4389FA"
+                    app:chipHeight="30dp"
+                    app:chipTextColor="@color/grey_50"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                style="@style/EditHint.Important"
+                android:id="@+id/origin_warning"
+                android:layout_height="wrap_content"
+                android:layout_width="0dp"
+                android:text="@string/required_for_ecoscore"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="@id/origin_of_ingredients_til"
+                app:layout_constraintStart_toStartOf="@id/origin_of_ingredients_til"
+                app:layout_constraintTop_toBottomOf="@id/origin_of_ingredients_til" />
+
+            <TextView
+                style="@style/EditHint"
+                android:id="@+id/origin_hint"
+                android:layout_height="wrap_content"
+                android:layout_width="0dp"
+                android:text="@string/hint_origin"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="@id/origin_of_ingredients_til"
+                app:layout_constraintStart_toStartOf="@id/origin_of_ingredients_til"
+                app:layout_constraintTop_toBottomOf="@id/origin_warning" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/manufacturing_place_til"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/origin_hint">
+
+                <EditText
+                    android:background="@drawable/bg_edittext_til"
+                    android:gravity="center_vertical"
+                    android:hint="@string/manufacturing_place"
+                    android:id="@+id/manufacturing_place"
+                    android:inputType="text"
+                    android:layout_height="50dp"
+                    android:layout_width="match_parent"
+                    android:nextFocusDown="@id/emb_code"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    tools:visibility="visible" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/emb_code_til"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/manufacturing_place_til">
+
+                <com.hootsuite.nachos.NachoTextView
+                    android:background="@drawable/bg_edittext_til"
+                    android:completionThreshold="1"
+                    android:gravity="center_vertical"
+                    android:hint="@string/emb_code"
+                    android:id="@+id/emb_code"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:minHeight="50dp"
+                    android:nextFocusDown="@id/link"
+                    android:paddingBottom="@dimen/floating_hint_margin_nacho"
+                    android:paddingTop="@dimen/floating_hint_margin_nacho"
+                    app:chipBackground="#4389FA"
+                    app:chipHeight="30dp"
+                    app:chipTextColor="@color/grey_50"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    tools:visibility="visible" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                style="@style/EditHint"
+                android:id="@+id/trace_hint"
+                android:layout_height="wrap_content"
+                android:layout_width="0dp"
+                android:text="@string/hint_trace_code"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="@id/emb_code_til"
+                app:layout_constraintStart_toStartOf="@id/emb_code_til"
+                app:layout_constraintTop_toBottomOf="@id/emb_code_til" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/link_til"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="0dp"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/trace_hint">
+
+                <EditText
+                    android:background="@drawable/bg_edittext_til"
+                    android:gravity="center_vertical"
+                    android:hint="@string/hint_product_URL"
+                    android:id="@+id/link"
+                    android:inputType="textUri"
+                    android:layout_height="50dp"
+                    android:layout_width="match_parent"
+                    android:nextFocusDown="@id/country_where_purchased"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    tools:visibility="visible" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <LinearLayout
                 android:gravity="center"
-                android:text="@string/search_url"
-                android:textAlignment="center"
-                android:textSize="12.5sp"
-                app:drawableLeftCompat="@drawable/ic_search_dark" />
-        </LinearLayout>
-
-        <View
-            android:id="@+id/grey_line3"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginLeft="@dimen/spacing_small"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/spacing_small"
-            android:background="@color/grey_400"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/linearLayout" />
-
-        <TextView
-            android:id="@+id/section_purchasing_details"
-            style="@style/EditHeader"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginLeft="16dp"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:text="@string/purchasing_details"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/grey_line3"
-            tools:drawableEnd="@drawable/ic_keyboard_arrow_down_grey_24dp"
-            tools:drawableRight="@drawable/ic_keyboard_arrow_down_grey_24dp" />
-
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/country_where_purchased_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/section_purchasing_details">
-
-            <com.hootsuite.nachos.NachoTextView
-                android:id="@+id/country_where_purchased"
-                android:layout_width="match_parent"
+                android:id="@+id/linearLayout"
                 android:layout_height="wrap_content"
-                android:background="@drawable/bg_edittext_til"
-                android:completionThreshold="1"
-                android:gravity="center_vertical"
-                android:hint="@string/country_where_purchased"
-                android:imeOptions="actionNext"
-                android:inputType="text"
-                android:minHeight="50dp"
-                android:nextFocusDown="@id/stores"
-                android:paddingTop="@dimen/floating_hint_margin_nacho"
-                android:paddingBottom="@dimen/floating_hint_margin_nacho"
-                app:chipBackground="#4389FA"
-                app:chipHeight="30dp"
-                app:chipTextColor="@color/grey_50"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_width="match_parent"
+                android:orientation="horizontal"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="@id/link_til"
+                app:layout_constraintStart_toStartOf="@id/link_til"
+                app:layout_constraintTop_toBottomOf="@id/link_til">
+
+                <TextView
+                    android:gravity="center"
+                    android:id="@+id/extract_url_text"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_width="match_parent"
+                    android:text="@string/extract_url"
+                    android:textAlignment="center"
+                    android:textSize="12.5sp"
+                    app:drawableLeftCompat="@drawable/barcode_grey_24dp" />
+
+                <TextView
+                    android:gravity="center"
+                    android:id="@+id/search_url_text"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:layout_width="match_parent"
+                    android:text="@string/search_url"
+                    android:textAlignment="center"
+                    android:textSize="12.5sp"
+                    app:drawableLeftCompat="@drawable/ic_search_dark" />
+            </LinearLayout>
+
+            <View
+                android:background="@color/grey_400"
+                android:id="@+id/grey_line3"
+                android:layout_height="1dp"
+                android:layout_marginLeft="@dimen/spacing_small"
+                android:layout_marginRight="@dimen/spacing_small"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="match_parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/linearLayout" />
+
+            <TextView
+                style="@style/EditHeader"
+                android:id="@+id/section_purchasing_details"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="16dp"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="match_parent"
+                android:text="@string/purchasing_details"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/grey_line3"
+                tools:drawableEnd="@drawable/ic_keyboard_arrow_down_grey_24dp"
+                tools:drawableRight="@drawable/ic_keyboard_arrow_down_grey_24dp" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/country_where_purchased_til"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                tools:visibility="visible" />
-        </com.google.android.material.textfield.TextInputLayout>
+                app:layout_constraintTop_toBottomOf="@id/section_purchasing_details">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/stores_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/country_where_purchased_til">
+                <com.hootsuite.nachos.NachoTextView
+                    android:background="@drawable/bg_edittext_til"
+                    android:completionThreshold="1"
+                    android:gravity="center_vertical"
+                    android:hint="@string/country_where_purchased"
+                    android:id="@+id/country_where_purchased"
+                    android:imeOptions="actionNext"
+                    android:inputType="text"
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:minHeight="50dp"
+                    android:nextFocusDown="@id/stores"
+                    android:paddingBottom="@dimen/floating_hint_margin_nacho"
+                    android:paddingTop="@dimen/floating_hint_margin_nacho"
+                    app:chipBackground="#4389FA"
+                    app:chipHeight="30dp"
+                    app:chipTextColor="@color/grey_50"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    tools:visibility="visible" />
+            </com.google.android.material.textfield.TextInputLayout>
 
-            <com.hootsuite.nachos.NachoTextView
-                android:id="@+id/stores"
-                android:layout_width="match_parent"
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/stores_til"
                 android:layout_height="wrap_content"
-                android:background="@drawable/bg_edittext_til"
-                android:gravity="center_vertical"
-                android:hint="@string/stores"
-                android:inputType="text"
-                android:minHeight="50dp"
-                android:nextFocusDown="@id/countries_where_sold"
-                android:paddingTop="@dimen/floating_hint_margin_nacho"
-                android:paddingBottom="@dimen/floating_hint_margin_nacho"
-                app:chipBackground="#4389FA"
-                app:chipHeight="30dp"
-                app:chipTextColor="@color/grey_50"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                tools:visibility="visible" />
-        </com.google.android.material.textfield.TextInputLayout>
+                app:layout_constraintTop_toBottomOf="@id/country_where_purchased_til">
 
-        <com.google.android.material.textfield.TextInputLayout
-            android:id="@+id/countries_where_sold_til"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="@dimen/activity_horizontal_margin"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/activity_horizontal_margin"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/stores_til"
-            tools:visibility="visible">
+                <com.hootsuite.nachos.NachoTextView
+                    android:background="@drawable/bg_edittext_til"
+                    android:gravity="center_vertical"
+                    android:hint="@string/stores"
+                    android:id="@+id/stores"
+                    android:inputType="text"
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:minHeight="50dp"
+                    android:nextFocusDown="@id/countries_where_sold"
+                    android:paddingBottom="@dimen/floating_hint_margin_nacho"
+                    android:paddingTop="@dimen/floating_hint_margin_nacho"
+                    app:chipBackground="#4389FA"
+                    app:chipHeight="30dp"
+                    app:chipTextColor="@color/grey_50"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    tools:visibility="visible" />
+            </com.google.android.material.textfield.TextInputLayout>
 
-            <com.hootsuite.nachos.NachoTextView
-                android:id="@+id/countries_where_sold"
-                android:layout_width="match_parent"
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/countries_where_sold_til"
                 android:layout_height="wrap_content"
-                android:background="@drawable/bg_edittext_til"
-                android:completionThreshold="1"
-                android:gravity="center_vertical"
-                android:hint="@string/country_string"
-                android:imeOptions="actionDone"
-                android:inputType="text"
-                android:minHeight="50dp"
-                android:paddingTop="@dimen/floating_hint_margin_nacho"
-                android:paddingBottom="@dimen/floating_hint_margin_nacho"
-                app:chipBackground="#4389FA"
-                app:chipHeight="30dp"
-                app:chipTextColor="@color/grey_50"
+                android:layout_marginLeft="@dimen/activity_horizontal_margin"
+                android:layout_marginRight="@dimen/activity_horizontal_margin"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="0dp"
+                android:visibility="gone"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/stores_til"
+                tools:visibility="visible">
+
+                <com.hootsuite.nachos.NachoTextView
+                    android:background="@drawable/bg_edittext_til"
+                    android:completionThreshold="1"
+                    android:gravity="center_vertical"
+                    android:hint="@string/country_string"
+                    android:id="@+id/countries_where_sold"
+                    android:imeOptions="actionDone"
+                    android:inputType="text"
+                    android:layout_height="wrap_content"
+                    android:layout_width="match_parent"
+                    android:minHeight="50dp"
+                    android:paddingBottom="@dimen/floating_hint_margin_nacho"
+                    android:paddingTop="@dimen/floating_hint_margin_nacho"
+                    app:chipBackground="#4389FA"
+                    app:chipHeight="30dp"
+                    app:chipTextColor="@color/grey_50"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    tools:visibility="visible" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <View
+                android:background="@color/grey_400"
+                android:id="@+id/grey_line4"
+                android:layout_height="1dp"
+                android:layout_marginLeft="@dimen/spacing_small"
+                android:layout_marginRight="@dimen/spacing_small"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="match_parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/countries_where_sold_til" />
+
+            <ProgressBar
+                android:id="@+id/other_image_progress"
+                android:layout_height="40dp"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="wrap_content"
+                android:visibility="gone"
+                app:layout_constraintEnd_toStartOf="@+id/other_image_progress_text"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/grey_line4"
                 tools:visibility="visible" />
-        </com.google.android.material.textfield.TextInputLayout>
 
-        <View
-            android:id="@+id/grey_line4"
-            android:layout_width="match_parent"
-            android:layout_height="1dp"
-            android:layout_marginLeft="@dimen/spacing_small"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:layout_marginRight="@dimen/spacing_small"
-            android:background="@color/grey_400"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/countries_where_sold_til" />
+            <TextView
+                android:gravity="center"
+                android:id="@+id/other_image_progress_text"
+                android:layout_height="40dp"
+                android:layout_marginTop="@dimen/spacing_small"
+                android:layout_width="wrap_content"
+                android:text="@string/toastSending"
+                android:visibility="gone"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintHorizontal_bias="0.5"
+                app:layout_constraintStart_toEndOf="@+id/other_image_progress"
+                app:layout_constraintTop_toBottomOf="@id/grey_line4"
+                tools:visibility="visible" />
 
-        <ProgressBar
-            android:id="@+id/other_image_progress"
-            android:layout_width="wrap_content"
-            android:layout_height="40dp"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:visibility="gone"
-            app:layout_constraintEnd_toStartOf="@+id/other_image_progress_text"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintHorizontal_chainStyle="packed"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/grey_line4"
-            tools:visibility="visible" />
+            <Button
+                style="@style/ButtonBorder"
+                android:drawablePadding="@dimen/spacing_tiny"
+                android:id="@+id/btn_other_pictures"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/padding_normal"
+                android:layout_width="wrap_content"
+                android:text="@string/take_more_pictures"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/other_image_progress_text" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
-        <TextView
-            android:id="@+id/other_image_progress_text"
-            android:layout_width="wrap_content"
-            android:layout_height="40dp"
-            android:layout_marginTop="@dimen/spacing_small"
-            android:gravity="center"
-            android:text="@string/toastSending"
-            android:visibility="gone"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintHorizontal_bias="0.5"
-            app:layout_constraintStart_toEndOf="@+id/other_image_progress"
-            app:layout_constraintTop_toBottomOf="@id/grey_line4"
-            tools:visibility="visible" />
+    </ScrollView>
 
-        <Button
-            android:id="@+id/btn_other_pictures"
-            style="@style/ButtonBorder"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/padding_normal"
-            android:drawablePadding="@dimen/spacing_tiny"
-            android:text="@string/take_more_pictures"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/other_image_progress_text" />
+    <Button
+        style="@style/ButtonFlat"
+        android:clickable="true"
+        android:focusable="true"
+        android:id="@+id/btn_next"
+        android:layout_width="match_parent"
+        android:text="@string/next"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        />
 
-        <Button
-            android:id="@+id/btn_next"
-            style="@style/ButtonFlat"
-            android:layout_width="match_parent"
-            android:layout_marginTop="16dp"
-            android:clickable="true"
-            android:focusable="true"
-            android:text="@string/next"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/btn_other_pictures" />
-
-    </androidx.constraintlayout.widget.ConstraintLayout>
-
-</ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
####  Description
Turn the "next" and "save" buttons in the edit screens to sticky buttons which are always visible at the bottom.
Additionally, fix wrong clipping in the scrollviews.

#### Related issues
- Fixes #4141

#### Screenshots
Emulator, Nexus S, API 21:
![Nexus S API 21](https://user-images.githubusercontent.com/2601296/138965370-fd788bf7-694d-43b0-bb30-ae1973a4603a.jpg)

Emulator, Pixel C, API 30:
![Pixel C API 30](https://user-images.githubusercontent.com/2601296/138965389-3178c54e-4dee-47df-a56d-89ed3813fe49.jpg)

#### Link to the automatically generated build APK
OFF APK: https://github.com/openfoodfacts/openfoodfacts-androidapp/suites/4170189320/artifacts/107241185

