### PR TITLE
Fix Issue #4613: Dark mode error in Contributions tab

### DIFF
--- a/app/src/main/res/layout/fragment_contributors.xml
+++ b/app/src/main/res/layout/fragment_contributors.xml
@@ -104,10 +104,9 @@
                         android:gravity="center"
                         android:text="@string/product_states"
                         android:textAlignment="center"
-                        android:textColor="@color/black"
+                        android:textAppearance="@android:style/TextAppearance.DeviceDefault.Small"
                         android:textSize="18sp"
                         android:textStyle="bold" />
-
                     <View
                         android:layout_width="match_parent"
                         android:layout_height="1dp"


### PR DESCRIPTION
`TextView` In fragment_contributors.xml the TextView for "Product
States" has text color set to black, which kept the text black when in
dark mode. After fix, the text color is light when in dark mode, and
dark when dark in light mode.

I used `textAppearance` because it is used in `attribute_group_item.xml`

####  Description
<!--Give a small description related to the changes you have made.-->

#### Related issues
<!--
- Add the issue number here.
- If you haven't solved the issue completely use "Linked issue #{issue_number}.
- If you have solved the issue completely use "Fixes #{issue_number}, example: "Fixes #123, #345".
-->

#### Related PRs
<!-- Link to all the related PRs openfoodfacts-androidapp, openfoodfacts-server, openfoodfacts-ios, etc. -->

#### Screenshots
<!-- If possible, please add relevant screenshots / GIFs -->

#### Link to the automatically generated build APK
<!-- If your build succeeds after making this PR, you will get an APK. Please edit your PR and add the link here -->
