### PR TITLE
fix: Harcoded search category hint

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/categories/fragment/CategoryListFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/categories/fragment/CategoryListFragment.kt
@@ -84,8 +84,7 @@ class CategoryListFragment : BaseFragment() {
         val searchMenuItem = menu.findItem(R.id.action_search)
         val searchView = searchMenuItem.actionView as SearchView
 
-        // TODO: 26/07/2020 use resources
-        searchView.queryHint = "Search for a food category"
+        searchView.queryHint = getString(R.string.hint_category_list)
 
         if (searchManager.getSearchableInfo(requireActivity().componentName) == null) return
 

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -762,4 +762,5 @@
     <string name="msg_welcome_ecoscore">Une synthèse de l\'impact environnemental de votre alimentation.</string>
     <string name="title_welcome_matomo">Partager anonymement les statistiques</string>
     <string name="msg_welcome_matomo">Aidez les bénévoles d\'Open Food Facts à améliorer l\'application. Vous décidez si vous envoyez des analyses anonymes.\n\nSi vous changez d\'avis, cette option peut être activée et désactivée à tout moment à partir des paramètres.</string>
+    <string name="hint_category_list">Recherche une catégorie</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -766,4 +766,5 @@
     <string name="night">Nuit</string>
     <string name="required_for_ecoscore">(Requis pour calculer l\'Eco-Score)</string>
     <string name="hint_origin">Exemples: USA, France, Italie</string>
+    <string name="hint_category_list">Recherche une catégorie</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -896,4 +896,5 @@
 
     <string name="title_welcome_matomo">Send anonymous analytics</string>
     <string name="msg_welcome_matomo">Help the Open Food Facts volunteers to improve the app. You decide if you send anonymous analytics.\n\nIf you change your mind this option can be enabled and disabled at any time from the settings.</string>
+    <string name="hint_category_list">Search for a food category</string>
 </resources>


### PR DESCRIPTION
Fix for "search for a food category" text being hardcoded in the app.
Will partially resolve #4535