### PR TITLE
fix: Attempting to launch an unregistered ActivityResultLauncher

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/summary/SummaryProductFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/summary/SummaryProductFragment.kt
@@ -30,6 +30,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.net.toUri
@@ -137,7 +138,7 @@ class SummaryProductFragment : BaseFragment(), ISummaryProductPresenter.View {
     private lateinit var customTabActivityHelper: CustomTabActivityHelper
 
     private lateinit var customTabsIntent: CustomTabsIntent
-
+    private lateinit var editProductLauncher: ActivityResultLauncher<Product>
 
     private var hasCategoryInsightQuestion = false
 
@@ -199,6 +200,9 @@ class SummaryProductFragment : BaseFragment(), ISummaryProductPresenter.View {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         mTagDao = daoSession.tagDao
+
+        editProductLauncher = registerForActivityResult(ProductEditActivity.EditProductContract())
+        { isOk -> if (isOk) (activity as? ProductViewActivity)?.onRefresh() }
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -896,9 +900,6 @@ class SummaryProductFragment : BaseFragment(), ISummaryProductPresenter.View {
             putExtra(Intent.EXTRA_TEXT, shareBody)
         }, null))
     }
-
-    private val editProductLauncher = registerForActivityResult(ProductEditActivity.EditProductContract())
-    { isOk -> if (isOk) (activity as? ProductViewActivity)?.onRefresh() }
 
     private fun editProduct() = editProductLauncher.launch(product)
 


### PR DESCRIPTION
The ActivityResultLauncher must be initialized in the `onCreate` method, otherwise the app may crash.
Fix for #4528 