### PR TITLE
fix: replace static.openfoodfacts.org with images.openfoodfacts.org

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/entities/analysistagconfig/AnalysisTagConfig.java
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/models/entities/analysistagconfig/AnalysisTagConfig.java
@@ -66,7 +66,7 @@ public class AnalysisTagConfig implements TaxonomyEntity {
     }
 
     public String getIconUrl() {
-        return "https://static.openfoodfacts.org/images/icons/" + icon + ".white.96x96.png";
+        return "https://images.openfoodfacts.org/images/icons/" + icon + ".white.96x96.png";
     }
 
     public void setIcon(String icon) {


### PR DESCRIPTION
## Description
Fixes #5296 - Replace references to static.openfoodfacts.org with images.openfoodfacts.org

This PR updates the image URL domain in `AnalysisTagConfig.java` to use the new images subdomain instead of the static subdomain for icon resources.

## Changes Made
- Updated the `getImageUrl()` method in `AnalysisTagConfig.java` (line 69)
- Changed URL from `https://static.openfoodfacts.org/images/icons/` to `https://images.openfoodfacts.org/images/icons/`
- Only one file modified, one line changed

## Testing
- Verified no remaining references to `static.openfoodfacts.org` exist in the codebase using grep
- Confirmed new URL pattern is correctly implemented
- The change is backwards compatible as it only updates the domain portion of the URL

## Related Issues
Fixes #5296

