### PR TITLE
fix: Attempt to fix NPE: interface method 'java.lang.Object java.util.Map.get(java.lang.Object)

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/entities/MapOfStringsToStringConverter.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/entities/MapOfStringsToStringConverter.java
@@ -1,5 +1,7 @@
 package openfoodfacts.github.scrachx.openfood.models.entities;
 
+import static android.util.Base64.DEFAULT;
+
 import android.util.Base64;
 import android.util.Log;
 
@@ -15,8 +17,6 @@ import java.io.ObjectOutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import static android.util.Base64.DEFAULT;
-
 class MapOfStringsToStringConverter implements PropertyConverter<Map<String, String>, String> {
     private static final String LOG_TAG;
 
@@ -26,14 +26,18 @@ class MapOfStringsToStringConverter implements PropertyConverter<Map<String, Str
         if (databaseValue == null) {
             return new HashMap<>();
         }
+
+        final Map<String, String> decodedResult = new HashMap<>();
         try {
             ByteArrayInputStream bis = new ByteArrayInputStream(Base64.decode(databaseValue, DEFAULT));
             ObjectInputStream objectInputStream = new ObjectInputStream(bis);
-            objectInputStream.readObject();
+            @SuppressWarnings("UNCHECKED_CAST")
+            final Map<String, String> readMap = (Map<String, String>) objectInputStream.readObject() ;
+            decodedResult.putAll(readMap);
         } catch (IOException | ClassNotFoundException e) {
             Log.e(LOG_TAG, "Cannot serialize map to database.", e);
         }
-        return new HashMap<>();
+        return decodedResult;
     }
 
     @Override

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/entities/OfflineSavedProduct.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/entities/OfflineSavedProduct.java
@@ -1,5 +1,7 @@
 package openfoodfacts.github.scrachx.openfood.models.entities;
 
+import static openfoodfacts.github.scrachx.openfood.utils.Utils.firstNotEmpty;
+
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
@@ -11,14 +13,14 @@ import org.greenrobot.greendao.annotation.Entity;
 import org.greenrobot.greendao.annotation.Generated;
 import org.greenrobot.greendao.annotation.Id;
 import org.greenrobot.greendao.annotation.Index;
+import org.greenrobot.greendao.annotation.Keep;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 
 import openfoodfacts.github.scrachx.openfood.network.ApiFields;
 import openfoodfacts.github.scrachx.openfood.utils.FileUtilsKt;
-
-import static openfoodfacts.github.scrachx.openfood.utils.Utils.firstNotEmpty;
 
 @Entity
 public class OfflineSavedProduct implements Serializable {
@@ -31,7 +33,7 @@ public class OfflineSavedProduct implements Serializable {
     private Long id;
     @Index
     private boolean isDataUploaded;
-    @SuppressWarnings("NotNullFieldNotInitialized")
+
     @NonNull
     @Convert(converter = MapOfStringsToStringConverter.class, columnType = String.class)
     private Map<String, String> productDetails;
@@ -52,8 +54,9 @@ public class OfflineSavedProduct implements Serializable {
         this.productDetails = productDetails;
     }
 
-    @Generated(hash = 403273060)
+    @Keep
     public OfflineSavedProduct() {
+        this.productDetails = new HashMap<>();
     }
 
     @NonNull

--- a/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/MapOfStringsToStringConverterTest.kt
+++ b/app/src/test/java/openfoodfacts/github/scrachx/openfood/models/entities/MapOfStringsToStringConverterTest.kt
@@ -1,0 +1,33 @@
+package openfoodfacts.github.scrachx.openfood.models.entities
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+// Robolectric is needed due to android.util.Base64 usage.
+@RunWith(RobolectricTestRunner::class)
+internal class MapOfStringsToStringConverterTest {
+
+    private val testSubject = MapOfStringsToStringConverter()
+
+    @Test
+    fun convertToEntityProperty() {
+        val input = """rO0ABXNyABFqYXZhLnV0aWwuSGFzaE1hcAUH2sHDFmDRAwACRgAKbG9hZEZhY3RvckkACXRocmVz
+            |aG9sZHhwP0AAAAAAAAN3CAAAAAQAAAACdAAEa2V5MXQABnZhbHVlMXQABGtleTJ0AAZ2YWx1ZTJ4""".trimMargin()
+
+        val result = testSubject.convertToEntityProperty(input)
+
+        assertThat(result).isEqualTo(mapOf("key1" to "value1", "key2" to "value2"))
+    }
+
+    @Test
+    fun convertToDatabaseValue() {
+        val map = mapOf("key1" to "value1", "key2" to "value2")
+
+        val result = testSubject.convertToDatabaseValue(map)
+
+        assertThat(result.trim()).isEqualTo("""rO0ABXNyABFqYXZhLnV0aWwuSGFzaE1hcAUH2sHDFmDRAwACRgAKbG9hZEZhY3RvckkACXRocmVz
+            |aG9sZHhwP0AAAAAAAAN3CAAAAAQAAAACdAAEa2V5MXQABnZhbHVlMXQABGtleTJ0AAZ2YWx1ZTJ4""".trimMargin())
+    }
+}


### PR DESCRIPTION
####  Description
Unfortunately, I wasn't able to reproduce the crash. I tried to ensure that `productDetails` is not ever to be null which can happen when no-arg Constructor is called during de-serialization by the system. I'd suggest trying out this change and seeing if the issues disappear :crossed_fingers: 

Also, I've fixed a bug where I noticed the conversion from database value to a Map, were never correct and an empty hashmap is always returned when trying to read from DB. I've fixed that as well. 

#### Related issues
Hopefully a fix for #4479