### PR TITLE
feat: Use new SplashScreen API on Android 12 and newer (API level 31 and up)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -132,6 +132,9 @@ dependencies {
     // ShowCaseView dependency
     implementation(libs.showcaseview)
 
+    // SplashScreen on API 31 and higher
+    implementation("androidx.core:core-splashscreen:1.0.0")
+
     // Unit Testing
     testImplementation(libs.bundles.testing)
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/splash/SplashActivity.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/splash/SplashActivity.kt
@@ -2,8 +2,11 @@ package openfoodfacts.github.scrachx.openfood.features.splash
 
 import android.annotation.SuppressLint
 import android.content.pm.ActivityInfo
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.core.splashscreen.SplashScreen
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.BaseTransientBottomBar
@@ -32,7 +35,12 @@ class SplashActivity : BaseActivity() {
     @SuppressLint("SourceLockedOrientationActivity")
     @ExperimentalTime
     public override fun onCreate(savedInstanceState: Bundle?) {
+        val splashScreen: SplashScreen? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            installSplashScreen()
+        } else null
+        splashScreen?.setKeepOnScreenCondition { true }
         super.onCreate(savedInstanceState)
+
         binding = ActivitySplashBinding.inflate(layoutInflater)
         setContentView(binding.root)
 

--- a/app/src/main/res/values-night-v31/styles.xml
+++ b/app/src/main/res/values-night-v31/styles.xml
@@ -48,11 +48,11 @@
         <item name="android:tint">@color/grey_200</item>
     </style>
 
-    <style name="SplashTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
-        <item name="android:windowNoTitle">true</item>
-        <item name="android:windowActionBar">false</item>
-        <item name="android:windowFullscreen">true</item>
-        <item name="android:windowContentOverlay">@null</item>
+    <style name="SplashTheme" parent="Theme.SplashScreen.IconBackground">
+        <item name="windowSplashScreenBackground">@color/grey_800</item>
+        <item name="windowSplashScreenIconBackgroundColor">@color/grey_400</item>
+        <item name="postSplashScreenTheme">@style/Theme.AppCompat.DayNight</item>
+        <item name="windowSplashScreenAnimatedIcon">@mipmap/ic_launcher_round</item>
     </style>
 
 </resources>


### PR DESCRIPTION
####  Description
This PR implements the new SplashScreen API on Android 12 and newer, provides backwards compatibility using the Splash Screen compat library (on API < 31, the old splash screen is shown). The implementation works both with light and dark themes.
Tested on API 29 (backwards compatible) and API 32 (uses the new API).

#### Related issues
Fixes #4548 

#### Related PRs


#### Screenshots
##### API >= 31:
![image](https://user-images.githubusercontent.com/44982432/198902473-7109e1d1-1077-493a-8a74-71975174c2ed.png)
![image](https://user-images.githubusercontent.com/44982432/198902685-f22717e4-6b27-40c6-aa17-d2d56ced6f4d.png)

##### API < 31:
![image](https://user-images.githubusercontent.com/44982432/198902888-89805bb5-592f-41f6-8cfb-a0d5728c3bf1.png)
![image](https://user-images.githubusercontent.com/44982432/198902821-24823b6f-81b9-4ad9-9759-67ac164dbc56.png)


#### Link to the automatically generated build APK
[debug.zip](https://github.com/openfoodfacts/openfoodfacts-androidapp/files/9896879/debug.zip)
