### PR TITLE
Use proper named arguments to load a product

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ProductViewActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/ProductViewActivity.kt
@@ -121,7 +121,7 @@ class ProductViewActivity : BaseActivity(), IProductView, OnRefreshListener {
      * @param barcode from the URL.
      */
     private suspend fun fetchProduct(barcode: String) = try {
-        client.getProductStateFull(barcode, Utils.HEADER_USER_AGENT_SCAN)
+        client.getProductStateFull(barcode = barcode, userAgent = Utils.HEADER_USER_AGENT_SCAN)
     } catch (err: Exception) {
         Log.w(this::class.simpleName, "Failed to load product $barcode.", err)
         finish()


### PR DESCRIPTION
####  Description
The issue is reproducible when deep-linking from the website to open a product with a barcode.

Open the website, type a barcode like `20518868`, pick 'Open Food Facts' to open the product, the crash happens.

The fix was quite simple, as the userAgent was sent in the position of the `fields` query param instead of being userAgent, so the product fields weren't being retrieved correctly and the request ended becoming ` https://ssl-api.openfoodfacts.org/api/v0/product/20518868?fields=Scan`. So I used named arguments to make sure that arguments positioning were correct.

#### Related issues
Fixes #4222

