### PR TITLE
fix: Environment photo should not be stretched

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/environment/EnvironmentProductFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/environment/EnvironmentProductFragment.kt
@@ -210,7 +210,6 @@ class EnvironmentProductFragment : BaseFragment() {
         mUrlImage = photoFile.absolutePath
         picasso
             .load(photoFile)
-            .fit()
             .into(binding.imageViewPackaging)
     }
 


### PR DESCRIPTION
Fix for #4653