### PR TITLE
feat: The Activity now notifies when the drawer status has changed

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/MainActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/MainActivity.kt
@@ -92,6 +92,8 @@ import openfoodfacts.github.scrachx.openfood.features.productlists.ProductListsA
 import openfoodfacts.github.scrachx.openfood.features.scanhistory.ScanHistoryActivity
 import openfoodfacts.github.scrachx.openfood.features.searchbycode.SearchByCodeFragment
 import openfoodfacts.github.scrachx.openfood.features.shared.BaseActivity
+import openfoodfacts.github.scrachx.openfood.features.shared.NavigationDrawerHost
+import openfoodfacts.github.scrachx.openfood.features.shared.OnNavigationDrawerStatusChanged
 import openfoodfacts.github.scrachx.openfood.images.ProductImage
 import openfoodfacts.github.scrachx.openfood.jobs.ProductUploaderWorker.Companion.scheduleProductUpload
 import openfoodfacts.github.scrachx.openfood.listeners.CommonBottomListenerInstaller.installBottomNavigation
@@ -127,7 +129,7 @@ import javax.inject.Inject
 import openfoodfacts.github.scrachx.openfood.features.search.ProductSearchActivity.Companion.start as startSearch
 
 @AndroidEntryPoint
-class MainActivity : BaseActivity(), NavigationDrawerListener {
+class MainActivity : BaseActivity(), NavigationDrawerListener, NavigationDrawerHost {
     private var _binding: ActivityMainBinding? = null
     private val binding get() = _binding!!
 
@@ -162,7 +164,7 @@ class MainActivity : BaseActivity(), NavigationDrawerListener {
     private var userSettingsURI: Uri? = null
 
     private var historySyncJob: Job? = null
-
+    private var drawerStatusChanged: OnNavigationDrawerStatusChanged? = null
 
     private val loginThenUpdate = registerForActivityResult(LoginContract())
     { isLoggedIn -> if (isLoggedIn) updateConnectedState() }
@@ -335,8 +337,13 @@ class MainActivity : BaseActivity(), NavigationDrawerListener {
 
         withOnDrawerListener(object : Drawer.OnDrawerListener {
             override fun onDrawerSlide(drawerView: View, slideOffset: Float) = hideKeyboard()
-            override fun onDrawerOpened(drawerView: View) = hideKeyboard()
-            override fun onDrawerClosed(drawerView: View) = Unit
+            override fun onDrawerOpened(drawerView: View) {
+                hideKeyboard()
+                drawerStatusChanged?.onDrawerOpened()
+            }
+            override fun onDrawerClosed(drawerView: View) {
+                drawerStatusChanged?.onDrawerClosed()
+            }
         })
 
         addDrawerItems(
@@ -965,7 +972,10 @@ class MainActivity : BaseActivity(), NavigationDrawerListener {
             setNegativeButton(R.string.txtNo) { d, _ -> d.cancel() }
             show()
         }
+    }
 
+    override fun setOnDrawerStatusChanged(onDrawerStatusChanged: OnNavigationDrawerStatusChanged?) {
+        this.drawerStatusChanged = onDrawerStatusChanged
     }
 
     companion object {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/searchbycode/SearchByCodeFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/searchbycode/SearchByCodeFragment.kt
@@ -13,11 +13,9 @@ import dagger.hilt.android.AndroidEntryPoint
 import openfoodfacts.github.scrachx.openfood.R
 import openfoodfacts.github.scrachx.openfood.databinding.FragmentFindProductBinding
 import openfoodfacts.github.scrachx.openfood.features.shared.NavigationBaseFragment
-import openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener
+import openfoodfacts.github.scrachx.openfood.features.shared.NavigationWithDrawerBaseFragment
+import openfoodfacts.github.scrachx.openfood.utils.*
 import openfoodfacts.github.scrachx.openfood.utils.NavigationDrawerListener.NavigationDrawerType
-import openfoodfacts.github.scrachx.openfood.utils.hideKeyboard
-import openfoodfacts.github.scrachx.openfood.utils.isBarcodeValid
-import openfoodfacts.github.scrachx.openfood.utils.isEmpty
 import java.time.Duration
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
@@ -27,7 +25,7 @@ import kotlin.time.DurationUnit
  * @see R.layout.fragment_find_product
  */
 @AndroidEntryPoint
-class SearchByCodeFragment : NavigationBaseFragment() {
+class SearchByCodeFragment : NavigationWithDrawerBaseFragment() {
     private var _binding: FragmentFindProductBinding? = null
     private val binding get() = _binding!!
 
@@ -99,6 +97,16 @@ class SearchByCodeFragment : NavigationBaseFragment() {
     override fun onResume() {
         super.onResume()
         (requireActivity() as AppCompatActivity).supportActionBar?.title = getString(R.string.search_by_barcode_drawer)
+    }
+
+    override fun onDrawerClosed() {
+        super.onDrawerClosed()
+
+        // Force the keyboard to be visible
+        if (binding.editTextBarcode.isEmpty()) {
+            binding.editTextBarcode.requestFocus()
+            requireActivity().showKeyboard()
+        }
     }
 
     companion object {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/shared/NavigationWithDrawerBaseFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/shared/NavigationWithDrawerBaseFragment.kt
@@ -1,0 +1,49 @@
+package openfoodfacts.github.scrachx.openfood.features.shared
+
+import android.content.Context
+
+/**
+ * A custom [NavigationBaseFragment] that can be notified of navigation drawer events.
+ * The host (= Activity) must contains a Navigation Drawer and implements [NavigationDrawerHost]
+ */
+abstract class NavigationWithDrawerBaseFragment : NavigationBaseFragment(), OnNavigationDrawerStatusChanged {
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+
+        if (context is NavigationDrawerHost) {
+            context.setOnDrawerStatusChanged(this)
+        }
+    }
+
+    override fun onDetach() {
+        if (requireContext() is NavigationDrawerHost) {
+            (context as NavigationDrawerHost).setOnDrawerStatusChanged(null)
+        }
+
+        super.onDetach()
+    }
+
+    override fun onDrawerOpened() {
+        // No implementation by default
+    }
+
+    override fun onDrawerClosed() {
+        // No implementation by default
+    }
+}
+
+/**
+ * Interface to implement for an Activity with a NavigationDrawer
+ */
+interface NavigationDrawerHost {
+    fun setOnDrawerStatusChanged(onDrawerStatusChanged: OnNavigationDrawerStatusChanged?)
+}
+
+/**
+ * Interface to notify when the status of a NavigationDrawer has changed (opened / closed)
+ */
+interface OnNavigationDrawerStatusChanged {
+    fun onDrawerOpened()
+    fun onDrawerClosed()
+}

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/shared/NavigationWithDrawerBaseFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/shared/NavigationWithDrawerBaseFragment.kt
@@ -4,7 +4,7 @@ import android.content.Context
 
 /**
  * A custom [NavigationBaseFragment] that can be notified of navigation drawer events.
- * The host (= Activity) must contains a Navigation Drawer and implements [NavigationDrawerHost]
+ * The host (= Activity) must contain a Navigation Drawer and implements [NavigationDrawerHost]
  */
 abstract class NavigationWithDrawerBaseFragment : NavigationBaseFragment(), OnNavigationDrawerStatusChanged {
 
@@ -12,13 +12,13 @@ abstract class NavigationWithDrawerBaseFragment : NavigationBaseFragment(), OnNa
         super.onAttach(context)
 
         if (context is NavigationDrawerHost) {
-            context.setOnDrawerStatusChanged(this)
+            context.addOnDrawerStatusChanged(this)
         }
     }
 
     override fun onDetach() {
         if (requireContext() is NavigationDrawerHost) {
-            (context as NavigationDrawerHost).setOnDrawerStatusChanged(null)
+            (context as NavigationDrawerHost).removeOnDrawerStatusChanged(this)
         }
 
         super.onDetach()
@@ -37,11 +37,12 @@ abstract class NavigationWithDrawerBaseFragment : NavigationBaseFragment(), OnNa
  * Interface to implement for an Activity with a NavigationDrawer
  */
 interface NavigationDrawerHost {
-    fun setOnDrawerStatusChanged(onDrawerStatusChanged: OnNavigationDrawerStatusChanged?)
+    fun addOnDrawerStatusChanged(onDrawerStatusChanged: OnNavigationDrawerStatusChanged)
+    fun removeOnDrawerStatusChanged(onDrawerStatusChanged: OnNavigationDrawerStatusChanged)
 }
 
 /**
- * Interface to notify when the status of a NavigationDrawer has changed (opened / closed)
+ * Interface to notify when the status of a NavigationDrawer has changed (opened/closed)
  */
 interface OnNavigationDrawerStatusChanged {
     fun onDrawerOpened()

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Activity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Activity.kt
@@ -15,6 +15,12 @@ fun Activity.hideKeyboard() {
         .hideSoftInputFromWindow(view.windowToken, 0)
 }
 
+fun Activity.showKeyboard() {
+    val view = currentFocus ?: return
+    (getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager)
+        .showSoftInput(view, 0)
+}
+
 fun Activity.getProductState() = intent.getSerializableExtra(ProductEditActivity.KEY_STATE) as ProductState?
 fun Activity.requireProductState() = this.getProductState()
     ?: error("Activity ${this::class.simpleName} started without '${ProductEditActivity.KEY_STATE}' serializable in intent.")


### PR DESCRIPTION
To fix #4540 and more particularly the issue with the focus, I had to make some changes.
Right now, the `MainActivity` has the following lifecycle:

- [User] Click to open the drawer
- [Activity] Close the keyboard
- [User] Select of choice
- [Activity] Change the fragment and close the keyboard

The problem here is that the last keyboard event happens after the fragment is added/attached (after the `onResume`).

To fix this, the Fragments now can listen to drawer events.
Here is the new lifecycle:

- [User] Click to open the drawer
- [Activity] Close the keyboard
- [User] Select of choice
- [Activity] Change the fragment, close the keyboard and notify the attached Fragment
- [Fragment] Can force the keyboard to be reopened