### PR TITLE
ci: Ensure Labeler is not triggered on forks

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -10,12 +10,12 @@ on: [pull_request]
 
 jobs:
   label:
-
     runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    #if: ${{ github.repository_owner == 'openfoodfacts' }}
     permissions:
       contents: read
       pull-requests: write
-
     steps:
     - uses: actions/labeler@v4
       with:


### PR DESCRIPTION


####  Description
ci: Ensure Labeler is not triggered on forks since otherwise the test will fail with integration not accessible