### PR TITLE
fix: "No nutrition facts" switch not working as intended

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
@@ -127,6 +127,10 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
             }
         }
 
+        binding.checkboxNoNutritionData.setOnCheckedChangeListener { _, isChecked ->
+            binding.nutritionFactsLayout.visibility = if (isChecked) View.GONE else View.VISIBLE
+        }
+
         binding.btnAddANutrient.setOnClickListener { displayAddNutrientDialog() }
 
         binding.salt.doAfterTextChanged { updateSodiumValue() }
@@ -551,9 +555,10 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
         // Add no nutrition data entry to map
         if (binding.checkboxNoNutritionData.isChecked) {
             targetMap[ApiFields.Keys.NO_NUTRITION_DATA] = "on"
-        } else {
-            targetMap += getNutrientsModeMap()
+            return targetMap
         }
+
+        targetMap += getNutrientsModeMap()
 
         // Add serving size entry to map if it has been changed
         if (binding.servingSize.isNotEmpty()) {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
@@ -554,7 +554,7 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
 
         // Add no nutrition data entry to map
         if (binding.checkboxNoNutritionData.isChecked) {
-            targetMap[ApiFields.Keys.NO_NUTRITION_DATA] = "on"
+            targetMap[ApiFields.Keys.NO_NUTRITION_DATA] = ApiFields.Defaults.NO_NUTRITION_DATA_ON
             return targetMap
         }
 
@@ -588,7 +588,7 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
         if (activity !is ProductEditActivity) return emptyMap()
 
         if (binding.checkboxNoNutritionData.isChecked) {
-            return mapOf(ApiFields.Keys.NO_NUTRITION_DATA to "on")
+            return mapOf(ApiFields.Keys.NO_NUTRITION_DATA to ApiFields.Defaults.NO_NUTRITION_DATA_ON)
         }
 
         val targetMap = mutableMapOf<String, String?>()

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
@@ -575,6 +575,10 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
             targetMap += getNutrientMapIfUpdated(view)
         }
 
+        // We force a null value here for "no nutrition", instead of an "off" String,
+        // to be sure to do not break other apps
+        targetMap[ApiFields.Keys.NO_NUTRITION_DATA] = null
+
         return targetMap
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
@@ -332,7 +332,7 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
             loadNutritionImage(path)
         }
 
-        if (productDetails[ApiFields.Keys.NO_NUTRITION_DATA] != null) {
+        if (productDetails[ApiFields.Keys.NO_NUTRITION_DATA]?.trim()?.lowercase() == ApiFields.Defaults.NO_NUTRITION_DATA_ON) {
             binding.checkboxNoNutritionData.isChecked = true
             binding.nutritionFactsLayout.visibility = View.GONE
         }
@@ -575,9 +575,8 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
             targetMap += getNutrientMapIfUpdated(view)
         }
 
-        // We force a null value here for "no nutrition", instead of an "off" String,
-        // to be sure to do not break other apps
-        targetMap[ApiFields.Keys.NO_NUTRITION_DATA] = null
+        // We force an "off" value here
+        targetMap[ApiFields.Keys.NO_NUTRITION_DATA] = ApiFields.Defaults.NO_NUTRITION_DATA_OFF
 
         return targetMap
     }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
@@ -575,8 +575,9 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
             targetMap += getNutrientMapIfUpdated(view)
         }
 
-        // We force an "off" value here
-        targetMap[ApiFields.Keys.NO_NUTRITION_DATA] = ApiFields.Defaults.NO_NUTRITION_DATA_OFF
+        if (targetMap.containsKey(ApiFields.Keys.NO_NUTRITION_DATA)) {
+            targetMap[ApiFields.Keys.NO_NUTRITION_DATA] = ApiFields.Defaults.NO_NUTRITION_DATA_OFF
+        }
 
         return targetMap
     }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/ApiFields.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/ApiFields.kt
@@ -59,6 +59,8 @@ object ApiFields {
      * Default values for some fields
      */
     object Defaults {
+        const val NO_NUTRITION_DATA_ON = "on"
+        const val NO_NUTRITION_DATA_OFF = "off"
         const val NUTRITION_DATA_PER_100G = "100g"
         const val NUTRITION_DATA_PER_SERVING = "serving"
         const val DEBUG_BARCODE = "1"

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/ApiFields.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/ApiFields.kt
@@ -60,7 +60,7 @@ object ApiFields {
      */
     object Defaults {
         const val NO_NUTRITION_DATA_ON = "on"
-        const val NO_NUTRITION_DATA_OFF = "off"
+        const val NO_NUTRITION_DATA_OFF = ""
         const val NUTRITION_DATA_PER_100G = "100g"
         const val NUTRITION_DATA_PER_SERVING = "serving"
         const val DEBUG_BARCODE = "1"


### PR DESCRIPTION
PR that fixes two issues:
- If Nutrition data is set to OFF, the table beneath shouldn't be displayed
- If Nutrition data is set to OFF, no nutritional data is sent to the API

 #4582