### PR TITLE
fix: Nutrition edition: no listener was set on unit/"data per"

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
@@ -121,7 +121,12 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
         binding.btnAddImageNutritionFacts.setOnClickListener { addNutritionFactsImage() }
         binding.btnEditImageNutritionFacts.setOnClickListener { newNutritionFactsImage() }
         binding.btnAdd.setOnClickListener { next() }
-        binding.for100g100ml.setOnClickListener { checkAllValues() }
+        binding.radioGroup.setOnCheckedChangeListener { _, checkedId ->
+            if (checkedId >= 0) {
+                viewModel.dataFormat.postValue(checkedId)
+            }
+        }
+
         binding.btnAddANutrient.setOnClickListener { displayAddNutrientDialog() }
 
         binding.salt.doAfterTextChanged { updateSodiumValue() }
@@ -133,7 +138,6 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
         binding.spinnerSodiumComp.setOnItemSelectedListener { _, _, _, _ ->
             binding.spinnerSaltComp.setSelection(binding.spinnerSodiumComp.selectedItemPosition)
         }
-
 
         val bundle = arguments
         lastEditText = binding.alcohol
@@ -375,11 +379,13 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
      */
     private fun updateSelectedDataPer(value: String) {
         binding.radioGroup.clearCheck()
+
         when (value) {
             NUTRITION_DATA_PER_100G -> binding.radioGroup.check(R.id.for100g_100ml)
             NUTRITION_DATA_PER_SERVING -> binding.radioGroup.check(R.id.per_serving)
             else -> throw IllegalArgumentException("Value is neither $NUTRITION_DATA_PER_100G nor $NUTRITION_DATA_PER_SERVING")
         }
+
         binding.radioGroup.jumpDrawablesToCurrentState()
     }
 


### PR DESCRIPTION
I think I've found why the "nutrition_data_per" was always wrong: no listener was set on the radio group.
This should resolve #4470

(But please test it, as I'm not 100% sure)