### PR TITLE
fix: Improvements for Search by text/code screen

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/searchbycode/SearchByCodeFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/searchbycode/SearchByCodeFragment.kt
@@ -1,9 +1,11 @@
 package openfoodfacts.github.scrachx.openfood.features.searchbycode
 
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.viewModels
@@ -15,6 +17,11 @@ import openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener
 import openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener.NavigationDrawerType
 import openfoodfacts.github.scrachx.openfood.utils.hideKeyboard
 import openfoodfacts.github.scrachx.openfood.utils.isBarcodeValid
+import openfoodfacts.github.scrachx.openfood.utils.isEmpty
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+import kotlin.time.DurationUnit
 
 /**
  * @see R.layout.fragment_find_product
@@ -38,7 +45,23 @@ class SearchByCodeFragment : NavigationBaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        binding.editTextBarcode.isSelected = false
+        binding.editTextBarcode.let { e ->
+            e.isSelected = false
+
+            // Accept both the Enter key (from the keyboard) or the search virtual key
+            e.setOnEditorActionListener { _, actionId, keyEvent ->
+                if (actionId == EditorInfo.IME_ACTION_SEARCH ||
+                    keyEvent.keyCode == KeyEvent.KEYCODE_ENTER
+                ) {
+                    checkBarcodeThenSearch()
+                    true
+                } else {
+                    false
+                }
+            }
+        }
+
+
         binding.buttonBarcode.setOnClickListener { checkBarcodeThenSearch() }
 
         // Get barcode from intent or saved instance or from arguments, in this order

--- a/app/src/main/res/layout/fragment_find_product.xml
+++ b/app/src/main/res/layout/fragment_find_product.xml
@@ -1,45 +1,63 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
-    android:orientation="vertical"
-    android:padding="@dimen/activity_horizontal_margin">
+    android:layout_gravity="center">
 
-    <ImageView
-        android:id="@+id/imageSearch"
-        android:layout_width="250dp"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="14dp"
-        android:adjustViewBounds="true"
-        android:contentDescription="@string/search_button"
-        app:srcCompat="@drawable/ic_crowdsourcing_icon" />
-
-    <EditText
-        android:id="@+id/editTextBarcode"
+    <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="50dp"
-        android:layout_marginTop="10dp"
-        android:layout_marginBottom="14dp"
-        android:background="@drawable/edittext_full"
-        android:drawablePadding="10dip"
-        android:ems="10"
-        android:hint="@string/hintBarcode"
-        android:inputType="number"
-        android:maxLines="1"
-        android:paddingLeft="10dip"
-        android:paddingRight="10dip" />
-
-    <Button
-        android:id="@+id/buttonBarcode"
-        style="@style/ButtonRounded"
-        android:layout_width="match_parent"
-
         android:layout_height="wrap_content"
-        android:layout_marginTop="4dp"
-        android:gravity="center"
-        android:text="@string/action_find"
-        android:textSize="@dimen/font_large" />
-</LinearLayout>
+        android:layout_gravity="center"
+        tools:ignore="UselessParent">
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:padding="@dimen/activity_horizontal_margin">
+
+            <ImageView
+                android:id="@+id/imageSearch"
+                android:layout_width="250dp"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="14dp"
+                android:adjustViewBounds="true"
+                android:contentDescription="@string/search_button"
+                app:srcCompat="@drawable/ic_crowdsourcing_icon" />
+
+            <EditText
+                android:id="@+id/editTextBarcode"
+                android:layout_width="match_parent"
+                android:layout_height="50dp"
+                android:layout_marginTop="10dp"
+                android:layout_marginBottom="14dp"
+                android:background="@drawable/edittext_full"
+                android:drawablePadding="10dp"
+                android:ems="10"
+                android:gravity="center"
+                android:hint="@string/hintBarcode"
+                android:imeOptions="actionSearch"
+                android:inputType="number"
+                android:maxLines="1"
+                android:paddingLeft="10dp"
+                android:paddingRight="10dp">
+
+            </EditText>
+
+            <Button
+                android:id="@+id/buttonBarcode"
+                style="@style/ButtonRounded"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:gravity="center"
+                android:text="@string/action_find"
+                android:textSize="@dimen/font_large" />
+        </LinearLayout>
+
+    </ScrollView>
+
+</FrameLayout>


### PR DESCRIPTION
- If the view is too small, it's now possible to scroll (useful when the keyboard is visible)
- The keyboard now shows the "search" icon
- Validating with the keyboard (search icon or Enter button) will trigger the search
- A request focus is asked, but not fully working as the `MainActivity` calls `hideKeyboard` after the Fragment lifecycle
- Linked to https://github.com/openfoodfacts/openfoodfacts-androidapp/issues/4540