### PR TITLE
fix(i18n): use formatted placeholder for other_editors

### DIFF
--- a/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/contributors/ContributorsFragment.kt
+++ b/app/src/main/java/openfoodfacts/github/scrachx/openfood/features/product/view/contributors/ContributorsFragment.kt
@@ -106,14 +106,11 @@ class ContributorsFragment : BaseFragment() {
         if (product.editors.isNotEmpty()) {
             binding.otherEditorsTxt.movementMethod = LinkMovementMethod.getInstance()
             binding.otherEditorsTxt.text = buildSpannedString {
-                append(getString(R.string.other_editors))
-                append(" ")
-                product.editors.map { getContributorsTag(it).subSequence(0, it.length) }
-                    .forEachIndexed { i, el ->
-                        if (i > 0) append(", ")
-                        append(el)
-                    }
-                append(getContributorsTag(product.editors.last()))
+                val editorsText = product.editors.joinToString(", ") {
+    getContributorsTag(it).subSequence(0, it.length).toString()
+}
+
+append(getString(R.string.other_editors, editorsText))
             }
         } else {
             binding.otherEditorsTxt.visibility = View.INVISIBLE


### PR DESCRIPTION
This PR moves the placeholder into the `other_editors` string resource and updates its usage to use proper formatted strings.

This fixes i18n issues for RTL and other languages where word order differs, as discussed in #4069.