### PR TITLE
Upgrade WorkManager to version 2.7.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,7 +65,7 @@ dependencies {
     implementation("androidx.multidex:multidex:2.0.1")
     implementation("androidx.viewpager2:viewpager2:1.0.0")
     implementation("androidx.startup:startup-runtime:1.1.0")
-    implementation("androidx.work:work-runtime-ktx:2.6.0")
+    implementation("androidx.work:work-runtime-ktx:2.7.1")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
 
     // ML Kit barcode Scanner
@@ -214,7 +214,7 @@ android {
         applicationId = "openfoodfacts.github.scrachx.openfood"
 
         minSdk = 16
-        targetSdk = 30
+        targetSdk = 31
 
         versionCode = 433
         versionName = "3.6.8"


### PR DESCRIPTION
####  Description
The crash [report](https://sentry.io/organizations/openfoodfacts/issues/2918977933/?frontend_events=%7B%22event_name%22%3A%22Sign+Up%22%2C%22event_label%22%3A%22github%22%7D&project=5276851&referrer=github_integration) was coming from WorkManager, which in v2.6.0, didn't handle the new PendingIntent flags that were introduced in SDK 31. 

Starting from v2.7 release that was fixed, and the library supports targetSdk 31 properly.

#### Related issues
#4428 

#### Testing
I just ran the app on an emulator running SDK 31, and it stopped crashing.