### PR TITLE
Fix NPE in ProductListAdapter

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlist/ProductListAdapter.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlist/ProductListAdapter.kt
@@ -37,7 +37,7 @@ class ProductListAdapter(
         holder.tvDetails.text = products[position].productDetails
         holder.tvBarcode.text = products[position].barcode
 
-        if (!isLowBatteryMode && products[position].imageUrl.isNotEmpty()) {
+        if (!isLowBatteryMode && !products[position].imageUrl.isNullOrEmpty()) {
             picasso
                 .load(products[position].imageUrl)
                 .placeholder(R.drawable.placeholder_thumb)

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/entities/ListedProduct.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/entities/ListedProduct.java
@@ -6,6 +6,8 @@ import org.greenrobot.greendao.annotation.Id;
 import org.greenrobot.greendao.annotation.Index;
 import org.greenrobot.greendao.annotation.Property;
 
+import javax.annotation.Nullable;
+
 @Entity(
     nameInDb = "YOUR_LISTED_PRODUCT",
     indexes = {@Index(value = "listId, barcode", unique = true)}
@@ -82,6 +84,7 @@ public class ListedProduct {
         this.productDetails = productDetails;
     }
 
+    @Nullable
     public String getImageUrl() {
         return this.imageUrl;
     }


### PR DESCRIPTION
####  Description

This NPE can be reproduced by adding the product that was mentioned in [here](https://github.com/openfoodfacts/openfoodfacts-androidapp/issues/4345#issuecomment-1030849453) to a list, the crash happens once you click on that products list. 

For the fix, I made the `ListedProduct` more null-safe by marking imageUrl as nullable, then handling the nullability inside the adapter to prevent the NPE.

#### Related issues
Fixes #4345