### PR TITLE
JUnit 5 migration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -153,12 +153,19 @@ implementation("com.squareup.okhttp3:logging-interceptor:3.12.13")
     implementation("com.github.mreram:showcaseview:1.0.5")
 
 
+    val junit5Bom = "5.8.2"
+    testImplementation(platform("org.junit:junit-bom:$junit5Bom"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
+
     // Unit Testing
     testImplementation("androidx.arch.core:core-testing:2.1.0")
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.robolectric:robolectric:4.7.3")
     testImplementation("org.mockito:mockito-core:4.2.0")
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")
+    testImplementation("org.mockito:mockito-junit-jupiter:4.2.0")
     testImplementation("net.javacrumbs.json-unit:json-unit-fluent:2.28.0")
     testImplementation("com.google.truth:truth:1.1.3")
     testImplementation("com.google.truth.extensions:truth-java8-extension:1.1.3")
@@ -369,6 +376,15 @@ android {
     }
 
     testOptions {
+        unitTests.all { test ->
+            test.useJUnitPlatform {
+                includeEngines("junit-jupiter", "junit-vintage")
+            }
+            test.testLogging {
+                events("passed", "skipped", "failed")
+            }
+        }
+
         // avoid "Method ... not mocked."
         unitTests.isReturnDefaultValues = true
         execution = "ANDROIDX_TEST_ORCHESTRATOR"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -152,13 +152,6 @@ implementation("com.squareup.okhttp3:logging-interceptor:3.12.13")
     // ShowCaseView dependency
     implementation("com.github.mreram:showcaseview:1.0.5")
 
-
-    val junit5Bom = "5.8.2"
-    testImplementation(platform("org.junit:junit-bom:$junit5Bom"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
-    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
-
     // Unit Testing
     testImplementation("androidx.arch.core:core-testing:2.1.0")
     testImplementation("junit:junit:4.13.2")
@@ -170,6 +163,12 @@ implementation("com.squareup.okhttp3:logging-interceptor:3.12.13")
     testImplementation("com.google.truth:truth:1.1.3")
     testImplementation("com.google.truth.extensions:truth-java8-extension:1.1.3")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:${coroutinesVersion}")
+
+    val junit5Bom = "5.8.2"
+    testImplementation(platform("org.junit:junit-bom:$junit5Bom"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 
     // Instrumented tests
     androidTestUtil("androidx.test:orchestrator:1.4.0")

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/category/CategoryRepositoryTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/category/CategoryRepositoryTest.kt
@@ -8,11 +8,11 @@ import openfoodfacts.github.scrachx.openfood.category.mapper.CategoryMapper
 import openfoodfacts.github.scrachx.openfood.category.model.Category
 import openfoodfacts.github.scrachx.openfood.category.network.CategoryNetworkService
 import openfoodfacts.github.scrachx.openfood.category.network.CategoryResponse
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
@@ -21,7 +21,7 @@ import org.mockito.kotlin.whenever
  * Created by Abdelali Eramli on 01/01/2018.
  */
 @ExperimentalCoroutinesApi
-@RunWith(MockitoJUnitRunner::class)
+@ExtendWith(MockitoExtension::class)
 class CategoryRepositoryTest {
     @Mock
     private lateinit var mapper: CategoryMapper
@@ -36,7 +36,7 @@ class CategoryRepositoryTest {
     private lateinit var response: CategoryResponse
     private lateinit var repository: CategoryRepository
 
-    @Before
+    @BeforeEach
     fun setup() = runBlockingTest {
         whenever(mapper.fromNetwork(any())) doReturn listOf(category, category, category)
         whenever(networkService.getCategories()) doReturn response

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/category/mapper/CategoryMapperTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/category/mapper/CategoryMapperTest.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.google.common.truth.Truth.assertThat
 import openfoodfacts.github.scrachx.openfood.category.network.CategoryResponse
 import openfoodfacts.github.scrachx.openfood.utils.readTextFileFromResources
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.IOException
 
 /**

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/features/compare/ProductCompareViewModelTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/features/compare/ProductCompareViewModelTest.kt
@@ -1,6 +1,5 @@
 package openfoodfacts.github.scrachx.openfood.features.compare
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
@@ -15,17 +14,16 @@ import openfoodfacts.github.scrachx.openfood.models.entities.additive.AdditiveNa
 import openfoodfacts.github.scrachx.openfood.repositories.ProductRepository
 import openfoodfacts.github.scrachx.openfood.repositories.TaxonomiesRepository
 import openfoodfacts.github.scrachx.openfood.utils.CoroutineDispatchersTest
+import openfoodfacts.github.scrachx.openfood.utils.InstantTaskExecutorExtension
 import openfoodfacts.github.scrachx.openfood.utils.LocaleManager
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.*
 
+@ExtendWith(InstantTaskExecutorExtension::class)
 @ExperimentalCoroutinesApi
 class ProductCompareViewModelTest {
-
-    @get:Rule
-    var instantExecutorRule = InstantTaskExecutorRule()
 
     private val taxonomiesRepository: TaxonomiesRepository = mock()
     private val localeManager: LocaleManager = mock()
@@ -35,7 +33,7 @@ class ProductCompareViewModelTest {
 
     private lateinit var viewModel: ProductCompareViewModel
 
-    @Before
+    @BeforeEach
     fun setup() {
         whenever(localeManager.getLanguage()).doReturn("en")
         viewModel = ProductCompareViewModel(taxonomiesRepository, localeManager, matomoAnalytics, coroutineDispatcher, productRepository)

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragmentTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragmentTest.kt
@@ -2,7 +2,7 @@ package openfoodfacts.github.scrachx.openfood.features.product.edit.nutrition
 
 import com.google.common.truth.Truth.assertThat
 import openfoodfacts.github.scrachx.openfood.models.Nutriment
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ProductEditNutritionFactsFragmentTest {
 

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/features/product/view/contributors/ContributorsFragmentTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/features/product/view/contributors/ContributorsFragmentTest.kt
@@ -1,7 +1,7 @@
 package openfoodfacts.github.scrachx.openfood.features.product.view.contributors
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ContributorsFragmentTest {
     @Test

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/features/simplescan/SimpleScanViewModelTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/features/simplescan/SimpleScanViewModelTest.kt
@@ -1,6 +1,5 @@
 package openfoodfacts.github.scrachx.openfood.features.simplescan
 
-import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.toList
@@ -10,23 +9,22 @@ import openfoodfacts.github.scrachx.openfood.features.simplescan.SimpleScanViewM
 import openfoodfacts.github.scrachx.openfood.models.CameraState
 import openfoodfacts.github.scrachx.openfood.repositories.ScannerPreferencesRepository
 import openfoodfacts.github.scrachx.openfood.utils.CoroutineDispatchersTest
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import openfoodfacts.github.scrachx.openfood.utils.InstantTaskExecutorExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.*
 
+@ExtendWith(InstantTaskExecutorExtension::class)
 @ExperimentalCoroutinesApi
 class SimpleScanViewModelTest {
-
-    @get:Rule
-    var instantExecutorRule = InstantTaskExecutorRule()
 
     private val prefsRepository = mock<ScannerPreferencesRepository>()
     private val dispatchers = CoroutineDispatchersTest()
 
     private lateinit var viewModel: SimpleScanViewModel
 
-    @Before
+    @BeforeEach
     fun setup() {
         whenever(prefsRepository.getAutoFocusPref()).doReturn(true)
         whenever(prefsRepository.getFlashPref()).doReturn(true)

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/images/ImageKeyHelperTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/images/ImageKeyHelperTest.kt
@@ -4,14 +4,14 @@ import com.google.common.truth.Truth
 import openfoodfacts.github.scrachx.openfood.BuildConfig
 import openfoodfacts.github.scrachx.openfood.models.Product
 import openfoodfacts.github.scrachx.openfood.models.ProductImageField
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 
 class ImageKeyHelperTest {
     private lateinit var mockProduct: Product
 
-    @Before
+    @BeforeEach
     fun setUp() {
         mockProduct = Mockito.mock(Product::class.java)
     }

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/images/ImageNameJsonParserTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/images/ImageNameJsonParserTest.kt
@@ -1,7 +1,7 @@
 package openfoodfacts.github.scrachx.openfood.images
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 
 class ImageNameJsonParserTest {

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/ModifierTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/ModifierTest.kt
@@ -3,8 +3,7 @@ package openfoodfacts.github.scrachx.openfood.models
 import android.widget.Spinner
 import com.google.common.truth.Truth.assertThat
 import openfoodfacts.github.scrachx.openfood.utils.modifier
-import org.junit.Test
-import org.mockito.Mockito
+import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/NutrientLevelsTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/NutrientLevelsTest.kt
@@ -3,8 +3,8 @@ package openfoodfacts.github.scrachx.openfood.models
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.google.common.truth.Truth
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * @author herau
@@ -12,7 +12,7 @@ import org.junit.Test
 class NutrientLevelsTest {
     private lateinit var nutrientLevels: NutrientLevels
 
-    @Before
+    @BeforeEach
     fun setUp() {
         nutrientLevels = NutrientLevels()
         nutrientLevels.fat = NutrimentLevel.LOW
@@ -31,7 +31,6 @@ class NutrientLevelsTest {
     }
 
     @Test
-    @Throws(Exception::class)
     fun jsonDeserialization_ok() {
         val objectMapper = jacksonObjectMapper()
         val nutrientLevelsResult = objectMapper.treeToValue(

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/NutrimentTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/NutrimentTest.kt
@@ -2,7 +2,7 @@ package openfoodfacts.github.scrachx.openfood.models
 
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertThrows
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NutrimentTest {
 

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/ProductIngredientTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/ProductIngredientTest.kt
@@ -1,7 +1,7 @@
 package openfoodfacts.github.scrachx.openfood.models
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [ProductIngredient]

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/ProductStateTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/ProductStateTest.kt
@@ -1,7 +1,7 @@
 package openfoodfacts.github.scrachx.openfood.models
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [ProductState]

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/ProductTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/ProductTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.common.truth.Truth.assertThat
 import org.junit.Assert.assertThrows
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [Product]

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/ToUploadProductTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/ToUploadProductTest.kt
@@ -2,8 +2,8 @@ package openfoodfacts.github.scrachx.openfood.models
 
 import com.google.common.truth.Truth.assertThat
 import openfoodfacts.github.scrachx.openfood.models.entities.ToUploadProduct
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [ToUploadProduct]
@@ -14,7 +14,7 @@ class ToUploadProductTest {
     // nutrients and NUTRITION
     private lateinit var toUploadProduct: ToUploadProduct
 
-    @Before
+    @BeforeEach
     fun setUp() {
         toUploadProduct = ToUploadProduct()
     }

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/additive/AdditiveNameTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/additive/AdditiveNameTest.kt
@@ -1,8 +1,8 @@
 package openfoodfacts.github.scrachx.openfood.models.entities.additive
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [AdditiveName]
@@ -10,7 +10,7 @@ import org.junit.Test
 class AdditiveNameTest {
     private lateinit var mAdditiveName: AdditiveName
 
-    @Before
+    @BeforeEach
     fun setup() {
         mAdditiveName = AdditiveName()
     }

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/additive/AdditiveResponseTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/additive/AdditiveResponseTest.kt
@@ -3,8 +3,8 @@ package openfoodfacts.github.scrachx.openfood.models.entities.additive
 import com.google.common.truth.Truth.assertThat
 import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAGE_CODE_ENGLISH
 import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAGE_CODE_FRENCH
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [AdditiveResponse]
@@ -12,7 +12,7 @@ import org.junit.Test
 class AdditiveResponseTest {
     private lateinit var mStringMap: Map<String, String>
 
-    @Before
+    @BeforeEach
     fun setup() {
         mStringMap = mapOf(
                 LANGUAGE_CODE_ENGLISH to AdditiveResponseTestData.VINEGAR_EN,

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/additive/AdditiveTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/additive/AdditiveTest.kt
@@ -4,20 +4,23 @@ import com.google.common.truth.Truth.assertThat
 import openfoodfacts.github.scrachx.openfood.models.DaoSession
 import org.greenrobot.greendao.DaoException
 import org.junit.Assert.assertThrows
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers
 import org.mockito.Mock
 import org.mockito.Mockito.verify
-import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
 
 /**
  * Tests for [Additive]
  */
-@RunWith(MockitoJUnitRunner::class)
+@ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class AdditiveTest {
     @Mock
     private val mockDaoSession: DaoSession? = null
@@ -29,7 +32,7 @@ class AdditiveTest {
     private lateinit var mockAdditiveNameDao: AdditiveNameDao
     private lateinit var mAdditive: Additive
 
-    @Before
+    @BeforeEach
     fun setup() {
         whenever(mockDaoSession!!.additiveNameDao) doReturn mockAdditiveNameDao
         whenever(mockDaoSession.additiveDao) doReturn mockAdditiveDao

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/additive/AdditivesWrapperTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/additive/AdditivesWrapperTest.kt
@@ -5,7 +5,7 @@ import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAG
 import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAGE_CODE_FRENCH
 import openfoodfacts.github.scrachx.openfood.models.entities.additive.AdditiveResponseTestData.ADDITIVE_TAG
 import openfoodfacts.github.scrachx.openfood.models.entities.additive.AdditiveResponseTestData.WIKI_DATA_ID
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [AdditivesWrapper]

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/allergen/AllergenResponseTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/allergen/AllergenResponseTest.kt
@@ -3,15 +3,15 @@ package openfoodfacts.github.scrachx.openfood.models.entities.allergen
 import com.google.common.truth.Truth.assertThat
 import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAGE_CODE_ENGLISH
 import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAGE_CODE_FRENCH
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [AllergenResponse]
  */
 class AllergenResponseTest {
     lateinit var nameMap: MutableMap<String, String>
-    @Before
+    @BeforeEach
     fun setUp() {
         nameMap = mutableMapOf()
     }

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/allergen/AllergenTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/allergen/AllergenTest.kt
@@ -3,14 +3,14 @@ package openfoodfacts.github.scrachx.openfood.models.entities.allergen
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import com.google.common.truth.Truth.assertThat
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.io.IOException
 
 class AllergenTest {
     lateinit var allergens: List<Allergen>
 
-    @Before
+    @BeforeEach
     @Throws(IOException::class)
     fun setUp() {
         //language=JSON

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/allergen/AllergensWrapperTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/allergen/AllergensWrapperTest.kt
@@ -4,8 +4,8 @@ import com.google.common.truth.Truth.assertThat
 import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAGE_CODE_ENGLISH
 import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAGE_CODE_FRENCH
 import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAGE_CODE_GERMAN
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [AllergensWrapper]
@@ -15,7 +15,7 @@ class AllergensWrapperTest {
     lateinit var allergen1: Allergen
     lateinit var allergen2: Allergen
 
-    @Before
+    @BeforeEach
     fun setUp() {
 
         val nameMap1 = mapOf(

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/analysistag/AnalysisTagTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/analysistag/AnalysisTagTest.kt
@@ -9,17 +9,17 @@ import openfoodfacts.github.scrachx.openfood.models.entities.allergen.PEANUTS_EN
 import openfoodfacts.github.scrachx.openfood.models.entities.allergen.UNIQUE_ALLERGEN_ID_1
 import openfoodfacts.github.scrachx.openfood.models.entities.allergen.UNIQUE_ALLERGEN_ID_2
 import org.greenrobot.greendao.DaoException
-import org.junit.Assert.assertThrows
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.Mockito
-import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
 
-@RunWith(MockitoJUnitRunner::class)
+@ExtendWith(MockitoExtension::class)
 class AnalysisTagTest {
     private lateinit var testAnalysisTag: AnalysisTag
     private val tagEnglish = AnalysisTagName(UNIQUE_ALLERGEN_ID_2, LANGUAGE_CODE_ENGLISH, PEANUTS_EN, "show")
@@ -27,28 +27,27 @@ class AnalysisTagTest {
     private lateinit var tagNames: MutableList<AnalysisTagName>
 
     @Mock
-    var mockDaoSession: DaoSession? = null
+    lateinit var mockDaoSession: DaoSession
 
     @Mock
-    var mockAnalysisTagNameDao: AnalysisTagNameDao? = null
+    lateinit var mockAnalysisTagNameDao: AnalysisTagNameDao
 
-    @Before
+    @BeforeEach
     fun setUp() {
         tagNames = arrayListOf(tagGerman, tagEnglish)
-
-        whenever(mockDaoSession!!.analysisTagNameDao) doReturn mockAnalysisTagNameDao
-        whenever(mockAnalysisTagNameDao!!._queryAnalysisTag_Names(Mockito.any())) doReturn tagNames
-
         testAnalysisTag = AnalysisTag()
     }
 
     @Test
     fun getNames_DaoSessionIsNull() {
-        assertThrows(DaoException::class.java) { testAnalysisTag.names }
+        assertThrows<DaoException> { testAnalysisTag.names }
     }
 
     @Test
     fun getNames_returnsListOfTags() {
+        whenever(mockDaoSession.analysisTagNameDao) doReturn mockAnalysisTagNameDao
+        whenever(mockAnalysisTagNameDao._queryAnalysisTag_Names(Mockito.any())) doReturn tagNames
+
         testAnalysisTag.__setDaoSession(mockDaoSession)
         val tags = testAnalysisTag.names
         assertThat(tags[0].analysisTag).isEqualTo(UNIQUE_ALLERGEN_ID_1)
@@ -59,10 +58,11 @@ class AnalysisTagTest {
         assertThat(tags[1].name).isEqualTo(PEANUTS_EN)
     }
 
-    @Test(expected = DaoException::class)
-    @Throws(DaoException::class)
+    @Test
     fun delete_throwsExceptionMyDaoIsNull() {
-        testAnalysisTag.__setDaoSession(mockDaoSession)
-        testAnalysisTag.delete()
+        assertThrows<DaoException> {
+            testAnalysisTag.__setDaoSession(mockDaoSession)
+            testAnalysisTag.delete()
+        }
     }
 }

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/category/CategoryNameTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/category/CategoryNameTest.kt
@@ -1,8 +1,8 @@
 package openfoodfacts.github.scrachx.openfood.models.entities.category
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [CategoryName]
@@ -10,7 +10,7 @@ import org.junit.Test
 class CategoryNameTest {
     private lateinit var mCategoryName: CategoryName
 
-    @Before
+    @BeforeEach
     fun setup() {
         mCategoryName = CategoryName()
     }

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/category/CategoryResponseTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/category/CategoryResponseTest.kt
@@ -5,8 +5,8 @@ import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAG
 import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAGE_CODE_FRENCH
 import openfoodfacts.github.scrachx.openfood.models.entities.category.CategoryResponseTestData.GUMMY_BEARS_EN
 import openfoodfacts.github.scrachx.openfood.models.entities.category.CategoryResponseTestData.GUMMY_BEARS_FR
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.util.*
 
 /**
@@ -16,7 +16,7 @@ class CategoryResponseTest {
     private val mNamesMap: MutableMap<String, String> = HashMap()
     private var mCategoryResponse: CategoryResponse? = null
 
-    @Before
+    @BeforeEach
     fun setup() {
         mNamesMap[LANGUAGE_CODE_ENGLISH] = GUMMY_BEARS_EN
         mNamesMap[LANGUAGE_CODE_FRENCH] = GUMMY_BEARS_FR

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/category/CategoryTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/category/CategoryTest.kt
@@ -4,17 +4,23 @@ import com.google.common.truth.Truth.assertThat
 import openfoodfacts.github.scrachx.openfood.models.DaoSession
 import org.greenrobot.greendao.DaoException
 import org.junit.Assert.assertThrows
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.*
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
 
 /**
  * Tests for [Category]
  */
-@RunWith(MockitoJUnitRunner.StrictStubs::class)
+@ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class CategoryTest {
     @Mock
     private lateinit var mockDaoSession: DaoSession
@@ -26,7 +32,7 @@ class CategoryTest {
     private lateinit var mockCategoryNameDao: CategoryNameDao
     private lateinit var mCategory: Category
 
-    @Before
+    @BeforeEach
     fun setup() {
         whenever(mockDaoSession.categoryDao) doReturn mockCategoryDao
         whenever(mockDaoSession.categoryNameDao) doReturn mockCategoryNameDao

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/country/CountriesWrapperTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/country/CountriesWrapperTest.kt
@@ -7,8 +7,8 @@ import openfoodfacts.github.scrachx.openfood.models.entities.country.CountryName
 import openfoodfacts.github.scrachx.openfood.models.entities.country.CountryNameTestData.GERMANY_FR
 import openfoodfacts.github.scrachx.openfood.models.entities.country.CountryNameTestData.USA_EN
 import openfoodfacts.github.scrachx.openfood.models.entities.country.CountryNameTestData.USA_FR
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [CountriesWrapper]
@@ -65,7 +65,7 @@ class CountriesWrapperTest {
         private lateinit var gerCountry: Country
 
         @JvmStatic
-        @BeforeClass
+        @BeforeAll
         fun setup() {
             val usaNamesMap = mapOf(LANGUAGE_CODE_ENGLISH to USA_EN, LANGUAGE_CODE_FRENCH to USA_FR)
             val usaCC2Map = mapOf(LANGUAGE_CODE_ENGLISH to "US")

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/country/CountryResponseTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/country/CountryResponseTest.kt
@@ -5,8 +5,8 @@ import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAG
 import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAGE_CODE_FRENCH
 import openfoodfacts.github.scrachx.openfood.models.entities.country.CountryNameTestData.GERMANY_EN
 import openfoodfacts.github.scrachx.openfood.models.entities.country.CountryNameTestData.GERMANY_FR
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.util.*
 
 /**
@@ -16,7 +16,7 @@ class CountryResponseTest {
     private var mCountryResponse: CountryResponse? = null
     private var country: Country? = null
 
-    @Before
+    @BeforeEach
     fun setup() {
         NAMES_MAP[LANGUAGE_CODE_ENGLISH] = GERMANY_EN
         NAMES_MAP[LANGUAGE_CODE_FRENCH] = GERMANY_FR

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/country/CountryTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/country/CountryTest.kt
@@ -8,17 +8,23 @@ import openfoodfacts.github.scrachx.openfood.models.entities.country.CountryName
 import openfoodfacts.github.scrachx.openfood.models.entities.country.CountryNameTestData.GERMANY_FR
 import org.greenrobot.greendao.DaoException
 import org.junit.Assert.assertThrows
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
-import org.mockito.junit.MockitoJUnitRunner
-import org.mockito.kotlin.*
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
 
 /**
  * Tests for [Country]
  */
-@RunWith(MockitoJUnitRunner::class)
+@ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class CountryTest {
 
     @Mock
@@ -31,7 +37,7 @@ class CountryTest {
     private lateinit var mockCountryNameDao: CountryNameDao
     private lateinit var country: Country
 
-    @Before
+    @BeforeEach
     fun setup() {
         whenever(mockDaoSession.countryDao) doReturn mockCountryDao
         whenever(mockDaoSession.countryNameDao) doReturn mockCountryNameDao

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/label/LabelNameTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/label/LabelNameTest.kt
@@ -1,8 +1,8 @@
 package openfoodfacts.github.scrachx.openfood.models.entities.label
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [LabelName]
@@ -10,7 +10,7 @@ import org.junit.Test
 class LabelNameTest {
     private lateinit var mLabelName: LabelName
 
-    @Before
+    @BeforeEach
     fun setup() {
         mLabelName = LabelName()
     }

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/label/LabelResponseTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/label/LabelResponseTest.kt
@@ -6,8 +6,8 @@ import openfoodfacts.github.scrachx.openfood.models.LanguageCodeTestData.LANGUAG
 import openfoodfacts.github.scrachx.openfood.models.entities.label.LabelNameTestData.LABEL_NAME_EN
 import openfoodfacts.github.scrachx.openfood.models.entities.label.LabelNameTestData.LABEL_NAME_FR
 import openfoodfacts.github.scrachx.openfood.models.entities.label.LabelNameTestData.LABEL_TAG
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import java.util.*
 
 /**
@@ -17,7 +17,7 @@ class LabelResponseTest {
     private lateinit var mNamesMap: MutableMap<String, String>
     private var mLabelResponse: LabelResponse? = null
 
-    @Before
+    @BeforeEach
     fun setup() {
         mNamesMap = HashMap(2)
         mNamesMap[LANGUAGE_CODE_ENGLISH] = LABEL_NAME_EN

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/label/LabelTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/label/LabelTest.kt
@@ -9,20 +9,23 @@ import openfoodfacts.github.scrachx.openfood.models.entities.label.LabelNameTest
 import openfoodfacts.github.scrachx.openfood.models.entities.label.LabelNameTestData.LABEL_TAG
 import org.greenrobot.greendao.DaoException
 import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers
 import org.mockito.Mock
 import org.mockito.Mockito.verify
-import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
 
 /**
  * Tests for [Label]
  */
-@RunWith(MockitoJUnitRunner::class)
+@ExtendWith(MockitoExtension::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class LabelTest {
     @Mock
     private lateinit var mockDaoSession: DaoSession
@@ -35,7 +38,7 @@ class LabelTest {
 
     private lateinit var mLabel: Label
 
-    @Before
+    @BeforeEach
     fun setup() {
         whenever(mockDaoSession.labelDao) doReturn mockLabelDao
         whenever(mockDaoSession.labelNameDao) doReturn mockLabelNameDao

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/label/LabelsWrapperTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/label/LabelsWrapperTest.kt
@@ -8,8 +8,8 @@ import openfoodfacts.github.scrachx.openfood.models.entities.label.LabelNameTest
 import openfoodfacts.github.scrachx.openfood.models.entities.label.LabelNameTestData.LABEL_NAME_EN
 import openfoodfacts.github.scrachx.openfood.models.entities.label.LabelNameTestData.LABEL_NAME_FR
 import openfoodfacts.github.scrachx.openfood.models.entities.label.LabelNameTestData.LABEL_TAG
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
 /**
  * Tests for [LabelsWrapper]
@@ -18,7 +18,7 @@ class LabelsWrapperTest {
     private var labels: List<Label?>? = null
     private var labelTag2: String? = null
 
-    @Before
+    @BeforeEach
     fun setUp() {
         val namesMap1 = hashMapOf(
                 LANGUAGE_CODE_ENGLISH to LABEL_NAME_EN,

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/FileUtilsTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/FileUtilsTest.kt
@@ -1,7 +1,7 @@
 package openfoodfacts.github.scrachx.openfood.utils
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class FileUtilsTest {
 

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/InstantTaskExecutorExtension.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/InstantTaskExecutorExtension.kt
@@ -1,0 +1,34 @@
+package openfoodfacts.github.scrachx.openfood.utils
+
+import androidx.arch.core.executor.ArchTaskExecutor
+import androidx.arch.core.executor.TaskExecutor
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * A JUnit 5 adaption of [InstantTaskExecutorRule].
+ *
+ * Inspired from https://jeroenmols.com/blog/2019/01/17/livedatajunit5/
+ */
+class InstantTaskExecutorExtension : BeforeEachCallback, AfterEachCallback {
+
+    override fun beforeEach(context: ExtensionContext?) {
+        ArchTaskExecutor.getInstance().setDelegate(object: TaskExecutor() {
+            override fun executeOnDiskIO(runnable: Runnable) {
+                runnable.run()
+            }
+
+            override fun postToMainThread(runnable: Runnable) {
+                runnable.run()
+            }
+
+            override fun isMainThread(): Boolean = true
+        })
+    }
+
+    override fun afterEach(context: ExtensionContext?) {
+        ArchTaskExecutor.getInstance().setDelegate(null)
+    }
+}

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/InstantTaskExecutorExtension.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/InstantTaskExecutorExtension.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
 /**
- * A JUnit 5 adaption of [InstantTaskExecutorRule].
+ * A JUnit 5 adaptation of [InstantTaskExecutorRule].
  *
  * Inspired from https://jeroenmols.com/blog/2019/01/17/livedatajunit5/
  */

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/LocaleUtilsTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/LocaleUtilsTest.kt
@@ -6,7 +6,7 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import com.google.common.truth.Truth.assertThat
 import openfoodfacts.github.scrachx.openfood.models.LanguageData
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import java.util.*

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/NumberParserUtilsTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/NumberParserUtilsTest.kt
@@ -1,7 +1,7 @@
 package openfoodfacts.github.scrachx.openfood.utils
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class NumberParserUtilsTest {
     @Test

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/ProductUtilsTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/ProductUtilsTest.kt
@@ -2,7 +2,7 @@ package openfoodfacts.github.scrachx.openfood.utils
 
 import com.google.common.truth.Truth.assertThat
 import openfoodfacts.github.scrachx.openfood.models.Product
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/QuantityParserTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/QuantityParserTest.kt
@@ -1,7 +1,7 @@
 package openfoodfacts.github.scrachx.openfood.utils
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  *

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/UnitUtilsTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/UnitUtilsTest.kt
@@ -4,7 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import openfoodfacts.github.scrachx.openfood.models.MeasurementUnit
 import openfoodfacts.github.scrachx.openfood.models.MeasurementUnit.*
 import org.junit.Assert.assertThrows
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 /**
  *

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/UtilsTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/utils/UtilsTest.kt
@@ -5,7 +5,7 @@ import android.content.pm.PackageManager
 import com.google.common.truth.Truth.assertThat
 import openfoodfacts.github.scrachx.openfood.R
 import openfoodfacts.github.scrachx.openfood.models.Product
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock

--- a/app/src/testOff/java/openfoodfacts/github/scrachx/openfood/network/ProductsAPITest.kt
+++ b/app/src/testOff/java/openfoodfacts/github/scrachx/openfood/network/ProductsAPITest.kt
@@ -9,7 +9,6 @@ import com.google.common.truth.Truth.assertThat
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.runBlockingTest
 import okhttp3.Credentials
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -20,8 +19,8 @@ import openfoodfacts.github.scrachx.openfood.network.ProductsAPITest.SearchSubje
 import openfoodfacts.github.scrachx.openfood.network.services.ProductsAPI
 import openfoodfacts.github.scrachx.openfood.utils.Utils
 import openfoodfacts.github.scrachx.openfood.utils.getUserAgent
-import org.junit.BeforeClass
-import org.junit.Test
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.jackson.JacksonConverterFactory
@@ -194,7 +193,7 @@ class ProductsAPITest {
         private lateinit var devClientWithAuth: ProductsAPI
         private lateinit var prodClient: ProductsAPI
 
-        @BeforeClass
+        @BeforeAll
         @JvmStatic
         fun setupClient() {
             val httpClientWithAuth = OkHttpClient.Builder()


### PR DESCRIPTION

####  Description
Introduction of JUnit 5 by including JUnit's Jupiter as a BoM, and migrating all the JUnit 4 classes to the new engine. 

Please note that I've kept JUnit 4 to keep compatibility with Robolectric tests, as it doesn't support JUnit 5 yet.

#### Related issues
Fixes #3137

