### PR TITLE
build(deps): Bump Truth to 1.4.2.

### DIFF
--- a/app/src/testOff/java/openfoodfacts/github/scrachx/openfood/network/ProductsAPITest.kt
+++ b/app/src/testOff/java/openfoodfacts/github/scrachx/openfood/network/ProductsAPITest.kt
@@ -228,23 +228,23 @@ class ProductsAPITest {
 
     class SearchSubject private constructor(
         failureMetadata: FailureMetadata,
-        private val actual: Search,
+        private val actual: Search?,
     ) : Subject(failureMetadata, actual) {
 
         fun hasFoundProducts() {
-            check("count").that(actual.count.toInt()).isGreaterThan(0)
+            check("count").that(actual!!.count.toInt()).isGreaterThan(0)
             check("products").that(actual.products).isNotEmpty()
         }
 
         fun hasFoundNoProducts() {
-            check("count").that(actual.count.toInt()).isEqualTo(0)
+            check("count").that(actual!!.count.toInt()).isEqualTo(0)
             check("products").that(actual.products).isEmpty()
         }
 
         companion object {
             private fun searches() = Factory(::SearchSubject)
 
-            fun assertThat(actual: Search): SearchSubject {
+            fun assertThat(actual: Search?): SearchSubject {
                 return assertAbout(searches()).that(actual)
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ org-mockito = "5.10.0"
 mockk = "1.13.9"
 com-squareup-retrofit2 = "2.6.4"
 androidx-test-espresso = "3.4.0"
-truth = "1.1.3"
+truth = "1.4.2"
 ui = "1.4.3"
 core-splashscreen = "1.0.1"
 


### PR DESCRIPTION
This requires adapting to Truth's recent nullness annotations.

Specifically, a `Subject` constructor (and the associated
`Subject.Factory` and `assertThat` function) should accept a null actual
value. By doing so, it makes it possible to write
`assertThat(foo).isNull()`, for example.

This does not necessarily mean that all assertions will _pass_ if the caller
passes `null`. Obviously `isNotNull()` will fail, of course, but so too may
other assertions, like `hasFoundProducts` will here.

(In principle, it would be nice for all assertions to fail _with
detailed `NullPointerException` messages_. In practice, we mostly
haven't done that even for the core Truth assertions. So I haven't here,
either.)

Without this PR, the error that Truth 1.4.2 produces is:

```
ProductsAPITest.kt:245:46 Type mismatch: inferred type is KFunction2<FailureMetadata, Search, ProductsAPITest.SearchSubject> but (FailureMetadata!, TypeVariable(ActualT)?) -> TypeVariable(SubjectT)! was expected
```

Fixes https://github.com/openfoodfacts/openfoodfacts-androidapp/pull/5191
