### PR TITLE
fix: SearchView : ensure that the bottom navigation bar is hidden when the keyboard is visible and vice-versa

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/MainActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/MainActivity.kt
@@ -647,28 +647,44 @@ class MainActivity : BaseActivity(), NavigationDrawerListener {
         super.onCreateOptionsMenu(menu)
         menuInflater.inflate(R.menu.menu_main, menu)
 
+
+
         // Associate searchable configuration with the SearchView
         val searchManager = getSystemService(SEARCH_SERVICE) as SearchManager
-        searchMenuItem = menu.findItem(R.id.action_search).also {
-            val searchView = it.actionView as SearchView
+        searchMenuItem = menu.findItem(R.id.action_search).also { menuItem ->
+            val searchView = menuItem.actionView as SearchView
+            val bottomNavigation = binding.bottomNavigationInclude.bottomNavigation
+
             searchView.setSearchableInfo(searchManager.getSearchableInfo(componentName))
             searchView.setOnQueryTextFocusChangeListener { _, hasFocus ->
                 if (hasFocus) {
-                    binding.bottomNavigationInclude.bottomNavigation.visibility = View.GONE
+                    bottomNavigation.visibility = View.GONE
                 } else {
-                    binding.bottomNavigationInclude.bottomNavigation.visibility = View.VISIBLE
+                    bottomNavigation.visibility = View.VISIBLE
                 }
             }
-            it.setOnActionExpandListener(object : MenuItem.OnActionExpandListener {
-                override fun onMenuItemActionExpand(menuItem: MenuItem): Boolean {
-                    binding.bottomNavigationInclude.bottomNavigation.visibility = View.GONE
-                    return true
-                }
 
-                override fun onMenuItemActionCollapse(menuItem: MenuItem) = true
-            })
+            searchView.setOnSearchClickListener {
+                listenToKeyboardVisibilityChanges(object : OnKeyboardVisibilityChanged {
+                    override fun onKeyboardVisible() {
+                        bottomNavigation.visibility = View.GONE
+                    }
+
+                    override fun onKeyboardDismissed() {
+                        bottomNavigation.visibility = View.VISIBLE
+                    }
+                })
+
+                bottomNavigation.visibility = View.GONE
+            }
+
+            searchView.setOnCloseListener {
+                stopListeningToKeyboardVisibilityChanges()
+                false
+            }
+
             if (intent.getBooleanExtra(PRODUCT_SEARCH_KEY, false)) {
-                it.expandActionView()
+                menuItem.expandActionView()
             }
         }
         return true
@@ -765,6 +781,7 @@ class MainActivity : BaseActivity(), NavigationDrawerListener {
 
     override fun onDestroy() {
         customTabActivityHelper.connectionCallback = null
+        stopListeningToKeyboardVisibilityChanges()
         _binding = null
         super.onDestroy()
     }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Activity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/utils/Activity.kt
@@ -2,7 +2,10 @@ package openfoodfacts.github.scrachx.openfood.utils
 
 import android.app.Activity
 import android.content.Context
+import android.view.View
 import android.view.inputmethod.InputMethodManager
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import openfoodfacts.github.scrachx.openfood.features.product.edit.ProductEditActivity
 import openfoodfacts.github.scrachx.openfood.models.ProductState
 
@@ -15,3 +18,25 @@ fun Activity.hideKeyboard() {
 fun Activity.getProductState() = intent.getSerializableExtra(ProductEditActivity.KEY_STATE) as ProductState?
 fun Activity.requireProductState() = this.getProductState()
     ?: error("Activity ${this::class.simpleName} started without '${ProductEditActivity.KEY_STATE}' serializable in intent.")
+
+fun Activity.getRootView(): View? = findViewById(android.R.id.content)
+
+fun Activity.listenToKeyboardVisibilityChanges(listener: OnKeyboardVisibilityChanged) {
+    getRootView()?.let {
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { _, insets ->
+            if (insets.isVisible(WindowInsetsCompat.Type.ime())) listener.onKeyboardVisible() else listener.onKeyboardDismissed()
+            insets
+        }
+    }
+}
+
+fun Activity.stopListeningToKeyboardVisibilityChanges() {
+    getRootView()?.let {
+        ViewCompat.setOnApplyWindowInsetsListener(it, null)
+    }
+}
+
+interface OnKeyboardVisibilityChanged {
+    fun onKeyboardVisible()
+    fun onKeyboardDismissed()
+}


### PR DESCRIPTION
A fix for #4558

This should fix all issues we have with the keyboard and the SearchView in the MainActivity
For your knowledge: `setOnActionExpandListener` is never called