### PR TITLE
chore: Upgrade to Android 34

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -173,7 +173,7 @@ dependencies {
 }
 
 android {
-    compileSdk = 33
+    compileSdk = 34
 
     testBuildType = obtainTestBuildType()
 
@@ -192,7 +192,7 @@ android {
         applicationId = "openfoodfacts.github.scrachx.openfood"
 
         minSdk = 21
-        targetSdk = 33
+        targetSdk = 34
 
         versionCode = 582
         versionName = "3.9.0"

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/analytics/SentryAnalytics.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/analytics/SentryAnalytics.kt
@@ -20,7 +20,7 @@ class SentryAnalytics @Inject constructor(
 
     private val enabledFromPrefs get() = sharedPreferences.getBoolean(prefKey, false)
 
-    private val listener: (SharedPreferences, String) -> Unit = { _, key ->
+    private val listener: (SharedPreferences, String?) -> Unit = { _, key ->
         if (key == prefKey) refresh()
     }
 

--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/preferences/PreferencesListener.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/preferences/PreferencesListener.kt
@@ -13,7 +13,7 @@ class PreferencesListener @Inject constructor(
 ) : SharedPreferences.OnSharedPreferenceChangeListener {
 
 
-    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
         when (key) {
             context.getString(R.string.pref_enable_mobile_data_key) -> {
                 ProductUploaderWorker.scheduleProductUpload(context, sharedPreferences)


### PR DESCRIPTION
Hi everyone,

This is the only upgrade we can do in the app without breaking anything.
Android API 35 will be released in a few weeks (but APIs are already stable) and it will require Gradle 8.
However, Green Dao is not maintained since 2020 and needs Gradle 7.

So unless we rewrite a lot of code, we can't do more than that.