### PR TITLE
fix: No nutrition data: Ensure empty values are sent to the server

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/edit/nutrition/ProductEditNutritionFactsFragment.kt
@@ -606,6 +606,8 @@ class ProductEditNutritionFactsFragment : ProductEditFragment() {
             addNutrientToMap(view, targetMap)
         }
 
+        targetMap[ApiFields.Keys.NO_NUTRITION_DATA] = ApiFields.Defaults.NO_NUTRITION_DATA_OFF
+
         return targetMap
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/ApiFields.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/network/ApiFields.kt
@@ -310,6 +310,11 @@ object ApiFields {
             ECOSCORE,
             NOVA_GROUPS
         )
+
+        val PRODUCT_FIELDS_WITH_EMPTY_VALUE = setOf(
+            NO_NUTRITION_DATA
+        )
+
     }
 
     fun getAllFields(langCode: String): String {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/OfflineProductRepository.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/repositories/OfflineProductRepository.kt
@@ -82,7 +82,7 @@ class OfflineProductRepository @Inject constructor(
             remove(ApiFields.Keys.IMAGE_FRONT_UPLOADED)
             remove(ApiFields.Keys.IMAGE_INGREDIENTS_UPLOADED)
             remove(ApiFields.Keys.IMAGE_NUTRITION_UPLOADED)
-        }.filter { !it.value.isNullOrEmpty() }
+        }.filter { !it.value.isNullOrEmpty() || ApiFields.Keys.PRODUCT_FIELDS_WITH_EMPTY_VALUE.contains(it.key) }
 
         Log.d(LOG_TAG, "Uploading data for product ${product.barcode}: $productDetails")
         try {


### PR DESCRIPTION
Two fixes in this PR:

- When no_nutrition_data is OFF, ensure the correct value is always sent
- Ensure empty values (= OFF value for no_nutrition_data) are not filtered before being sent