### PR TITLE
fix: wrong number of products for lists + analytics events

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -189,7 +189,7 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
     androidTestImplementation("androidx.test.espresso:espresso-intents:3.4.0")
     androidTestImplementation("androidx.test.espresso:espresso-web:3.4.0")
-    androidTestImplementation("androidx.test.espresso:espresso-contrib:3.3.0") {
+    androidTestImplementation("androidx.test.espresso:espresso-contrib:3.4.0") {
         exclude(group = "com.android.support", module = "appcompat-v7")
         exclude(group = "com.android.support", module = "support-v4")
         exclude(group = "com.android.support", module = "design")

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/analytics/AnalyticsEvent.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/analytics/AnalyticsEvent.kt
@@ -26,7 +26,7 @@ sealed class AnalyticsEvent(val category: String, val action: String, val name: 
 
     object RobotoffLoggedInAfterPrompt : AnalyticsEvent("user-account", "logged-in-after-prompt", "robotoff", null)
 
-    data class ShoppingListCreated(val listName: String?) : AnalyticsEvent("shopping-lists", "created", listName, null)
+    object ShoppingListCreated : AnalyticsEvent("shopping-lists", "created", null, null)
 
     data class ShoppingListProductAdded(val barcode: String) : AnalyticsEvent("shopping-lists", "add_product", barcode, null)
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/analytics/AnalyticsEvent.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/analytics/AnalyticsEvent.kt
@@ -26,7 +26,13 @@ sealed class AnalyticsEvent(val category: String, val action: String, val name: 
 
     object RobotoffLoggedInAfterPrompt : AnalyticsEvent("user-account", "logged-in-after-prompt", "robotoff", null)
 
-    object ShoppingListCreated : AnalyticsEvent("shopping-lists", "created", null, null)
+    data class ShoppingListCreated(val listName: String?) : AnalyticsEvent("shopping-lists", "created", listName, null)
+
+    data class ShoppingListProductAdded(val barcode: String) : AnalyticsEvent("shopping-lists", "add_product", barcode, null)
+
+    data class ShoppingListProductRemoved(val barcode: String) : AnalyticsEvent("shopping-lists", "remove_product", barcode, null)
+
+    object ShoppingListShared : AnalyticsEvent("shopping-lists", "shared", null, null)
 
     object ShoppingListExported : AnalyticsEvent("shopping-lists", "exported", null, null)
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/summary/SummaryProductFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/summary/SummaryProductFragment.kt
@@ -893,9 +893,7 @@ class SummaryProductFragment : BaseFragment(), ISummaryProductPresenter.View {
         // Add listener to text view
         val addToNewList = dialog.findViewById<TextView>(R.id.tvAddToNewList)!!
         addToNewList.setOnClickListener {
-            context.startActivity(Intent(context, ProductListsActivity::class.java).apply {
-                putExtra("product", product)
-            })
+            ProductListsActivity.start(context, productToAdd = product)
         }
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/summary/SummaryProductFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/summary/SummaryProductFragment.kt
@@ -82,6 +82,7 @@ import openfoodfacts.github.scrachx.openfood.images.ProductImage
 import openfoodfacts.github.scrachx.openfood.models.*
 import openfoodfacts.github.scrachx.openfood.models.entities.ListedProduct
 import openfoodfacts.github.scrachx.openfood.models.entities.ListedProductDao
+import openfoodfacts.github.scrachx.openfood.models.entities.ProductLists
 import openfoodfacts.github.scrachx.openfood.models.entities.additive.AdditiveName
 import openfoodfacts.github.scrachx.openfood.models.entities.allergen.AllergenHelper
 import openfoodfacts.github.scrachx.openfood.models.entities.allergen.AllergenName
@@ -883,7 +884,8 @@ class SummaryProductFragment : BaseFragment(), ISummaryProductPresenter.View {
                 it.productDetails = product.getProductBrandsQuantityDetails()
                 it.imageUrl = product.getImageSmallUrl(localeManager.getLanguage())
             }
-            daoSession.listedProductDao.insertOrReplace(product)
+            addListedProductToDatabase(product, list)
+            matomoAnalytics.trackEvent(AnalyticsEvent.ShoppingListProductAdded(product.barcode))
             dialog.dismiss()
             onRefresh()
         }
@@ -897,6 +899,16 @@ class SummaryProductFragment : BaseFragment(), ISummaryProductPresenter.View {
         }
     }
 
+    private fun addListedProductToDatabase(
+        product: ListedProduct,
+        list: ProductLists
+    ) {
+        daoSession.listedProductDao.insertOrReplace(product)
+        daoSession.productListsDao.update(list.apply {
+            products.add(product)
+            numOfProducts++
+        })
+    }
 
     private fun takeMorePicture() {
         sendOther = true

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlist/ProductListActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlist/ProductListActivity.kt
@@ -24,6 +24,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.squareup.picasso.Picasso
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 import openfoodfacts.github.scrachx.openfood.AppFlavors.OFF
 import openfoodfacts.github.scrachx.openfood.AppFlavors.isFlavors
 import openfoodfacts.github.scrachx.openfood.BuildConfig

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlists/ProductListsActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlists/ProductListsActivity.kt
@@ -180,7 +180,7 @@ class ProductListsActivity : BaseActivity(), SwipeController.Actions {
     }
 
     private fun addNewListName(listName: String, productToAdd: Product?) {
-        matomoAnalytics.trackEvent(AnalyticsEvent.ShoppingListCreated(listName))
+        matomoAnalytics.trackEvent(AnalyticsEvent.ShoppingListCreated)
         val productList = ProductLists(listName, if (productToAdd != null) 1 else 0)
 
         adapter.add(productList)

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlists/ProductListsAdapter.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlists/ProductListsAdapter.kt
@@ -3,13 +3,14 @@ package openfoodfacts.github.scrachx.openfood.features.productlists
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import openfoodfacts.github.scrachx.openfood.databinding.YourProductListsItemBinding
 import openfoodfacts.github.scrachx.openfood.models.entities.ProductLists
 
 class ProductListsAdapter(
-        internal val context: Context,
-        val lists: MutableList<ProductLists>
+    internal val context: Context,
+    val lists: MutableList<ProductLists>
 ) : RecyclerView.Adapter<ProductListsViewHolder>() {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductListsViewHolder {
         val binding = YourProductListsItemBinding.inflate(LayoutInflater.from(context), parent, false)
@@ -27,10 +28,28 @@ class ProductListsAdapter(
 
     override fun getItemCount() = lists.size
 
+    fun add(productList: ProductLists) {
+        lists.add(productList)
+        notifyItemInserted(lists.size - 1)
+    }
+
     fun remove(data: ProductLists) {
         val position = lists.indexOf(data)
         lists.removeAt(position)
         notifyItemRemoved(position)
+    }
+
+    fun replaceWith(newList: MutableList<ProductLists>) {
+        val oldList = lists.toList()
+        lists.clear()
+        lists.addAll(newList)
+
+        DiffUtil.calculateDiff(
+            ProductListsDiffCallback(
+                oldList,
+                newList
+            ),
+        ).dispatchUpdatesTo(this)
     }
 
 }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlists/ProductListsDiff.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/productlists/ProductListsDiff.kt
@@ -1,0 +1,22 @@
+package openfoodfacts.github.scrachx.openfood.features.productlists
+
+import androidx.recyclerview.widget.DiffUtil
+import openfoodfacts.github.scrachx.openfood.models.entities.ProductLists
+
+class ProductListsDiffCallback(
+    private val oldItems: List<ProductLists>,
+    private val newItems: List<ProductLists>,
+) : DiffUtil.Callback() {
+
+    override fun getOldListSize(): Int = oldItems.size
+
+    override fun getNewListSize(): Int = newItems.size
+
+    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        return oldItems[oldItemPosition].id == newItems[newItemPosition].id
+    }
+
+    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
+        return areItemsTheSame(oldItemPosition, newItemPosition)
+    }
+}


### PR DESCRIPTION
Fix for #4647 and will partially implement #4640

ProductsListsDao was never updated after a product addition/removal
+ analytics events when a product is added / removed
+ analytics event when a list is shared