### PR TITLE
fix: Sign in button is disabled outside the updateLoginButtonState method

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/login/LoginActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/login/LoginActivity.kt
@@ -112,7 +112,6 @@ class LoginActivity : BaseActivity() {
 
         val loadingSnackbar = Snackbar.make(binding.loginLinearlayout, R.string.toast_retrieving, LENGTH_LONG)
             .apply { show() }
-        binding.btnLogin.isClickable = false
 
         lifecycleScope.launch(Dispatchers.Main) {
             val response = withContext(Dispatchers.IO) {


### PR DESCRIPTION
Fix for issue #4530

The sign-in button is disabled manually before all requests and never re-enabled after.
This is useless since updateLoginButtonState already handles all the different cases (loading, error…)