### PR TITLE
fix: Lint errors in GitHub Actions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -361,7 +361,13 @@ android {
 
     lint {
         isAbortOnError = false
-        disable("MissingTranslation")
+
+        disable(
+            "MissingTranslation",
+            "ImpliedQuantity",
+            // Invalid Resource Folder is for values-b+sr… folders
+            "InvalidResourceFolder"
+        )
     }
 
     packagingOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,10 +67,16 @@
             android:value="2.1" />
 
         <provider
-            android:name="androidx.work.impl.WorkManagerInitializer"
-            android:authorities="${applicationId}.workmanager-init"
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
             android:exported="false"
-            tools:node="remove" />
+            tools:node="merge">
+            <!-- If you are using androidx.startup to initialize other components -->
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
 
         <provider
             android:name=".utils.SearchSuggestionProvider"

--- a/app/src/obf/res/values-en/strings.xml
+++ b/app/src/obf/res/values-en/strings.xml
@@ -8,7 +8,6 @@
     <string name="website_discover">https://world.openbeautyfacts.org/discover</string>
     <!-- For fr, Replace by https://world-fr.openbeautyfacts.org/produit/ -->
     <string name="website_product">https://world.openbeautyfacts.org/product/</string>
-    <string name="deeplink_product" translatable="false">*.openbeautyfacts.org</string>
     <!-- For fr, Replace by https://world-fr.openbeautyfacts.org/contributeur/ -->
     <string name="website_contributor">https://world.openbeautyfacts.org/contributor/</string>
     <string name="terms_url">https://world.openbeautyfacts.org/terms-of-use</string>


### PR DESCRIPTION
This is just some changes to remove all Lint errors:
- Ignore `InvalidResourceFolder` -> new name conventions for some folders since Android 7
- Ignore `ImpliedQuantity ` -> in some translations, "1" is hardcoded, but seems OK
- WorkManager: fix (the class name as changed)