### PR TITLE
fix: Empty search list after a research by barcode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -70,12 +70,7 @@
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"
             android:exported="false"
-            tools:node="merge">
-            <!-- If you are using androidx.startup to initialize other components -->
-            <meta-data
-                android:name="androidx.work.WorkManagerInitializer"
-                android:value="androidx.startup"
-                tools:node="remove" />
+            tools:node="remove">
         </provider>
 
         <provider

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/search/ProductSearchActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/search/ProductSearchActivity.kt
@@ -24,7 +24,6 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.squareup.picasso.Picasso
 import dagger.hilt.android.AndroidEntryPoint
 import io.reactivex.Single
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers.IO
 import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.isActive
@@ -37,7 +36,9 @@ import openfoodfacts.github.scrachx.openfood.analytics.MatomoAnalytics
 import openfoodfacts.github.scrachx.openfood.customtabs.CustomTabActivityHelper
 import openfoodfacts.github.scrachx.openfood.databinding.ActivityProductBrowsingListBinding
 import openfoodfacts.github.scrachx.openfood.features.adapters.ProductSearchAdapter
+import openfoodfacts.github.scrachx.openfood.features.product.view.OnProductViewActivityStarterResultListener
 import openfoodfacts.github.scrachx.openfood.features.product.view.ProductViewActivityStarter
+import openfoodfacts.github.scrachx.openfood.features.product.view.ProductViewActivityStarterErrorType
 import openfoodfacts.github.scrachx.openfood.features.shared.BaseActivity
 import openfoodfacts.github.scrachx.openfood.listeners.CommonBottomListenerInstaller.installBottomNavigation
 import openfoodfacts.github.scrachx.openfood.listeners.CommonBottomListenerInstaller.selectNavigationItem
@@ -329,7 +330,14 @@ class ProductSearchActivity : BaseActivity() {
 
             SEARCH -> {
                 if (isBarcodeValid(searchQuery)) {
-                    productViewActivityStarter.openProduct(searchQuery, this@ProductSearchActivity)
+                    productViewActivityStarter.openProduct(searchQuery, this@ProductSearchActivity, object: OnProductViewActivityStarterResultListener {
+                        override fun onProductOpened() {
+                            finish()
+                        }
+
+                        override fun onProductError(type: ProductViewActivityStarterErrorType) {}
+
+                    })
                 } else {
                     client.searchProductsByName(searchQuery, pageAddress)
                         .startSearch(R.string.txt_no_matching_products, R.string.txt_broaden_search)


### PR DESCRIPTION
Will fix #4552

When a barcode is searched directly through the SearchView, the Search Activity is shown briefly… and then the Product Activity. But if we press the back button from the product, we will see the search activity with an infinite loader.
This page should have been finished before, which is now possible thanks to a dedicated listener