### PR TITLE
fix: imageNames sorting to preserve descending timestamp order

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/photos/ProductPhotosViewModel.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/photos/ProductPhotosViewModel.kt
@@ -36,6 +36,7 @@ class ProductPhotosViewModel @Inject constructor(
         .filterNotNull()
         .map { product ->
             ImageNameParser.extractImageNames(productsAPI.getProductImages(product.code))
+                .sortedByDescending { it.timestamp }  // Ensure explicit sorting
                 .map { it.value }
         }.stateIn(
             viewModelScope,


### PR DESCRIPTION
## Description
Fixes #5013 - Image names sorting by upload time

This PR fixes the failing test in `ProductPhotosViewModelTest` where `imageNames` should return image names sorted by upload timestamp in descending order (newest first).

## Changes Made
- Added explicit `.sortedByDescending { it.timestamp }` in `ProductPhotosViewModel` to ensure images are returned in the correct order
- Ensures sort order is preserved through Flow transformations
- The `ImageNameParser.extractImageNames()` already returns sorted data, but this ensures the order is maintained through the reactive Flow pipeline

## Testing
- The fix addresses the failing test: `ProductPhotosViewModelTest > Given product api returns product images > When imageNames is called > it should return image names sorted by uploaded time`
- Unable to run tests locally due to build environment issues (Java version compatibility), relying on CI/CD for verification

## Related Issues
Fixes #5013

## Notes
This is my contribution as part of EECS 481 (Software Engineering) at University of Michigan.