### PR TITLE
fix: Launch (fragment-ktx), Product Photos, Contributions bug fixes.

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/contributors/ContributorsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/contributors/ContributorsFragment.kt
@@ -47,14 +47,8 @@ class ContributorsFragment : BaseFragment() {
     lateinit var localeManager: LocaleManager
 
     private lateinit var productState: ProductState
-
-    private val dateFormat = DateFormat.getDateFormat(requireContext()).apply {
-        timeZone = TimeZone.getTimeZone("CET")
-    }
-    private val timeFormatter = DateFormat.getTimeFormat(requireContext()).apply {
-        timeZone = TimeZone.getTimeZone("CET")
-    }
-
+    private lateinit var dateFormat: java.text.DateFormat
+    private lateinit var timeFormatter: java.text.DateFormat
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentContributorsBinding.inflate(inflater)
@@ -63,6 +57,13 @@ class ContributorsFragment : BaseFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        dateFormat = DateFormat.getDateFormat(requireContext()).apply {
+            timeZone = TimeZone.getTimeZone("CET")
+        }
+        timeFormatter = DateFormat.getTimeFormat(requireContext()).apply {
+            timeZone = TimeZone.getTimeZone("CET")
+        }
 
         binding.incompleteStates.setOnClickListener { toggleIncompleteStatesVisibility() }
         binding.completeStates.setOnClickListener { toggleCompleteStatesVisibility() }

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/photos/ProductPhotoViewHolder.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/photos/ProductPhotoViewHolder.kt
@@ -13,10 +13,8 @@ import javax.inject.Inject
 
 class ProductPhotoViewHolder(
     private val binding: ImagesItemBinding,
+    private val picasso: Picasso
 ) : RecyclerView.ViewHolder(binding.root) {
-
-    @Inject
-    lateinit var picasso: Picasso
 
     fun setImage(barcode: Barcode, imageName: String) {
         val imageUrl = getImageUrl(barcode, imageName, IMAGE_EDIT_SIZE)

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/photos/ProductPhotosAdapter.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/photos/ProductPhotosAdapter.kt
@@ -4,6 +4,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
+import com.squareup.picasso.Picasso
 import openfoodfacts.github.scrachx.openfood.databinding.ImagesItemBinding
 import openfoodfacts.github.scrachx.openfood.models.Product
 
@@ -15,6 +16,7 @@ class ProductPhotosAdapter(
     private val imageNames: List<String>,
     private val onImageTap: (Int) -> Unit,
     private val onLoginNeeded: (View, Int) -> Unit,
+    private val picasso: Picasso
 ) : RecyclerView.Adapter<ProductPhotoViewHolder>() {
 
     override fun getItemCount() = imageNames.count()
@@ -22,7 +24,7 @@ class ProductPhotosAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ProductPhotoViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         val itemView = ImagesItemBinding.inflate(inflater, parent, false)
-        return ProductPhotoViewHolder(itemView)
+        return ProductPhotoViewHolder(itemView, picasso)
     }
 
     override fun onBindViewHolder(holder: ProductPhotoViewHolder, position: Int) {

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/photos/ProductPhotosFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/photos/ProductPhotosFragment.kt
@@ -106,7 +106,8 @@ class ProductPhotosFragment : BaseFragment() {
                 } else {
                     showEditPopup(view, imageNames, position, product)
                 }
-            }
+            },
+            picasso
         )
 
         binding.progress.hide()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-co
 kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlin-coroutines" }
 test-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlin-coroutines" }
 # Android KTX
-android-ktx-fragment = "androidx.fragment:fragment-ktx:1.4.1"
+android-ktx-fragment = "androidx.fragment:fragment-ktx:1.5.6"
 android-ktx-activity = "androidx.activity:activity-ktx:1.7.0"
 android-ktx-preference = "androidx.preference:preference-ktx:1.2.0"
 android-ktx-core = "androidx.core:core-ktx:1.8.0"


### PR DESCRIPTION
Hi,
I encountered a few issues while checking out the `develop` branch. Here's my setup:

Branch: `develop`
Device: `Android 11`, `Android 13`
Flavor: `offPlaystoreDebug`
Product: https://world.openfoodfacts.org/product/5449000214911, and others
Preferences: `Show contribution tab` & `Show all product photos`
My exceptions: [Android Errors](https://docs.google.com/document/d/174vvkBkDAcW2RjcLofz0XMimKR1XvlHzslNB7Floh8w/edit?usp=sharing)

I believe that I have fixed these issues, and I tested on Android 11 + 13. Feel free to test, discuss, and make updates to these changes, or let me know if you have any questions. I'm happy to help with this project in any way that I can, and make any changes if required 😀. If these errors are due to me not configuring the project correctly, please let me know & feel free to disregard.

## Issue 1 - Launch error

First, I got an error when launching: `CreationExtras must have a value by 'SAVED_STATE_REGISTRY_OWNER_KEY'`.
Upgrading to: `android-ktx-fragment = "androidx.fragment:fragment-ktx:1.5.6"` fixes this issue. While not entirely related, this is a helpful link w/some insights: https://stackoverflow.com/questions/73302605/creationextras-must-have-a-value-by-saved-state-registry-owner-key

## Issue 2 - ProductView > Contributions

Error: `Unable to start activity ComponentInfo{ProductViewActivity}: java.lang.IllegalStateException: Fragment ContributorsFragment{1eda312} (6d0cfe9f-a0b6-499a-99c7-3fde777ebf98) not attached to a context.`

I believe this is because two DateFormats were requiring the context before the fragment actually had the context.

```
private val dateFormat = DateFormat.getDateFormat(requireContext()).apply {
    timeZone = TimeZone.getTimeZone("CET")
}
private val timeFormatter = DateFormat.getTimeFormat(requireContext()).apply {
    timeZone = TimeZone.getTimeZone("CET")
}
```

I changed these to `lateinit vars`.

## Issue 3 - ProductView > Product Photos

Error: `lateinit property picasso has not been initialized`. I'm no expert here, but I think Hilt is having an issue injecting into `RecyclerView.ViewHolder`, even though the parent fragment is in fact an `@AndroidEntryPoint`:

```
class ProductPhotoViewHolder(
    private val binding: ImagesItemBinding,
) : RecyclerView.ViewHolder(binding.root)
```

Since we're already getting a ref to Picasso in `ProductPhotosFragment`, I made updates to pass the reference down to `ProductPhotoViewHolder` instead. Is there a more Hilt appropriate way to do this? Maybe something like this, but for `RecyclerView.ViewHolder`?

```
class ExampleContentProvider : ContentProvider() {

  @EntryPoint
  @InstallIn(SingletonComponent::class)
  interface ExampleContentProviderEntryPoint {
    fun analyticsService(): AnalyticsService
  }

  ...
}
```
                

