### PR TITLE
revert the app to targetSdk = 30

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -208,7 +208,7 @@ android {
         applicationId = "openfoodfacts.github.scrachx.openfood"
 
         minSdk = 16
-        targetSdk = 31
+        targetSdk = 30
 
         versionCode = 433
         versionName = "3.6.8"


### PR DESCRIPTION
### What
- revert the app to targetSdk = 30 as otherwise it's crashing on startup
- Related issue: https://github.com/openfoodfacts/openfoodfacts-androidapp/issues/4428