### PR TITLE
fix: Sentry bug #OPENFOODFACTS-ANDROID-5C0

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/images/manage/ImagesManageActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/images/manage/ImagesManageActivity.kt
@@ -114,7 +114,7 @@ class ImagesManageActivity : BaseActivity() {
         }
 
         binding.comboImageType.onItemSelectedListener = object : OnItemSelectedListener {
-            override fun onItemSelected(parent: AdapterView<*>?, view: View, position: Int, id: Long) =
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) =
                 onImageTypeChanged()
 
             override fun onNothingSelected(parent: AdapterView<*>?) = Unit // Do nothing


### PR DESCRIPTION
The error is:

```
NullPointerException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter view
    at openfoodfacts.github.scrachx.openfood.features.images.manage.ImagesManageActivity$onCreate$8.onItemSelected
    at android.widget.AdapterView.fireOnSelected(AdapterView.java:957)
    at android.widget.AdapterView.dispatchOnItemSelected(AdapterView.java:946)
    at android.widget.AdapterView.selectionChanged(AdapterView.java:935)
    at android.widget.AdapterView.checkSelectionChanged(AdapterView.java:1118)
...
(50 additional frame(s) were not displayed)
```


A simple question mark is missing