### PR TITLE
fix: When syncing the history, deleted products/products not found should be skipped

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/ProductRepository.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/ProductRepository.kt
@@ -286,8 +286,10 @@ class ProductRepository @Inject constructor(
                 getUserAgent(Utils.HEADER_USER_AGENT_SEARCH)
             )
 
-            if (state.status == 0L) throw IOException("Could not sync history. Error with product ${state.code} ")
-            else {
+            // Products not found should be skipped
+            if (state.status == 0L && state.statusVerbose?.contains("not found") != true) {
+                throw IOException("Could not sync history. Error with product ${state.code} ")
+            } else if (state.status > 0L) {
                 val product = state.product!!
                 val hp = HistoryProduct(
                     product.productName,


### PR DESCRIPTION
If a product is not found when syncing an old history, this product should simply be skipped

Linked to issue #4340