### PR TITLE
fix: Fix crash on SearchByCodeFragment

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/searchbycode/SearchByCodeFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/searchbycode/SearchByCodeFragment.kt
@@ -103,10 +103,13 @@ class SearchByCodeFragment : NavigationWithDrawerBaseFragment() {
         super.onDrawerClosed()
 
         // Force the keyboard to be visible
-        if (binding.editTextBarcode.isEmpty()) {
-            binding.editTextBarcode.requestFocus()
-            requireActivity().showKeyboard()
+        _binding?.apply {
+            if (editTextBarcode.isEmpty()) {
+                editTextBarcode.requestFocus()
+                requireActivity().showKeyboard()
+            }
         }
+
     }
 
     companion object {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/searchbycode/SearchByCodeFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/searchbycode/SearchByCodeFragment.kt
@@ -37,6 +37,7 @@ class SearchByCodeFragment : NavigationWithDrawerBaseFragment() {
     }
 
     override fun onDestroyView() {
+        removeDrawerListener()
         super.onDestroyView()
         _binding = null
     }
@@ -103,11 +104,9 @@ class SearchByCodeFragment : NavigationWithDrawerBaseFragment() {
         super.onDrawerClosed()
 
         // Force the keyboard to be visible
-        _binding?.apply {
-            if (editTextBarcode.isEmpty()) {
-                editTextBarcode.requestFocus()
-                requireActivity().showKeyboard()
-            }
+        if (binding.editTextBarcode.isEmpty()) {
+            binding.editTextBarcode.requestFocus()
+            requireActivity().showKeyboard()
         }
 
     }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/shared/NavigationWithDrawerBaseFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/shared/NavigationWithDrawerBaseFragment.kt
@@ -17,11 +17,14 @@ abstract class NavigationWithDrawerBaseFragment : NavigationBaseFragment(), OnNa
     }
 
     override fun onDetach() {
+        removeDrawerListener()
+        super.onDetach()
+    }
+
+    fun removeDrawerListener() {
         if (requireContext() is NavigationDrawerHost) {
             (context as NavigationDrawerHost).removeOnDrawerStatusChangedListener(this)
         }
-
-        super.onDetach()
     }
 
     override fun onDrawerOpened() {


### PR DESCRIPTION
Fix crash:

```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: openfoodfacts.github.scrachx.openfood.debug, PID: 4914
    java.lang.NullPointerException
        at openfoodfacts.github.scrachx.openfood.features.searchbycode.SearchByCodeFragment.getBinding(SearchByCodeFragment.kt:30)
        at openfoodfacts.github.scrachx.openfood.features.searchbycode.SearchByCodeFragment.onDrawerClosed(SearchByCodeFragment.kt:106)
        at openfoodfacts.github.scrachx.openfood.features.MainActivity$setupDrawer$1$1.onDrawerClosed(MainActivity.kt:348)
        at com.mikepenz.materialdrawer.DrawerBuilder$handleDrawerNavigation$1.onDrawerClosed(DrawerBuilder.kt:1444)
        at androidx.drawerlayout.widget.DrawerLayout.dispatchOnDrawerClosed(DrawerLayout.java:891)
        at androidx.drawerlayout.widget.DrawerLayout.updateDrawerState(DrawerLayout.java:861)
        at androidx.drawerlayout.widget.DrawerLayout$ViewDragCallback.onViewDragStateChanged(DrawerLayout.java:2249)
        at androidx.customview.widget.ViewDragHelper.setDragState(ViewDragHelper.java:920)
        at androidx.customview.widget.ViewDragHelper$2.run(ViewDragHelper.java:345)
        at android.os.Handler.handleCallback(Handler.java:942)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7850)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```