### PR TITLE
fix: Vector drawables are not supported with drawableStart on Android < 5

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlists/ProductListsActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlists/ProductListsActivity.kt
@@ -29,6 +29,8 @@ import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -93,6 +95,7 @@ class ProductListsActivity : BaseActivity(), SwipeController.Actions {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         _binding = ActivityProductListsBinding.inflate(layoutInflater)
+        fixFabIcon()
 
         setContentView(binding.root)
         setTitle(R.string.your_lists)
@@ -136,6 +139,15 @@ class ProductListsActivity : BaseActivity(), SwipeController.Actions {
         itemTouchHelper.attachToRecyclerView(binding.productListsRecyclerView)
 
         binding.fabAdd.setOnClickListener { showCreateListDialog() }
+    }
+
+    // On Android < 5, the drawableStart attribute in XML will cause a crash
+    // That's why, it's instead done here in the code
+    private fun fixFabIcon() {
+        binding.fabAdd.setCompoundDrawablesRelative(
+            ContextCompat.getDrawable(this, R.drawable.ic_plus_blue_24),
+            null, null, null
+        )
     }
 
     private fun showCreateListDialog(productToAdd: Product? = null) {

--- a/app/src/main/res/layout/activity_product_lists.xml
+++ b/app/src/main/res/layout/activity_product_lists.xml
@@ -18,7 +18,6 @@
         android:layout_marginRight="8dp"
         android:layout_marginBottom="16dp"
         android:contentDescription="@string/add_a_list"
-        android:drawableStart="@drawable/ic_plus_blue_24"
         android:text="@string/add_a_list"
         app:elevation="10dp"
         app:layout_constraintBottom_toTopOf="@id/tipBox"


### PR DESCRIPTION
Fix for issue https://github.com/openfoodfacts/openfoodfacts-androidapp/issues/4474

On Android < 5, drawables passed to a drawableStart attribute (in XML) can not be a vector
But doing it in the code is actually possible