### PR TITLE
fix: Useless swipe to refresh with an empty product

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/environment/EnvironmentProductFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/environment/EnvironmentProductFragment.kt
@@ -80,7 +80,7 @@ class EnvironmentProductFragment : BaseFragment() {
         super.onViewCreated(view, savedInstanceState)
         val langCode = localeManager.getLanguage()
         productState = requireProductState()
-        binding.imageViewPackaging.setOnClickListener { openFullScreen() }
+        binding.imageViewPackaging.setOnClickListener { openFullScreenImage() }
 
         // If Battery Level is low and the user has checked the Disable Image in Preferences , then set isLowBatteryMode to true
         if (requireContext().isDisableImageLoad() && requireContext().isBatteryLevelLow()) {
@@ -172,7 +172,7 @@ class EnvironmentProductFragment : BaseFragment() {
         refreshTagsPrompt()
     }
 
-    private fun openFullScreen() {
+    private fun openFullScreenImage() {
         val imageUrl = mUrlImage
         val product = productState.product
         if (imageUrl != null && product != null) {
@@ -193,6 +193,8 @@ class EnvironmentProductFragment : BaseFragment() {
     }
 
     private fun newPackagingImage() = doChooseOrTakePhotos()
+
+    override fun doOnPhotosPermissionGranted() = doChooseOrTakePhotos()
 
     private fun loadPackagingPhoto(photoFile: File) {
         // Create a new instance of ProductImage so we can load to server

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/search/ProductSearchActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/search/ProductSearchActivity.kt
@@ -456,6 +456,7 @@ class ProductSearchActivity : BaseActivity() {
      * @param extendedMessage additional message to display, -1 if no message is displayed
      */
     private fun showEmptyResponse(@StringRes message: Int, @StringRes extendedMessage: Int) {
+        binding.swipeRefresh.isEnabled = false
         binding.swipeRefresh.isRefreshing = false
 
         binding.productsRecyclerView.visibility = View.INVISIBLE

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/shared/BaseFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/shared/BaseFragment.kt
@@ -93,10 +93,9 @@ abstract class BaseFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener, 
     protected fun doChooseOrTakePhotos() {
         if (canTakePhotos()) {
             EasyImage.openCamera(this, 0)
-            return
+        } else {
+            cameraPermissionRequestLauncher.launch(Manifest.permission.CAMERA)
         }
-        // Ask for permissions
-        cameraPermissionRequestLauncher.launch(Manifest.permission.CAMERA)
     }
 
     protected open fun doOnPhotosPermissionGranted() = Unit

--- a/app/src/main/res/layout/activity_product_browsing_list.xml
+++ b/app/src/main/res/layout/activity_product_browsing_list.xml
@@ -181,5 +181,5 @@
         android:layout_height="wrap_content"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_environment_product.xml
+++ b/app/src/main/res/layout/fragment_environment_product.xml
@@ -22,7 +22,6 @@
             android:orientation="vertical"
             android:paddingBottom="@dimen/nav_bar_height">
 
-
             <openfoodfacts.github.scrachx.openfood.features.shared.views.TipBox
                 android:id="@+id/packagingImagetipBox"
                 android:layout_width="match_parent"


### PR DESCRIPTION
If a product doesn't exist, the app shows a dedicated screen to create it.
On this screen, a swipe to refresh is available: but to refresh what?

That's why this PR disables the swipe to refresh